### PR TITLE
修复：云效(Aliyun Thoughts)代码块导出后换行丢失、被压平成一行

### DIFF
--- a/export_aliyun_thoughts.py
+++ b/export_aliyun_thoughts.py
@@ -1118,7 +1118,14 @@ def slate_block_markdown(node: dict[str, Any], images: list[str], depth: int = 0
         return "---\n\n"
     if "code" in node_type and node_type != "code":
         language = data.get("language") or data.get("lang") or ""
-        return f"```{language}\n{slate_text(node).rstrip()}\n```\n\n"
+        # 云效 code blocks store each line as a separate child node (e.g. code-line);
+        # join them with newlines so multi-line code isn't flattened onto one line.
+        child_nodes = node.get("nodes") or []
+        if child_nodes:
+            code_body = "\n".join(slate_text(child) for child in child_nodes)
+        else:
+            code_body = slate_text(node)
+        return f"```{language}\n{code_body.rstrip()}\n```\n\n"
 
     level = heading_level(node_type)
     inline = "".join(slate_inline_markdown(child, images) for child in children).strip()


### PR DESCRIPTION
## 改了什么
`export_aliyun_thoughts.py` 的 `slate_block_markdown`：代码块正文改为把每个 `code-line` 子节点用换行连接，不再用 `slate_text(node)` 直接拼接。

## 为什么要改
云效把代码块的每一行存成独立的 Slate 子节点（`code-line`）。原来 `slate_text(node)` 用 `"".join(...)` 递归拼接所有后代文本、节点之间不补换行，于是导出的代码块被压平成一行——每行行首缩进保留、换行全部丢失，行注释还会把后面的语句吞进去。几乎每个含代码的云效文档都受影响。

## 怎么测
- `python -m py_compile export_aliyun_thoughts.py` 通过。
- 单元验证：构造一个与云效同构的最小 Slate 代码块（code-block 下挂多个 code-line）。改前 `slate_text` 输出被压平成一行；改后恢复为正常多行代码块。
- 端到端验证：用改后的代码从云效实际重导了一批含代码的文档，代码块均恢复为正常多行（Java / JSON / SQL 等），行注释不再吞并后续代码。

## 是否涉及用户凭证 / 登录态 / 平台权限
否。仅改动 Markdown 生成逻辑，不涉及登录、Cookie、Token 或权限，也未新增依赖（仅用标准库）。
