### PR TITLE
ci: publish unsigned macOS release artifacts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -58,23 +58,6 @@ jobs:
         working-directory: wandao_electron
         run: npm ci
 
-      - name: Require signing credentials for a release tag
-        if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        env:
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          test -n "$CSC_LINK" || { echo "CSC_LINK is required for signed releases" >&2; exit 1; }
-          test -n "$CSC_KEY_PASSWORD" || { echo "CSC_KEY_PASSWORD is required for signed releases" >&2; exit 1; }
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            test -n "$APPLE_ID" || { echo "APPLE_ID is required for notarization" >&2; exit 1; }
-            test -n "$APPLE_APP_SPECIFIC_PASSWORD" || { echo "APPLE_APP_SPECIFIC_PASSWORD is required for notarization" >&2; exit 1; }
-            test -n "$APPLE_TEAM_ID" || { echo "APPLE_TEAM_ID is required for notarization" >&2; exit 1; }
-          fi
       - name: Build unpacked application
         working-directory: wandao_electron
         env:
@@ -125,12 +108,9 @@ jobs:
       - name: Build desktop package
         working-directory: wandao_electron
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # This project currently publishes unsigned desktop artifacts. Keep
+          # electron-builder from probing an unavailable macOS identity.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
           GITHUB_TOKEN: ${{ github.token }}
         run: ${{ matrix.command }}
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Author: `tllovesxs`
 4. 在左侧进入“平台中心”，选择要使用的平台。
 5. 按界面提示填写链接、登录、读取目录、选择范围并执行任务。
 
-> **macOS 用户注意**：正式发行包应通过 Developer ID 签名和公证。若系统阻止运行开发预览包，请不要直接绕过 Gatekeeper；优先使用正式发行包，或校验源码和 SHA-256 后从源码启动。
+> **macOS 用户注意**：当前 macOS `.zip` 包未进行 Apple 公证。请只从本项目 GitHub Release 下载；若解压并移动到“应用程序”后提示“已损坏，无法打开”，在终端执行：`xattr -cr /Applications/Wandao.app`，再重新打开。
 
 发行版已内置 Python 运行时，普通用户不需要额外安装 Python。
 

--- a/docs/发布与回滚手册.md
+++ b/docs/发布与回滚手册.md
@@ -24,11 +24,11 @@ python scripts/package_smoke.py --resources wandao_electron/dist/win-unpacked/re
 
 1. 维护者审阅变更、`SECURITY.md`、版本说明和兼容性风险。
 2. 推送格式为 `vX.Y.Z` 的受保护 tag。
-3. `Build Desktop` 工作流在 Windows 和 macOS 构建发行物；tag 构建必须提供 `CSC_LINK`、`CSC_KEY_PASSWORD`，macOS 还必须提供 `APPLE_ID`、`APPLE_APP_SPECIFIC_PASSWORD`、`APPLE_TEAM_ID`。
+3. `Build Desktop` 工作流在 Windows 和 macOS 构建发行物。当前发行配置不要求代码签名或 macOS 公证，并显式关闭 Electron Builder 的证书自动发现。
 4. CI 为发行物生成 `SHA256SUMS`、SPDX SBOM 和 build provenance，再创建 GitHub Release。
-5. 下载发行资产，以干净系统验证安装、签名/公证状态、插件中心、一个导出任务与一个恢复任务。
+5. 下载发行资产，以干净系统验证安装、插件中心、一个导出任务与一个恢复任务；macOS 测试机还应验证 Gatekeeper 提示下的 `xattr -cr /Applications/Wandao.app` 恢复路径。
 
-缺少任何签名或公证凭证时，工作流会拒绝 tag 发布；这不是可绕过的警告。可以继续发布源码，但不得把未签名产物标为正式稳定版。
+当前 macOS 包未签名且未公证。Release 说明必须提示用户仅从本项目 Release 下载，并在首次启动出现“已损坏，无法打开”时执行 `xattr -cr /Applications/Wandao.app`。未来配置 Developer ID 证书和 Apple 公证凭据后，再恢复签名发布流程。
 
 ## 官方插件发布
 

--- a/tests/test_electron_health.py
+++ b/tests/test_electron_health.py
@@ -202,7 +202,9 @@ class ElectronHealthTests(unittest.TestCase):
         self.assertEqual(package["build"]["electronDist"], "node_modules/electron/dist")
         self.assertNotIn("signExecutable", package["build"]["win"])
         self.assertTrue(package["build"]["mac"]["hardenedRuntime"])
-        self.assertIn("Require signing credentials for a release tag", workflow)
+        self.assertIn('CSC_IDENTITY_AUTO_DISCOVERY: "false"', workflow)
+        self.assertNotIn("Require signing credentials for a release tag", workflow)
+        self.assertNotIn("CSC_LINK:", workflow)
         self.assertIn("actions/attest-build-provenance", workflow)
         self.assertIn("Generate release SBOM", workflow)
 

--- a/wandao_electron/USAGE.md
+++ b/wandao_electron/USAGE.md
@@ -7,7 +7,13 @@
 - Windows：下载 `.exe` 安装包。
 - macOS：下载 `.zip` 压缩包，解压后运行应用。
 
-正式发行包应通过 Developer ID 签名和公证。若系统阻止运行开发预览包，请不要直接绕过 Gatekeeper；优先使用正式发行包，或校验源码和 SHA-256 后从源码启动。
+当前 macOS `.zip` 包未进行 Apple 公证。请只从本项目 GitHub Release 下载；若解压并移动到“应用程序”后提示“已损坏，无法打开”，在终端执行：
+
+```bash
+xattr -cr /Applications/Wandao.app
+```
+
+再重新打开应用。
 
 发行版已内置 Python 运行时和导入导出依赖，普通用户不需要额外安装 Python。
 


### PR DESCRIPTION
## 变更内容
- macOS 发行构建改为无签名模式，不再要求 Apple 证书或公证 Secrets。
- 发行说明补充 macOS 首次启动出现 Gatekeeper 提示时的 `xattr -cr /Applications/Wandao.app` 指引。
- 保留 Windows/macOS 打包、SBOM、校验和和 provenance 流程。

## 验证
- `python scripts/quality_check.py`
