### PR TITLE
fix: pass target URLs to platform login actions

### DIFF
--- a/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
+++ b/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
@@ -634,6 +634,11 @@ def js_string(value: str) -> str:
 
 def page_fetch_json(cdp: CDPClient, url: str, args: argparse.Namespace | None = None) -> Any:
     throttle_request(args)
+    # CDP evaluation can temporarily run in an about:blank context while the
+    # Thoughts page is still loading. Relative XHR paths are invalid there, so
+    # always give the browser a complete endpoint URL.
+    if url.startswith("/"):
+        url = f"https://thoughts.aliyun.com{url}"
     expression = f"""
 new Promise((resolve, reject) => {{
   const xhr = new XMLHttpRequest();

--- a/plugins/aliyun_thoughts/plugin.json
+++ b/plugins/aliyun_thoughts/plugin.json
@@ -4,7 +4,7 @@
   "id": "aliyun_thoughts",
   "name": "阿里云 Thoughts",
   "description": "阿里云 Thoughts 工作区 Markdown 导出。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "license": "AGPL-3.0-only",
   "core": { "minVersion": "1.2.9" },

--- a/plugins/aliyun_thoughts/providers/aliyun/provider.json
+++ b/plugins/aliyun_thoughts/providers/aliyun/provider.json
@@ -17,7 +17,7 @@
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "title", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
   "fields": [
-    { "name": "workspace_url", "label": "Thoughts 工作区 URL", "type": "text", "arg": "--workspace-url", "required": true, "actions": ["scan", "export"] },
+    { "name": "workspace_url", "label": "Thoughts 工作区 URL", "type": "text", "arg": "--workspace-url", "required": true, "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },
     { "name": "update_existing", "label": "更新已有文档", "type": "checkbox", "arg": "--update-existing", "default": false, "advanced": true, "actions": ["export"] },

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/plugins/feishu/providers/feishu-export/provider.json
+++ b/plugins/feishu/providers/feishu-export/provider.json
@@ -18,7 +18,7 @@
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "toc": { "itemsPath": "ordered", "idKey": "wiki_token", "exportIdKey": "wiki_token", "titleKey": "title", "parentIdKey": "parent_wiki_token", "selectionArg": "--doc-id", "selectableWhenExportId": true },
   "fields": [
-    { "name": "wiki_url", "label": "飞书 Wiki URL", "type": "text", "arg": "--wiki-url", "required": true, "placeholder": "https://xxx.feishu.cn/wiki/...", "actions": ["scan", "export"] },
+    { "name": "wiki_url", "label": "飞书 Wiki URL", "type": "text", "arg": "--wiki-url", "required": true, "placeholder": "https://xxx.feishu.cn/wiki/...", "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },
     { "name": "update_existing", "label": "增量时更新已有文档", "type": "checkbox", "arg": "--update-existing", "default": false, "advanced": true, "actions": ["export"] },

--- a/plugins/feishu/providers/feishu-import/provider.json
+++ b/plugins/feishu/providers/feishu-import/provider.json
@@ -14,7 +14,7 @@
   "tags": ["导入", "Wiki", "图片补全", "权限检测"],
   "capabilities": { "export": false, "import": true, "guide": true, "login": true, "scanToc": false, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": false },
   "fields": [
-    { "name": "wiki_url", "label": "目标飞书 Wiki URL", "type": "text", "arg": "--wiki-url", "required": true, "placeholder": "https://xxx.feishu.cn/wiki/...", "actions": ["probe", "plan", "import", "setupTarget"] },
+    { "name": "wiki_url", "label": "目标飞书 Wiki URL", "type": "text", "arg": "--wiki-url", "required": true, "placeholder": "https://xxx.feishu.cn/wiki/...", "actions": ["login", "probe", "plan", "import", "setupTarget"] },
     { "name": "source_dir", "label": "本地 Markdown 目录", "type": "directory", "arg": "--source-dir", "required": true, "actions": ["plan", "import"] },
     { "name": "app_id", "label": "飞书应用 App ID（留空读取已保存配置）", "type": "text", "arg": "--app-id", "actions": ["saveConfig", "checkApp", "permissions", "probe", "plan", "import", "setupTarget"] },
     { "name": "app_secret", "label": "飞书应用 App Secret（留空读取已保存配置）", "type": "password", "arg": "--app-secret", "actions": ["saveConfig", "checkApp", "probe", "plan", "import", "setupTarget"] },

--- a/plugins/yuque/plugin.json
+++ b/plugins/yuque/plugin.json
@@ -4,7 +4,7 @@
   "id": "yuque",
   "name": "语雀",
   "description": "语雀知识库 Markdown 导出与批量导入。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "homepage": "https://www.yuque.com/",
   "license": "AGPL-3.0-only",

--- a/plugins/yuque/providers/yuque-import/provider.json
+++ b/plugins/yuque/providers/yuque-import/provider.json
@@ -14,7 +14,7 @@
   "capabilities": { "export": false, "import": true, "guide": false, "login": true, "scanToc": false, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "retryFailures": { "arg": "--retry-failures", "label": "只重试失败项" },
   "fields": [
-    { "name": "target_book_url", "label": "目标语雀知识库 URL", "type": "text", "arg": "--target-book-url", "required": true, "actions": ["saveConfig", "plan", "importOne", "import"] },
+    { "name": "target_book_url", "label": "目标语雀知识库 URL", "type": "text", "arg": "--target-book-url", "required": true, "actions": ["login", "saveConfig", "plan", "importOne", "import"] },
     { "name": "source_dir", "label": "本地 Markdown 目录", "type": "directory", "arg": "--source-dir", "required": true, "actions": ["saveConfig", "plan", "importOne", "import"] },
     { "name": "max_import", "label": "最多导入篇数（0 为全部）", "type": "number", "arg": "--max-import", "default": 0, "min": 0, "advanced": true, "actions": ["import"] },
     { "name": "skip_existing", "label": "跳过已存在文档", "type": "checkbox", "arg": "--skip-existing", "default": false, "advanced": true, "actions": ["importOne", "import"] },

--- a/plugins/yuque/providers/yuque/provider.json
+++ b/plugins/yuque/providers/yuque/provider.json
@@ -17,7 +17,7 @@
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "toc": { "itemsPath": "ordered", "idKey": "uuid", "exportIdKey": "uuid", "titleKey": "title", "parentIdKey": "parent_uuid", "selectionArg": "--doc-id", "selectableWhenExportId": true },
   "fields": [
-    { "name": "book_url", "label": "语雀知识库 URL", "type": "text", "arg": "--book-url", "required": true, "actions": ["scan", "export"] },
+    { "name": "book_url", "label": "语雀知识库 URL", "type": "text", "arg": "--book-url", "required": true, "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },
     { "name": "update_existing", "label": "更新已有文档", "type": "checkbox", "arg": "--update-existing", "default": false, "advanced": true, "actions": ["export"] },

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/plugins/zsxq/providers/zsxq-column/provider.json
+++ b/plugins/zsxq/providers/zsxq-column/provider.json
@@ -17,7 +17,7 @@
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "toc": { "itemsPath": "ordered", "idKey": "key", "exportIdKey": "key", "titleKey": "title", "parentIdKey": "parentKey", "selectionArg": "--toc-key", "selectableWhenExportId": true },
   "fields": [
-    { "name": "entry_url", "label": "知识星球专栏 URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["scan", "export"] },
+    { "name": "entry_url", "label": "知识星球专栏 URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },
     { "name": "update_existing", "label": "更新已有文档", "type": "checkbox", "arg": "--update-existing", "default": false, "advanced": true, "actions": ["export"] },

--- a/plugins/zsxq/providers/zsxq-group/provider.json
+++ b/plugins/zsxq/providers/zsxq-group/provider.json
@@ -16,7 +16,7 @@
   "checkpoint": { "supported": true, "strategy": "cursor", "resourceTracking": true },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "fields": [
-    { "name": "entry_url", "label": "知识星球 Group URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["export"] },
+    { "name": "entry_url", "label": "知识星球 Group URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["login", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "group_scope", "label": "帖子范围", "type": "select", "arg": "--group-scope", "default": "auto", "options": [{ "value": "auto", "label": "自动" }, { "value": "all", "label": "全部" }, { "value": "digests", "label": "精华" }, { "value": "by_owner", "label": "星主" }], "advanced": true, "actions": ["export"] },
     { "name": "limit", "label": "最多导出篇数（0 为全部）", "type": "number", "arg": "--limit", "default": 0, "min": 0, "advanced": true, "actions": ["export"] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandao"
-version = "1.3.0"
+version = "1.3.1"
 description = "万能导：多平台知识库 Markdown 导出与互转工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_aliyun_provider_contract.py
+++ b/tests/test_aliyun_provider_contract.py
@@ -1,0 +1,44 @@
+import json
+import unittest
+from pathlib import Path
+
+from export_aliyun_thoughts import page_fetch_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class FakeCDP:
+    def __init__(self) -> None:
+        self.expression = ""
+
+    def evaluate(self, expression: str, timeout: int) -> dict:
+        self.expression = expression
+        self.timeout = timeout
+        return {"result": []}
+
+
+class ProviderActionContractTests(unittest.TestCase):
+    def test_login_actions_receive_their_required_target_url(self) -> None:
+        required_login_fields = {
+            "plugins/aliyun_thoughts/providers/aliyun/provider.json": "workspace_url",
+            "plugins/feishu/providers/feishu-export/provider.json": "wiki_url",
+            "plugins/feishu/providers/feishu-import/provider.json": "wiki_url",
+            "plugins/yuque/providers/yuque/provider.json": "book_url",
+            "plugins/yuque/providers/yuque-import/provider.json": "target_book_url",
+            "plugins/zsxq/providers/zsxq-group/provider.json": "entry_url",
+            "plugins/zsxq/providers/zsxq-column/provider.json": "entry_url",
+        }
+        for relative_path, field_name in required_login_fields.items():
+            with self.subTest(provider=relative_path):
+                manifest = json.loads((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+                field = next(item for item in manifest["fields"] if item["name"] == field_name)
+                self.assertIn("login", field["actions"])
+
+    def test_browser_fetch_expands_relative_api_path(self) -> None:
+        cdp = FakeCDP()
+
+        page_fetch_json(cdp, "/api/workspaces/demo/nodes?pageSize=1000")
+
+        self.assertIn('https://thoughts.aliyun.com/api/workspaces/demo/nodes?pageSize=1000', cdp.expression)
+        self.assertEqual(cdp.timeout, 60)

--- a/wandao_electron/package-lock.json
+++ b/wandao_electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wandao",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wandao",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "electron": "^39.8.5",

--- a/wandao_electron/package.json
+++ b/wandao_electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wandao",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Wandao multi-platform document conversion tool",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## 修复内容

- 登录操作现在会传递各平台后端要求的工作区、Wiki、知识库或入口链接。
- 阿里云 Thoughts 的目录请求改为完整 HTTPS API 地址，避免页面初始上下文下的 Invalid URL。
- 新增跨 Provider 回归测试，并将桌面版本提升至 1.3.1。

## 根因

插件清单的字段动作范围遗漏了 login；桌面端会据此过滤参数，导致后端在登录前收不到必填目标链接。

## 验证

- python -m unittest discover -s tests -v（104 项通过）
- 
pm run check（通过）