### PR TITLE
fix: 让插件 provider 走 manifest 渲染，绕过残留 HTML 模板（补充 #30）

### DIFF
--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -3192,12 +3192,15 @@ function switchTool(toolId) {
   // Load tool template
   const contentArea = document.getElementById('content-area');
   const template = document.getElementById(config.templateId || `template-${currentTool}`);
+  // Plugin providers render from their manifest; a lingering HTML template would use removed
+  // fields (urlParam/noUrl), so bypass it.
+  const isPluginSourced = config.sourceKind === 'plugin' || config.sourceKind === 'bundled-plugin';
 
   if (config.sourceKind === 'plugin' && config.ui?.mode === 'custom') {
     renderCustomPluginProvider(config);
   } else if (config.type === 'guide' || (!config.script && !template && !(config.actions || []).length)) {
     renderGuideProvider(config);
-  } else if (template) {
+  } else if (template && !isPluginSourced) {
     contentArea.innerHTML = '';
     const clone = template.content.cloneNode(true);
     contentArea.appendChild(clone);


### PR DESCRIPTION
## 关联 Issue

本 PR 是 #30 的补充修复，无单独 Issue。#30 修复了插件 manifest 字段动作范围遗漏 `login` 的问题，本 PR 修复导致该问题的上游根因：插件 provider 未走 manifest 渲染路径。

## 改动内容

- `wandao_electron/renderer/app.js` 的 `switchTool` 渲染分支增加 `isPluginSourced` 判断：`sourceKind` 为 `plugin` 或 `bundled-plugin` 的 provider 跳过 `index.html` 中残留的同名 HTML 模板（`template-aliyun`、`template-zsxq-*` 等），改走 manifest 驱动的 `renderManifestProviderForm`。

单文件、4 行改动。

## 为什么需要这个改动

#30 让阿里云等插件的 `workspace_url` 等字段应用于 `login` 动作，但这些平台的 `provider.json` 仍带 `templateId`，`switchTool` 的 `else if (template)` 分支会优先命中 `index.html` 里残留的旧 HTML 模板，导致插件 provider **根本没走到 manifest 渲染路径**：

- 旧模板路径的 `handleLogin` / `handleExport` 依赖 `config.urlParam`、`config.noUrl` 等已随插件化移除的字段。`urlParam` 恒为 `undefined`，登录时拼出 `["--login"]` 之外多一个 `undefined` 参数，后端报 `unrecognized arguments: undefined https://...`。

让插件来源的 provider 统一走 manifest 路径（按 `fields[].arg` 正确拼参数）后，#30 对 `login` 动作的字段修复才能真正生效，阿里云 Thoughts 等平台的登录/读取目录/导出才恢复可用。

## 共创流程确认

- [x] 我已经搜索过已有 Issue 和 PR，没有重复实现同一个功能或 Bug。（已确认 #30 修复的是字段归属，本 PR 修复的是渲染路径劫持，两者互补不重叠。）
- [x] 如果这是新平台、大功能或复杂 Bug，我已经先提交或认领了对应 Issue。（本 PR 为 #30 的小范围补充修复。）
- [x] 这个 PR 尽量只解决一个问题，没有混入无关改动。
- [x] 我没有提交 Cookie、账号密码、App Secret、Token、API Key 或私人知识库内容。

## 测试方式

- [x] 我已运行 `python scripts/quality_check.py`
- [x] 我已运行 Electron JS 语法检查
- [x] 我已在桌面端手动测试
- [x] 我已测试目录结构
- [x] 我已测试图片/附件处理
- [x] 我已测试失败项或异常提示
- [ ] 只改文档，不需要运行代码检查

具体测试过程：

```text
1. python scripts/quality_check.py
   → 104 个 Python 测试 + Node 语法检查 + 空白检查全部通过。
2. ./start-wandao.sh 源码启动，阿里云 Thoughts 手动验证：
   - 填写工作区 URL → 登录并保存凭证 → 浏览器正常打开并导航到工作区页面 → 完成登录后保存凭证成功（修复前报 unrecognized arguments: undefined）。
   - 读取工作区目录 → 360 节点 / 332 篇文档目录树正确加载。
   - 导出 → 332 篇全部处理，本次导出 6 篇、增量跳过 326 篇、0 失败；图片本地化成功 1、失败 0；checkpoint 完整。
```

## 涉及范围

- [x] 阿里云 Thoughts 导出
- [x] Provider 架构
- [x] 桌面端界面

（同样保留残留 HTML 模板的 zsxq 等插件平台一并受益。）

## 用户影响

```text
无需重新登录或重新配置。修复后阿里云 Thoughts（及同样走残留模板的 zsxq 等插件平台）的登录、读取目录、导出功能恢复正常可用。原有凭证、checkpoint、任务历史不受影响。
```

## 已知限制

```text
- 本 PR 通过让插件 provider 绕过残留 HTML 模板修复问题，未删除 index.html 中的 template-aliyun / template-zsxq-* 等旧模板（它们已不再被插件 provider 命中，留作旧 UI 资产；如维护者希望清理可另行处理）。
- 仅实际验证了阿里云 Thoughts 全链路；zsxq 等平台同属残留模板型，理论上同样受益，但未逐一手动验证导出。
```

## 敏感信息检查

- [x] PR 中不包含 Cookie、账号密码、App Secret、Token、API Key 等敏感信息
- [x] 日志和截图已脱敏
- [x] 测试文件不包含私人知识库内容或未授权平台数据
