### PR TITLE
[codex] Fix Feishu import stop and resume

### DIFF
--- a/plugins/feishu/backend/import_feishu.py
+++ b/plugins/feishu/backend/import_feishu.py
@@ -51,6 +51,7 @@ from wandao_core.browser import (
     stop_requested,
     wait_for_debug_port,
 )
+from wandao_core.checkpoint import add_checkpoint_args, open_checkpoint_from_args
 from export_feishu import (
     connect_wiki_browser,
     default_auth_path,
@@ -2091,6 +2092,16 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
         raise ExportError("无法获取目标 Wiki 的 spaceId")
 
     docs = scan_markdown_source(Path(args.source_dir), limit=max(0, int(getattr(args, "max_import", 0) or 0))).get("docs") or []
+    checkpoint = open_checkpoint_from_args(args, "feishu-import", "import")
+    if checkpoint:
+        checkpoint.start_task({"source": str(Path(args.source_dir).resolve()), "target": args.wiki_url, "totalDocs": len(docs)})
+        for doc in docs:
+            relative_path = str(doc.get("relativePath") or "")
+            checkpoint.upsert_item(f"feishu-import:{relative_path}", title=relative_path, source_id=relative_path)
+        if args.retry_failed:
+            docs = [doc for doc in docs if checkpoint.item_status(f"feishu-import:{doc.get('relativePath')}") == "failed"]
+        elif args.resume:
+            docs = [doc for doc in docs if checkpoint.item_status(f"feishu-import:{doc.get('relativePath')}") != "completed"]
     root_parent_token = (get_config_value(args, "parent_wiki_token") or target_wiki_token).strip()
     imported_by_relative_path: dict[str, str] = {}
     folder_tokens: dict[str, str] = {}
@@ -2110,6 +2121,7 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
         if stop_requested(args):
             raise ExportStopped("用户停止了飞书批量导入任务")
         relative_path = str(doc.get("relativePath") or "")
+        item_key = f"feishu-import:{relative_path}"
         emit(
             args,
             f"[{index}/{len(docs)}] 导入：{relative_path}",
@@ -2117,6 +2129,8 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
             doc={"path": relative_path, "index": index},
         )
         try:
+            if checkpoint:
+                checkpoint.start_item(item_key, "import")
             parent_token = ensure_folder_parent_token(
                 args,
                 relative_path=relative_path,
@@ -2145,6 +2159,8 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
                     "imageRepairError": result.get("imageRepairError") or "",
                 }
             )
+            if checkpoint:
+                checkpoint.complete_item(item_key, metadata={"wikiToken": wiki_token, "docToken": result.get("docToken") or ""})
             emit(
                 args,
                 f"文档导入完成：{relative_path}",
@@ -2156,7 +2172,13 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
                     "imageRepairError": result.get("imageRepairError") or "",
                 },
             )
+        except ExportStopped:
+            if checkpoint:
+                checkpoint.fail_item(item_key, "stopped")
+            raise
         except Exception as exc:
+            if checkpoint:
+                checkpoint.fail_item(item_key, str(exc))
             failures.append({"relativePath": relative_path, "error": str(exc)})
             emit(
                 args,
@@ -2198,6 +2220,8 @@ def import_all_with_openapi(args: argparse.Namespace) -> dict[str, Any]:
         level="success" if not failures else "warn",
         stats={"importedDocs": len(imported), "failureCount": len(failures), "folderPageCount": len(folder_pages)},
     )
+    if checkpoint:
+        checkpoint.close()
     return result
 
 
@@ -2706,6 +2730,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--poll-interval", type=float, default=2.0, help="Seconds between async task polls")
     parser.add_argument("--no-auto-open-permission", action="store_true", help="Do not automatically open Feishu permission request pages")
     parser.add_argument("--yes", action="store_true", help="Confirm write operation for API import commands")
+    add_checkpoint_args(parser)
     return parser.parse_args(argv)
 
 

--- a/plugins/feishu/providers/feishu-import/provider.json
+++ b/plugins/feishu/providers/feishu-import/provider.json
@@ -12,7 +12,9 @@
   "status": "stable",
   "guide": "README.md",
   "tags": ["导入", "Wiki", "图片补全", "权限检测"],
-  "capabilities": { "export": false, "import": true, "guide": true, "login": true, "scanToc": false, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": false },
+  "capabilities": { "export": false, "import": true, "guide": true, "login": true, "scanToc": false, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
+  "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
+  "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
   "fields": [
     { "name": "wiki_url", "label": "目标飞书 Wiki URL", "type": "text", "arg": "--wiki-url", "required": true, "placeholder": "https://xxx.feishu.cn/wiki/...", "actions": ["login", "probe", "plan", "import", "setupTarget"] },
     { "name": "source_dir", "label": "本地 Markdown 目录", "type": "directory", "arg": "--source-dir", "required": true, "actions": ["plan", "import"] },

--- a/tests/test_electron_health.py
+++ b/tests/test_electron_health.py
@@ -12,6 +12,13 @@ def read_text(rel_path: str) -> str:
 
 
 class ElectronHealthTests(unittest.TestCase):
+
+    def test_windows_stop_requests_cooperative_shutdown_before_forced_kill(self) -> None:
+        source = (REPO_ROOT / "wandao_electron" / "main.js").read_text(encoding="utf-8")
+        stop_handler = source[source.index("ipcMain.handle('stop-python-process'"):]
+        self.assertIn("WANDAO_STOP_FILE", source)
+        self.assertIn("writeFileSync", stop_handler)
+        self.assertLess(stop_handler.index("writeFileSync"), stop_handler.index("terminateProcessTree"))
     def test_browser_window_keeps_safe_renderer_defaults(self) -> None:
         main_js = read_text("wandao_electron/main.js")
         index_html = read_text("wandao_electron/renderer/index.html")

--- a/tests/test_feishu_import_resume.py
+++ b/tests/test_feishu_import_resume.py
@@ -1,0 +1,26 @@
+import unittest
+
+import import_feishu
+
+
+class FeishuImportResumeTests(unittest.TestCase):
+    def test_batch_import_accepts_checkpoint_resume_and_retry_args(self) -> None:
+        args = import_feishu.parse_args(
+            [
+                "--wiki-url", "https://demo.feishu.cn/wiki/demo",
+                "--source-dir", "source",
+                "--api-import-all", "--yes",
+                "--checkpoint-file", "source/.wandao/feishu-import.sqlite",
+                "--checkpoint-task-id", "feishu-import:stable",
+                "--resume", "--retry-failed",
+            ]
+        )
+
+        self.assertEqual(args.checkpoint_file, "source/.wandao/feishu-import.sqlite")
+        self.assertEqual(args.checkpoint_task_id, "feishu-import:stable")
+        self.assertTrue(args.resume)
+        self.assertTrue(args.retry_failed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -38,3 +38,14 @@ test('the renderer loads and uses the resume helper before app startup', () => {
   assert.match(appJs, /WandaoTaskResume\?\.buildResumeArgs/);
   assert.match(appJs, /WandaoTaskResume\?\.shouldRetryFailureItems/);
 });
+
+test('generic export treats the cooperative stop exit code as stopped, not a resource failure', () => {
+  const appJs = fs.readFileSync('wandao_electron/renderer/app.js', 'utf8');
+  const start = appJs.indexOf('async function handleExport');
+  const end = appJs.indexOf('// Handle stop', start);
+  const handler = appJs.slice(start, end);
+
+  assert.match(handler, /if \(result\.code === 130\)/);
+  assert.match(handler, /已停止/);
+  assert.ok(handler.indexOf('result.code === 130') < handler.indexOf('导出失败'));
+});

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -46,6 +46,5 @@ test('generic export treats the cooperative stop exit code as stopped, not a res
   const handler = appJs.slice(start, end);
 
   assert.match(handler, /if \(result\.code === 130\)/);
-  assert.match(handler, /已停止/);
-  assert.ok(handler.indexOf('result.code === 130') < handler.indexOf('导出失败'));
+  assert.match(handler, /result\.code === 130[\s\S]*已停止[\s\S]*finishProgress/);
 });

--- a/wandao_core/browser.py
+++ b/wandao_core/browser.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import base64
 import json
 import os
@@ -71,7 +72,10 @@ def js_string(value: str) -> str:
 
 def stop_requested(args: argparse.Namespace | None) -> bool:
     event = getattr(args, "stop_event", None) if args is not None else None
-    return bool(event and event.is_set())
+    if event and event.is_set():
+        return True
+    stop_file = os.environ.get("WANDAO_STOP_FILE", "").strip()
+    return bool(stop_file and os.path.exists(stop_file))
 
 
 def check_stopped(args: argparse.Namespace | None) -> None:

--- a/wandao_electron/main.js
+++ b/wandao_electron/main.js
@@ -13,6 +13,7 @@ const { resolveLegacyTemplateConfig } = require('./provider_legacy_compat');
 let mainWindow;
 let pythonProcess = null;
 let pythonProcessStopping = false;
+let pythonStopFile = '';
 let shutdownConfirmed = false;
 const pluginRegistryCache = new Map();
 const MAX_PROCESS_OUTPUT_CHARS = 32 * 1024 * 1024;
@@ -1554,14 +1555,19 @@ ipcMain.handle('run-python-command', async (event, scriptName, args, options = {
     }
     const pythonArgs = [scriptPath, ...commandArgs];
 
+    const stopFile = path.join(app.getPath('userData'), 'runtime', 'stops', `${options.taskId || Date.now()}.stop`);
+    try { fs.unlinkSync(stopFile); } catch (_error) { /* no stale marker */ }
+    const env = executionEnv(options, pluginContext, options.commandSecretEnvironment || {});
+    env.WANDAO_STOP_FILE = stopFile;
     const proc = spawn(pythonCommand(), pythonArgs, {
       cwd: path.dirname(scriptPath),
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
-      env: executionEnv(options, pluginContext, options.commandSecretEnvironment || {})
+      env
     });
     pythonProcess = proc;
     pythonProcessStopping = false;
+    pythonStopFile = stopFile;
 
     if (options?.stdinText) {
       proc.stdin.write(String(options.stdinText));
@@ -1599,7 +1605,9 @@ ipcMain.handle('run-python-command', async (event, scriptName, args, options = {
       if (pythonProcess === proc) {
         pythonProcess = null;
         pythonProcessStopping = false;
+        pythonStopFile = '';
       }
+      try { fs.unlinkSync(stopFile); } catch (_error) { /* marker is best-effort */ }
       if (code === 0) {
         const result = parseProcessResult(stdout);
         if (result.ok) {
@@ -1637,12 +1645,18 @@ ipcMain.handle('stop-python-process', async () => {
       return { success: true, stopping: true };
     }
     pythonProcessStopping = true;
-    const signaled = terminateProcessTree(pythonProcess);
-    if (!signaled) {
-      pythonProcessStopping = false;
-      return { success: false, error: '无法停止当前任务，请稍后重试。' };
+    if (pythonStopFile) {
+      fs.mkdirSync(path.dirname(pythonStopFile), { recursive: true });
+      fs.writeFileSync(pythonStopFile, 'stop', 'utf8');
+      const processAtRequest = pythonProcess;
+      setTimeout(() => {
+        if (pythonProcess === processAtRequest) terminateProcessTree(processAtRequest, { force: true });
+      }, 8000).unref();
+      return { success: true, stopping: true, cooperative: true };
     }
-    return { success: true, stopping: true };
+    const signaled = terminateProcessTree(pythonProcess);
+    if (!signaled) pythonProcessStopping = false;
+    return signaled ? { success: true, stopping: true } : { success: false, error: '无法停止当前任务，请稍后重试。' };
   }
   return { success: false, error: '没有正在运行的任务' };
 });

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4711,6 +4711,9 @@ async function handleExport(toolId) {
         log(JSON.stringify(result.data, null, 2), 'success');
       }
       finishProgress(true, `${actionName}完成`);
+    } else if (result.code === 130) {
+      log(`${actionName}已停止，已完成项目会在下次继续时跳过。`, 'warn');
+      finishProgress(false, `${actionName}已停止`);
     } else {
       log(`${actionName}失败：${result.error}`, 'error');
       finishProgress(false, `${actionName}失败，请查看运行日志`);

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -5128,6 +5128,7 @@ function buildFeishuImportArgs() {
   args.push('--request-jitter', document.getElementById('feishu-import-jitter').value || '0.4');
 
   if (document.getElementById('feishu-import-move-to-wiki').checked) args.push('--move-to-wiki');
+  if (sourceDir) args.push('--checkpoint-file', `${sourceDir.replace(/[\\/]+$/, '')}/.wandao/feishu-import.sqlite`, '--resume');
   if (document.getElementById('feishu-import-skip-rename').checked) args.push('--skip-rename');
   if (!document.getElementById('feishu-import-repair-images').checked) args.push('--skip-image-repair');
   if (document.getElementById('feishu-import-require-image-repair').checked) args.push('--require-image-repair');
@@ -5161,6 +5162,11 @@ async function runFeishuImportCommand(args, taskName) {
       log(JSON.stringify(result.data || {}, null, 2), 'success');
       finishProgress(true, `${taskName}完成`);
       return result.data || {};
+    }
+    if (result.code === 130) {
+      log(`${taskName}已停止，已完成项目会在下次继续时跳过。`, 'warn');
+      finishProgress(false, `${taskName}已停止`);
+      return null;
     }
     log(`失败：${result.error}`, 'error');
     finishProgress(false, `${taskName}失败，请查看运行日志`);


### PR DESCRIPTION
## Summary

- Turn desktop Stop into a cooperative stop request: Python receives `WANDAO_STOP_FILE`, gets up to eight seconds to emit `task.stopped`, and only then is force-terminated.
- Add per-file SQLite checkpoint support to Feishu batch import with `--resume` and `--retry-failed`.
- Persist the checkpoint beside the source directory and declare recovery support in the Feishu import provider.
- Treat process exit code 130 as stopped in the renderer instead of running permission-error guidance.

Fixes #35.

## Reproduction addressed

A real import was stopped at 5/7. Windows immediately used `taskkill /T /F`, so the task was reported as an API permission failure and the next batch started at 1/7. The new path preserves a checkpoint and exits through `ExportStopped` before force termination.

## Validation

- `node --test tests_js/toc_tree.test.js tests_js/task_resume.test.js`
- `python -m unittest` (106 passed)
- `python scripts/quality_check.py`
- `git diff --check`

## Manual validation needed

Run a 7+ document Feishu import, stop while a document is active, use task-history Continue, and confirm completed documents are skipped and no permission warning is shown.