### PR TITLE
[codex] Fix Youdao export stop handling

### DIFF
--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -40,6 +40,8 @@ from wandao_core.browser import (
     CDPClient,
     DEFAULT_PORT,
     ExportError,
+    ExportStopped,
+    check_stopped,
     chrome_debug_available,
     default_data_dir,
     default_state_path,
@@ -1086,6 +1088,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     exported = 0
     skipped = 0
     failures: list[dict[str, Any]] = []
+    stopped = False
     rows: list[dict[str, Any]] = []
     stats = {
         "imageSuccess": 0,
@@ -1104,6 +1107,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         md_or_file_path = local_paths[node.id]
         item_key = f"youdao:node:{node.id}"
         try:
+            check_stopped(args)
             if checkpoint and getattr(args, "resume", False) and not args.update_existing and checkpoint.item_status(item_key) == "completed":
                 row_file = md_or_file_path.with_suffix(".md") if node.is_note_like else md_or_file_path
                 skipped += 1
@@ -1141,12 +1145,14 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 doc={"id": node.id, "title": node.title, "index": index, "path": "/".join(node.path_parts)},
             )
             downloaded = client.download_file(node.id)
+            check_stopped(args)
             markdown, is_markdown = convert_note_to_markdown(node, downloaded)
             resource_failures_before = stats["imageFailureCount"] + stats["attachmentFailureCount"]
             if is_markdown:
                 md_path = md_or_file_path.with_suffix(".md")
                 md_path.parent.mkdir(parents=True, exist_ok=True)
                 markdown = localize_links(client, markdown, md_path, args, stats)
+                check_stopped(args)
                 md_path.write_text(clean_markdown(markdown, node.title), encoding="utf-8")
                 apply_remote_file_time(md_path, node)
                 row_file = md_path
@@ -1179,6 +1185,12 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 event="document.export.completed",
                 doc={"id": node.id, "title": node.title, "index": index, "path": str(row_file)},
             )
+        except ExportStopped:
+            stopped = True
+            if checkpoint:
+                checkpoint.fail_item(item_key, "stopped")
+            emit(f"有道云笔记导出已停止：{node.title}", event="task.stopped", level="warn")
+            break
         except Exception as exc:
             if checkpoint:
                 checkpoint.fail_item(item_key, str(exc))
@@ -1203,6 +1215,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         "skippedDocs": skipped,
         "failureCount": len(failures),
         "failures": failures,
+        "stopped": stopped,
         "requestCount": client.request_count,
         **stats,
     }
@@ -1213,7 +1226,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     if checkpoint:
         resource_failure_count = stats["imageFailureCount"] + stats["attachmentFailureCount"]
-        if failures or resource_failure_count:
+        if stopped:
+            checkpoint.fail_task("stopped", status="stopped")
+        elif failures or resource_failure_count:
             checkpoint.fail_task(
                 f"{len(failures)} 个文档失败，{resource_failure_count} 个资源失败",
                 status="failed",
@@ -1222,9 +1237,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
             checkpoint.complete_task(report)
         checkpoint.close()
     emit(
-        "有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项",
-        event="task.completed",
-        level="success" if not failures and not (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "warn",
+        "有道云笔记导出已停止" if stopped else ("有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项"),
+        event="task.stopped" if stopped else "task.completed",
+        level="warn" if stopped or failures or (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "success",
         reportFile=str(report_path),
         stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures), **stats},
     )
@@ -1288,7 +1303,7 @@ def run_gui() -> int:
     tk.Button(actions, text="退出", command=root.destroy).pack(side="right")
 
     root.mainloop()
-    return 0
+    return 130 if result.get("stopped") else 0
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/test_youdao_stop.py
+++ b/tests/test_youdao_stop.py
@@ -1,0 +1,28 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class YoudaoStopContractTests(unittest.TestCase):
+    def test_youdao_export_records_stopped_item_and_returns_code_130(self) -> None:
+        source = (REPO_ROOT / "plugins/youdao/backend/export_youdao.py").read_text(encoding="utf-8")
+
+        self.assertIn("ExportStopped", source)
+        self.assertIn("check_stopped(args)", source)
+        self.assertIn('checkpoint.fail_item(item_key, "stopped")', source)
+        self.assertIn('return 130 if result.get("stopped") else 0', source)
+
+    def test_shared_runtime_and_generic_export_ui_handle_controlled_stop(self) -> None:
+        browser = (REPO_ROOT / "wandao_core/browser.py").read_text(encoding="utf-8")
+        main_js = (REPO_ROOT / "wandao_electron/main.js").read_text(encoding="utf-8")
+        app_js = (REPO_ROOT / "wandao_electron/renderer/app.js").read_text(encoding="utf-8")
+
+        self.assertIn("WANDAO_STOP_FILE", browser)
+        self.assertIn("fs.writeFileSync(pythonStopFile, 'stop', 'utf8')", main_js)
+        self.assertIn("else if (result.code === 130)", app_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wandao_core/browser.py
+++ b/wandao_core/browser.py
@@ -71,7 +71,10 @@ def js_string(value: str) -> str:
 
 def stop_requested(args: argparse.Namespace | None) -> bool:
     event = getattr(args, "stop_event", None) if args is not None else None
-    return bool(event and event.is_set())
+    if event and event.is_set():
+        return True
+    stop_file = os.environ.get("WANDAO_STOP_FILE", "").strip()
+    return bool(stop_file and os.path.exists(stop_file))
 
 
 def check_stopped(args: argparse.Namespace | None) -> None:

--- a/wandao_electron/main.js
+++ b/wandao_electron/main.js
@@ -13,6 +13,7 @@ const { resolveLegacyTemplateConfig } = require('./provider_legacy_compat');
 let mainWindow;
 let pythonProcess = null;
 let pythonProcessStopping = false;
+let pythonStopFile = '';
 let shutdownConfirmed = false;
 const pluginRegistryCache = new Map();
 const MAX_PROCESS_OUTPUT_CHARS = 32 * 1024 * 1024;
@@ -79,6 +80,7 @@ function cleanupPythonProcess() {
     }
     pythonProcess = null;
     pythonProcessStopping = false;
+    pythonStopFile = '';
   }
 }
 
@@ -1553,15 +1555,20 @@ ipcMain.handle('run-python-command', async (event, scriptName, args, options = {
       return;
     }
     const pythonArgs = [scriptPath, ...commandArgs];
+    const stopFile = path.join(app.getPath('userData'), 'runtime', 'stops', `${options.taskId || Date.now()}.stop`);
+    try { fs.unlinkSync(stopFile); } catch (_error) { /* no stale marker */ }
+    const env = executionEnv(options, pluginContext, options.commandSecretEnvironment || {});
+    env.WANDAO_STOP_FILE = stopFile;
 
     const proc = spawn(pythonCommand(), pythonArgs, {
       cwd: path.dirname(scriptPath),
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
-      env: executionEnv(options, pluginContext, options.commandSecretEnvironment || {})
+      env
     });
     pythonProcess = proc;
     pythonProcessStopping = false;
+    pythonStopFile = stopFile;
 
     if (options?.stdinText) {
       proc.stdin.write(String(options.stdinText));
@@ -1599,7 +1606,9 @@ ipcMain.handle('run-python-command', async (event, scriptName, args, options = {
       if (pythonProcess === proc) {
         pythonProcess = null;
         pythonProcessStopping = false;
+        pythonStopFile = '';
       }
+      try { fs.unlinkSync(stopFile); } catch (_error) { /* marker is best-effort */ }
       if (code === 0) {
         const result = parseProcessResult(stdout);
         if (result.ok) {
@@ -1625,7 +1634,9 @@ ipcMain.handle('run-python-command', async (event, scriptName, args, options = {
       if (pythonProcess === proc) {
         pythonProcess = null;
         pythonProcessStopping = false;
+        pythonStopFile = '';
       }
+      try { fs.unlinkSync(stopFile); } catch (_error) { /* marker is best-effort */ }
       resolve({ success: false, error: error.message || String(error) });
     });
   });
@@ -1637,6 +1648,15 @@ ipcMain.handle('stop-python-process', async () => {
       return { success: true, stopping: true };
     }
     pythonProcessStopping = true;
+    if (pythonStopFile) {
+      fs.mkdirSync(path.dirname(pythonStopFile), { recursive: true });
+      fs.writeFileSync(pythonStopFile, 'stop', 'utf8');
+      const processAtRequest = pythonProcess;
+      setTimeout(() => {
+        if (pythonProcess === processAtRequest) terminateProcessTree(processAtRequest, { force: true });
+      }, 8000).unref();
+      return { success: true, stopping: true, cooperative: true };
+    }
     const signaled = terminateProcessTree(pythonProcess);
     if (!signaled) {
       pythonProcessStopping = false;

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4711,6 +4711,9 @@ async function handleExport(toolId) {
         log(JSON.stringify(result.data, null, 2), 'success');
       }
       finishProgress(true, `${actionName}完成`);
+    } else if (result.code === 130) {
+      log(`${actionName}已停止，已完成项目会在下次继续时跳过。`, 'warn');
+      finishProgress(false, `${actionName}已停止`);
     } else {
       log(`${actionName}失败：${result.error}`, 'error');
       finishProgress(false, `${actionName}失败，请查看运行日志`);


### PR DESCRIPTION
Fixes #39

## Summary

- Make the Youdao export loop observe the shared stop marker before and after document/resource work.
- Mark the interrupted checkpoint item and task as stopped, return code 130, and keep prior completed items resumable.
- Add the shared Electron/Python cooperative-stop bridge and render code 130 as a stopped generic export.

## Validation

- `node --test tests_js/task_resume.test.js tests_js/toc_tree.test.js` (8 passing)
- `python -m unittest discover -s tests` (106 passing)
- `python scripts/quality_check.py`
- `git diff --check`

Manual validation: stop after several Youdao documents, then continue from task history and verify the completed documents are skipped.