### PR TITLE
fix: align second-batch Plugin v1 TOC contracts

### DIFF
--- a/plugins/ima/providers/ima-export/provider.json
+++ b/plugins/ima/providers/ima-export/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": false, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "name", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "client_id", "label": "ima Client ID", "type": "text", "arg": "--client-id", "actions": ["saveConfig", "list", "scan", "export"] },
     { "name": "api_key", "label": "ima API Key", "type": "password", "arg": "--api-key", "actions": ["saveConfig", "list", "scan", "export"] },

--- a/plugins/onenote/providers/onenote/provider.json
+++ b/plugins/onenote/providers/onenote/provider.json
@@ -16,7 +16,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": false, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "title", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },

--- a/plugins/yinxiang/backend/export_yinxiang.py
+++ b/plugins/yinxiang/backend/export_yinxiang.py
@@ -502,6 +502,12 @@ def note_markdown(note_el: ET.Element, md_path: Path) -> tuple[str, str]:
     return "\n".join(lines), guid
 
 
+def select_enex_notes(notes: list[ET.Element], selected_doc_ids: set[str]) -> list[ET.Element]:
+    if not selected_doc_ids:
+        return notes
+    return [note_el for note_el in notes if (note_el.findtext("guid") or "") in selected_doc_ids]
+
+
 def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
     output = args.output
     output.mkdir(parents=True, exist_ok=True)
@@ -568,13 +574,14 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
                     checkpoint.skip_item(item_key, "empty-enex")
                 skipped += 1
                 continue
-            note_el = notes[0]
-            guid = note_el.findtext("guid") or ""
-            if selected and guid not in selected:
+            selected_notes = select_enex_notes(notes, selected)
+            if not selected_notes:
                 if checkpoint:
                     checkpoint.skip_item(item_key, "not-selected")
                 skipped += 1
                 continue
+            note_el = selected_notes[0]
+            guid = note_el.findtext("guid") or ""
             if args.incremental and md_path.exists():
                 if checkpoint:
                     checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"guid": guid, "skippedExisting": True})

--- a/plugins/yinxiang/providers/yinxiang/provider.json
+++ b/plugins/yinxiang/providers/yinxiang/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "guid", "exportIdKey": "guid", "titleKey": "title", "parentIdKey": "parentGuid", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "adapter": "yinxiang-notebooks", "itemsPath": "notebooks", "selectionArg": "--doc-id" },
   "fields": [
     { "name": "username", "label": "印象笔记账号", "type": "text", "arg": "--username", "actions": ["initAuth"] },
     { "name": "database", "label": "本地同步库", "type": "file", "arg": "--database", "advanced": true, "actions": ["scan", "export"] },

--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -119,6 +119,11 @@ class RemoteNode:
             return None
 
 
+def select_export_documents(nodes: list[RemoteNode], selected_doc_ids: list[str] | set[str] | None) -> list[RemoteNode]:
+    selected = set(selected_doc_ids or [])
+    return [node for node in nodes if not node.is_dir and (not selected or node.id in selected)]
+
+
 @dataclass
 class DownloadedContent:
     content: bytes
@@ -1052,14 +1057,13 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     checkpoint = open_checkpoint_from_args(args, "youdao", "export")
     client = YoudaoClient(auth_path_from_args(args), args)
     nodes, root_id = build_remote_tree(client)
-    selected = set(args.selected_doc_ids or [])
     counters: dict[str, int] = {}
     local_paths = {
         node.id: path_for_node(output, node, counters, create_dirs=False)
         for node in nodes
         if not node.is_dir
     }
-    docs = [node for node in nodes if not node.is_dir and (not selected or node.id in selected)]
+    docs = select_export_documents(nodes, args.selected_doc_ids)
     if checkpoint:
         checkpoint.start_task(
             {

--- a/plugins/youdao/providers/youdao/provider.json
+++ b/plugins/youdao/providers/youdao/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "title", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },

--- a/plugins/zsxq/providers/zsxq-column/provider.json
+++ b/plugins/zsxq/providers/zsxq-column/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": true },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "key", "exportIdKey": "key", "titleKey": "title", "parentIdKey": "parentKey", "selectionArg": "--toc-key", "selectableWhenExportId": true },
+  "toc": { "adapter": "zsxq-column-groups", "itemsPath": "groups", "selectionPrefixArgs": ["--toc-mode", "toc"], "selectionArg": "--toc-key" },
   "fields": [
     { "name": "entry_url", "label": "知识星球专栏 URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },

--- a/tests/test_second_batch_toc_contract.py
+++ b/tests/test_second_batch_toc_contract.py
@@ -1,0 +1,47 @@
+import argparse
+import unittest
+import xml.etree.ElementTree as ET
+
+from plugins.ima.backend.ima_knowledge import KnowledgeEntry, selected_entries
+from plugins.onenote.backend.export_onenote import TocNode, selected_pages
+from plugins.youdao.backend.export_youdao import RemoteNode, select_export_documents
+from plugins.yinxiang.backend.export_yinxiang import select_enex_notes
+from plugins.zsxq.backend.export_zsxq import select_toc_items
+
+
+class SecondBatchTocContractTests(unittest.TestCase):
+    def test_ima_filters_the_export_id_emitted_by_the_nodes_toc(self) -> None:
+        folder = KnowledgeEntry('kb', 'KB', 'folder', 'Folder', '', [], True)
+        doc = KnowledgeEntry('kb', 'KB', 'doc', 'Document', 'folder', [], False)
+
+        self.assertEqual([entry.export_id for entry in selected_entries([folder, doc], [doc.export_id])], [doc.export_id])
+
+    def test_onenote_filters_the_page_export_id_emitted_by_the_nodes_toc(self) -> None:
+        folder = TocNode('', 'notebook', 'notebook', 'Notebook', '', False, 0, [])
+        page = TocNode('page-id', 'page', 'page', 'Page', 'notebook', True, 1, [])
+        args = argparse.Namespace(selected_doc_ids=['page-id'])
+
+        self.assertEqual([node.id for node in selected_pages(args, [folder, page])], ['page-id'])
+
+    def test_youdao_filters_only_selected_non_folder_export_ids(self) -> None:
+        folder = RemoteNode('folder-id', 'Folder', True)
+        doc = RemoteNode('doc-id', 'Note.note', False, parent_id='folder-id', raw={'createTime': '123'})
+
+        self.assertEqual([node.id for node in select_export_documents([folder, doc], ['doc-id'])], ['doc-id'])
+        self.assertEqual(doc.created_time, 123.0)
+
+    def test_yinxiang_filters_enex_notes_by_the_guid_emitted_by_the_toc(self) -> None:
+        first = ET.fromstring('<note><guid>first-guid</guid></note>')
+        selected = ET.fromstring('<note><guid>selected-guid</guid></note>')
+
+        self.assertEqual(select_enex_notes([first, selected], {'selected-guid'}), [selected])
+
+    def test_zsxq_column_filters_the_toc_key_emitted_by_the_group_adapter(self) -> None:
+        toc = {'groups': [{'groupTitle': 'Section', 'topics': [{'key': 'toc:3:0', 'title': 'Article'}, {'key': 'toc:3:1', 'title': 'Other'}]}]}
+        args = argparse.Namespace(selected_toc_keys=['toc:3:0'], toc_group_pattern=None, toc_title_pattern=None, link_pattern=None, limit=0)
+
+        self.assertEqual([item['key'] for item in select_toc_items(toc, args)], ['toc:3:0'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests_js/toc_tree.test.js
+++ b/tests_js/toc_tree.test.js
@@ -1,6 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { normalizeStandardTocNodes, tocNodeMaps, selectionArgs } = require('../wandao_electron/renderer/toc_tree.js');
+const {
+  normalizeProviderTocNodes,
+  normalizeStandardTocNodes,
+  tocNodeMaps,
+  selectionArgs
+} = require('../wandao_electron/renderer/toc_tree.js');
 
 test('restores Aliyun parent_id hierarchy when a legacy manifest still points at ordered', () => {
   const provider = { id: 'aliyun', toc: { itemsPath: 'ordered', idKey: 'id', exportIdKey: 'id', titleKey: 'title', parentIdKey: 'parentId' } };
@@ -88,4 +93,89 @@ test('maps Feishu ordered nodes with explicit document selectability', () => {
   assert.deepEqual(tree.children.get('feishu-export:folder').map((node) => node.nodeId), ['feishu-export:non-url', 'feishu-export:doc']);
   assert.deepEqual(nodes.filter((node) => node.selectable).map((node) => node.exportId), ['doc']);
   assert.deepEqual(selectionArgs(provider, ['doc']), ['--doc-id', 'doc']);
+});
+
+test('maps the standard Plugin v1 nodes contracts for ima, OneNote, and Youdao', () => {
+  const fixtures = [
+    {
+      provider: require('../plugins/ima/providers/ima-export/provider.json'),
+      root: { nodeId: 'ima-kb:demo', exportId: '', title: 'Knowledge base', parentNodeId: '', selectable: false },
+      doc: { nodeId: 'ima-media:demo:doc', exportId: 'ima-export-id', title: 'Document', parentNodeId: 'ima-kb:demo', selectable: true }
+    },
+    {
+      provider: require('../plugins/onenote/providers/onenote/provider.json'),
+      root: { nodeId: 'onenote-notebook:demo', exportId: '', title: 'Notebook', parentNodeId: '', selectable: false },
+      doc: { nodeId: 'onenote-page:demo', exportId: 'onenote-page-id', title: 'Page', parentNodeId: 'onenote-notebook:demo', selectable: true }
+    },
+    {
+      provider: require('../plugins/youdao/providers/youdao/provider.json'),
+      root: { nodeId: 'youdao-folder:demo', exportId: '', title: 'Folder', parentNodeId: '', selectable: false, type: 'folder' },
+      doc: { nodeId: 'youdao-doc:demo', exportId: 'youdao-doc-id', title: 'Note', parentNodeId: 'youdao-folder:demo', selectable: true, type: 'document' }
+    }
+  ];
+
+  fixtures.forEach(({ provider, root, doc }) => {
+    assert.equal(provider.toc.itemsPath, 'nodes');
+    assert.equal(provider.toc.idKey, 'nodeId');
+    assert.equal(provider.toc.exportIdKey, 'exportId');
+    assert.equal(provider.toc.parentIdKey, 'parentNodeId');
+    assert.equal(provider.toc.selectableKey, 'selectable');
+    assert.equal(provider.toc.selectionArg, '--doc-id');
+
+    const nodes = normalizeProviderTocNodes(provider, { nodes: [root, doc] });
+    const tree = tocNodeMaps(nodes);
+    assert.deepEqual(tree.children.get('').map((node) => node.nodeId), [root.nodeId]);
+    assert.deepEqual(tree.children.get(root.nodeId).map((node) => node.nodeId), [doc.nodeId]);
+    assert.equal(nodes[0].selectable, false);
+    assert.equal(nodes[1].selectable, true);
+    assert.equal(nodes[1].exportId, doc.exportId);
+    assert.deepEqual(selectionArgs(provider, [nodes[1].exportId]), ['--doc-id', doc.exportId]);
+  });
+});
+
+test('maps Yinxiang notebook scan results through its explicit adapter', () => {
+  const provider = require('../plugins/yinxiang/providers/yinxiang/provider.json');
+  assert.equal(provider.toc.adapter, 'yinxiang-notebooks');
+  assert.equal(provider.toc.itemsPath, 'notebooks');
+  assert.equal(provider.toc.selectionArg, '--doc-id');
+
+  const nodes = normalizeProviderTocNodes(provider, { notebooks: [
+    {
+      guid: 'notebook-guid',
+      name: 'Notebook',
+      stack: 'Stack',
+      notes: [{ guid: 'note-guid', title: 'Selected note' }]
+    }
+  ] });
+  const tree = tocNodeMaps(nodes);
+
+  assert.deepEqual(tree.children.get('').map((node) => node.nodeId), ['yinxiang-stack:Stack']);
+  assert.deepEqual(tree.children.get('yinxiang-stack:Stack').map((node) => node.nodeId), ['yinxiang-notebook:notebook-guid']);
+  assert.deepEqual(tree.children.get('yinxiang-notebook:notebook-guid').map((node) => node.nodeId), ['yinxiang-note:note-guid']);
+  assert.equal(nodes.at(-1).selectable, true);
+  assert.equal(nodes.at(-1).exportId, 'note-guid');
+  assert.deepEqual(selectionArgs(provider, [nodes.at(-1).exportId]), ['--doc-id', 'note-guid']);
+});
+
+test('maps ZSXQ column groups through its explicit adapter', () => {
+  const provider = require('../plugins/zsxq/providers/zsxq-column/provider.json');
+  assert.equal(provider.toc.adapter, 'zsxq-column-groups');
+  assert.equal(provider.toc.itemsPath, 'groups');
+  assert.equal(provider.toc.selectionArg, '--toc-key');
+
+  const nodes = normalizeProviderTocNodes(provider, { groups: [
+    {
+      groupIndex: 3,
+      groupTitle: 'Section',
+      topics: [{ key: 'toc:3:0', title: 'Article' }]
+    }
+  ] });
+  const tree = tocNodeMaps(nodes);
+
+  assert.deepEqual(tree.children.get('').map((node) => node.nodeId), ['zsxq-column-group:3']);
+  assert.deepEqual(tree.children.get('zsxq-column-group:3').map((node) => node.nodeId), ['zsxq-column:toc:3:0']);
+  assert.equal(nodes[0].selectable, false);
+  assert.equal(nodes[1].selectable, true);
+  assert.equal(nodes[1].exportId, 'toc:3:0');
+  assert.deepEqual(selectionArgs(provider, [nodes[1].exportId]), ['--toc-mode', 'toc', '--toc-key', 'toc:3:0']);
 });

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4354,7 +4354,7 @@ function buildExportArgs(toolId, options = {}) {
 }
 
 function normalizeStandardTocNodes(provider, data) {
-  return window.WandaoTocTree.normalizeStandardTocNodes(provider, data);
+  return window.WandaoTocTree.normalizeProviderTocNodes(provider, data);
 }
 
 function normalizeTocNodes(toolId, data) {
@@ -4634,14 +4634,7 @@ function selectedTocArgs(toolId) {
   if (!selected.length) {
     throw new Error('目录已读取，但没有选择任何文档。请至少勾选一篇，或重新读取目录。');
   }
-  const args = [];
-  if (toolId === 'zsxq-column') {
-    args.push('--toc-mode', 'toc');
-    selected.forEach((id) => args.push('--toc-key', id));
-  } else {
-    args.push(...window.WandaoTocTree.selectionArgs(TOOLS[toolId], selected));
-  }
-  return args;
+  return window.WandaoTocTree.selectionArgs(TOOLS[toolId], selected);
 }
 
 async function handleScanToc(toolId) {

--- a/wandao_electron/renderer/toc_tree.js
+++ b/wandao_electron/renderer/toc_tree.js
@@ -49,6 +49,74 @@
     });
   }
 
+  function normalizeYinxiangTocNodes(data) {
+    const nodes = [];
+    (data?.notebooks || []).forEach((notebook, notebookIndex) => {
+      const stack = String(notebook.stack || '');
+      let parentNodeId = '';
+      if (stack) {
+        parentNodeId = `yinxiang-stack:${stack}`;
+        if (!nodes.some((node) => node.nodeId === parentNodeId)) {
+          nodes.push({ nodeId: parentNodeId, exportId: '', title: stack, parentNodeId: '', selectable: false });
+        }
+      }
+      const notebookId = String(notebook.guid || `notebook-${notebookIndex}`);
+      const notebookNodeId = `yinxiang-notebook:${notebookId}`;
+      nodes.push({
+        nodeId: notebookNodeId,
+        exportId: '',
+        title: notebook.name || `Notebook ${notebookIndex + 1}`,
+        parentNodeId,
+        selectable: false
+      });
+      (notebook.notes || []).forEach((note, noteIndex) => {
+        const guid = String(note.guid || '');
+        if (!guid) return;
+        nodes.push({
+          nodeId: `yinxiang-note:${guid}`,
+          exportId: guid,
+          title: note.title || `Untitled note ${noteIndex + 1}`,
+          parentNodeId: notebookNodeId,
+          selectable: true
+        });
+      });
+    });
+    return nodes;
+  }
+
+  function normalizeZsxqColumnTocNodes(data) {
+    const nodes = [];
+    (data?.groups || []).forEach((group, groupIndex) => {
+      const groupIndexValue = group.groupIndex ?? groupIndex;
+      const groupId = `zsxq-column-group:${groupIndexValue}`;
+      nodes.push({
+        nodeId: groupId,
+        exportId: '',
+        title: group.groupTitle || `Group ${groupIndex + 1}`,
+        parentNodeId: '',
+        selectable: false
+      });
+      (group.topics || []).forEach((topic, topicIndex) => {
+        const key = String(topic.key || `toc:${groupIndexValue}:${topic.topicIndex ?? topicIndex}`);
+        nodes.push({
+          nodeId: `zsxq-column:${key}`,
+          exportId: key,
+          title: topic.title || `Untitled article ${topicIndex + 1}`,
+          parentNodeId: groupId,
+          selectable: true
+        });
+      });
+    });
+    return nodes;
+  }
+
+  function normalizeProviderTocNodes(provider, data) {
+    const adapter = provider?.toc?.adapter;
+    if (adapter === 'yinxiang-notebooks') return normalizeYinxiangTocNodes(data);
+    if (adapter === 'zsxq-column-groups') return normalizeZsxqColumnTocNodes(data);
+    return normalizeStandardTocNodes(provider, data);
+  }
+
   function tocNodeMaps(nodes) {
     const byId = new Map(nodes.map((node) => [node.nodeId, node]));
     const children = new Map();
@@ -61,11 +129,21 @@
   }
 
   function selectionArgs(provider, exportIds) {
-    const selectionArg = provider?.toc?.selectionArg || '--doc-id';
-    return (exportIds || [])
+    const toc = provider?.toc || {};
+    const selectionArg = toc.selectionArg || '--doc-id';
+    const prefixArgs = Array.isArray(toc.selectionPrefixArgs) ? toc.selectionPrefixArgs.map(String) : [];
+    return prefixArgs.concat((exportIds || [])
       .filter((exportId) => exportId !== null && exportId !== undefined && String(exportId).trim())
-      .flatMap((exportId) => [selectionArg, String(exportId)]);
+      .flatMap((exportId) => [selectionArg, String(exportId)]));
   }
 
-  return { normalizeStandardTocNodes, tocNodeMaps, selectionArgs, valueAtPath };
+  return {
+    normalizeProviderTocNodes,
+    normalizeStandardTocNodes,
+    normalizeYinxiangTocNodes,
+    normalizeZsxqColumnTocNodes,
+    tocNodeMaps,
+    selectionArgs,
+    valueAtPath
+  };
 });


### PR DESCRIPTION
Partially addresses #33.

This is the second-batch, manifest-led TOC contract follow-up rebased on current `main` after #42. It deliberately excludes the first-batch Yuque/Aliyun/Feishu work and does not close #33.

## Scope

- Correct Plugin v1 TOC manifests for **ima**, **OneNote**, and **Youdao** to use the real standard `nodes` schema: `nodeId`, `exportId`, `parentNodeId`, `selectable`, and `--doc-id`.
- Make **Yinxiang** (`notebooks`) and **ZSXQ column** (`groups`) adapters explicit rather than relying on legacy UI fallbacks.
- Move the ZSXQ column `--toc-mode toc` requirement into the provider TOC contract (`selectionPrefixArgs`), so the generic selector produces the full CLI sequence.
- Add backend selection-contract tests and renderer TOC contract tests.

## Desensitized scan-contract samples

```json
{"nodes":[
  {"nodeId":"folder:demo","exportId":"","parentNodeId":"","selectable":false},
  {"nodeId":"doc:demo","exportId":"doc-id","parentNodeId":"folder:demo","selectable":true}
]}
```

```json
{"notebooks":[{"guid":"notebook-guid","stack":"Stack","notes":[{"guid":"note-guid","title":"Selected note"}]}]}
```

```json
{"groups":[{"groupIndex":3,"groupTitle":"Section","topics":[{"key":"toc:3:0","title":"Article"}]}]}
```

Expected ZSXQ selection CLI arguments: `--toc-mode toc --toc-key toc:3:0`.

## Automated verification

Passed on this branch:

```text
node --test tests_js/toc_tree.test.js   # 10/10
python -m unittest                      # 125 tests
python scripts/quality_check.py
python scripts/validate_providers.py
git diff --check
```

The tests cover tree parent/child relationships, default selectability, emitted export IDs, final selection arguments, and the corresponding backend filter for each platform in this batch. They also cover the restored Youdao `RemoteNode.created_time` property.

## Still requiring manual authenticated acceptance

- ima: real configured knowledge-base credentials/data.
- OneNote: OAuth account and nested notebook/section/page selection.
- Youdao: browser login; selected child note count, stop/continue, and retry-failed.
- Yinxiang: authenticated ENEX/notebook scan with nested stacks.
- ZSXQ column: authenticated column with groups; selected topic export count and retry behavior.

No production credentials or user documents are included.
