### PR TITLE
fix: preserve Youdao stop and resume task state

### DIFF
--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -40,6 +40,8 @@ from wandao_core.browser import (
     CDPClient,
     DEFAULT_PORT,
     ExportError,
+    ExportStopped,
+    check_stopped,
     chrome_debug_available,
     default_data_dir,
     default_state_path,
@@ -1050,8 +1052,45 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     output = Path(args.output).expanduser().resolve()
     output.mkdir(parents=True, exist_ok=True)
     checkpoint = open_checkpoint_from_args(args, "youdao", "export")
-    client = YoudaoClient(auth_path_from_args(args), args)
-    nodes, root_id = build_remote_tree(client)
+    client: YoudaoClient | None = None
+    try:
+        client = YoudaoClient(auth_path_from_args(args), args)
+        nodes, root_id = build_remote_tree(client)
+    except ExportStopped as exc:
+        report = {
+            "provider": "youdao",
+            "rootId": "",
+            "output": str(output),
+            "totalDocs": 0,
+            "exportedDocs": 0,
+            "skippedDocs": 0,
+            "failureCount": 0,
+            "failures": [],
+            "stopped": True,
+            "requestCount": client.request_count if client else 0,
+            "imageSuccess": 0,
+            "imageFailureCount": 0,
+            "attachmentSuccess": 0,
+            "attachmentFailureCount": 0,
+        }
+        if checkpoint:
+            checkpoint.start_task(
+                {
+                    "source": YOUDAO_WEB_URL,
+                    "outputDir": str(output),
+                    "stage": "scanning",
+                    "resume": bool(getattr(args, "resume", False)),
+                    "retryFailed": bool(getattr(args, "retry_failed", False)),
+                }
+            )
+            checkpoint.fail_task("stopped", status="stopped")
+            report["checkpoint"] = checkpoint.stats()
+            checkpoint.close()
+        report_path = output / "00-导出报告.json"
+        report = finalize_report(report, provider="youdao", mode="export", report_file=report_path, output=output)
+        report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        emit("有道云笔记导出已停止", event="task.stopped", level="warn", reportFile=str(report_path))
+        return report
     selected = set(args.selected_doc_ids or [])
     counters: dict[str, int] = {}
     local_paths = {
@@ -1086,6 +1125,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     exported = 0
     skipped = 0
     failures: list[dict[str, Any]] = []
+    stopped = False
     rows: list[dict[str, Any]] = []
     stats = {
         "imageSuccess": 0,
@@ -1104,6 +1144,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         md_or_file_path = local_paths[node.id]
         item_key = f"youdao:node:{node.id}"
         try:
+            check_stopped(args)
             if checkpoint and getattr(args, "resume", False) and not args.update_existing and checkpoint.item_status(item_key) == "completed":
                 row_file = md_or_file_path.with_suffix(".md") if node.is_note_like else md_or_file_path
                 skipped += 1
@@ -1141,12 +1182,14 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 doc={"id": node.id, "title": node.title, "index": index, "path": "/".join(node.path_parts)},
             )
             downloaded = client.download_file(node.id)
+            check_stopped(args)
             markdown, is_markdown = convert_note_to_markdown(node, downloaded)
             resource_failures_before = stats["imageFailureCount"] + stats["attachmentFailureCount"]
             if is_markdown:
                 md_path = md_or_file_path.with_suffix(".md")
                 md_path.parent.mkdir(parents=True, exist_ok=True)
                 markdown = localize_links(client, markdown, md_path, args, stats)
+                check_stopped(args)
                 md_path.write_text(clean_markdown(markdown, node.title), encoding="utf-8")
                 apply_remote_file_time(md_path, node)
                 row_file = md_path
@@ -1179,6 +1222,12 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 event="document.export.completed",
                 doc={"id": node.id, "title": node.title, "index": index, "path": str(row_file)},
             )
+        except ExportStopped:
+            stopped = True
+            if checkpoint:
+                checkpoint.fail_item(item_key, "stopped")
+            emit(f"有道云笔记导出已停止：{node.title}", event="task.stopped", level="warn")
+            break
         except Exception as exc:
             if checkpoint:
                 checkpoint.fail_item(item_key, str(exc))
@@ -1203,6 +1252,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         "skippedDocs": skipped,
         "failureCount": len(failures),
         "failures": failures,
+        "stopped": stopped,
         "requestCount": client.request_count,
         **stats,
     }
@@ -1213,7 +1263,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     if checkpoint:
         resource_failure_count = stats["imageFailureCount"] + stats["attachmentFailureCount"]
-        if failures or resource_failure_count:
+        if stopped:
+            checkpoint.fail_task("stopped", status="stopped")
+        elif failures or resource_failure_count:
             checkpoint.fail_task(
                 f"{len(failures)} 个文档失败，{resource_failure_count} 个资源失败",
                 status="failed",
@@ -1222,9 +1274,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
             checkpoint.complete_task(report)
         checkpoint.close()
     emit(
-        "有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项",
-        event="task.completed",
-        level="success" if not failures and not (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "warn",
+        "有道云笔记导出已停止" if stopped else ("有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项"),
+        event="task.stopped" if stopped else "task.completed",
+        level="warn" if stopped or failures or (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "success",
         reportFile=str(report_path),
         stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures), **stats},
     )
@@ -1357,7 +1409,7 @@ def main(argv: list[str]) -> int:
         print(f"Export failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(result, ensure_ascii=False, indent=2))
-    return 0
+    return 130 if result.get("stopped") else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_youdao_stop.py
+++ b/tests/test_youdao_stop.py
@@ -1,0 +1,99 @@
+import argparse
+import contextlib
+import io
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from plugins.youdao.backend import export_youdao
+
+
+def export_args(root: Path, *, resume: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        output=root / 'output', auth_file='', selected_doc_ids=[], checkpoint_file=str(root / 'checkpoint.sqlite'),
+        checkpoint_task_id='stop-contract', reset_checkpoint=False, resume=resume, retry_failed=False,
+        update_existing=False, incremental=False, progress_every=1, download_timeout=1, keep_remote_images=True,
+    )
+
+
+class FakeYoudaoClient:
+    request_count = 0
+    downloaded_ids: list[str] = []
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def download_file(self, node_id: str) -> export_youdao.DownloadedContent:
+        self.request_count += 1
+        self.downloaded_ids.append(node_id)
+        return export_youdao.DownloadedContent(b'# note\n', 'text/markdown', 'https://example.test/note')
+
+
+class YoudaoStopContractTests(unittest.TestCase):
+    def test_cli_main_returns_130_when_export_reports_controlled_stop(self) -> None:
+        args = argparse.Namespace(gui=False, login=False, scan_toc=False, output=Path('output'))
+        with mock.patch.object(export_youdao, 'parse_args', return_value=args), mock.patch.object(export_youdao, 'export_youdao', return_value={'stopped': True}), contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(export_youdao.main(['--output', 'output']), 130)
+
+    def test_cli_main_treats_stop_during_remote_tree_build_as_controlled_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            args = export_args(Path(tmp))
+            args.gui = False
+            args.login = False
+            args.scan_toc = False
+            stdout = io.StringIO()
+            with mock.patch.object(export_youdao, 'parse_args', return_value=args), mock.patch.object(export_youdao, 'YoudaoClient', FakeYoudaoClient), mock.patch.object(export_youdao, 'build_remote_tree', side_effect=export_youdao.ExportStopped('用户已停止当前任务')), contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(export_youdao.main(['--output', str(args.output)]), 130)
+
+            self.assertIn('"stopped": true', stdout.getvalue())
+            conn = sqlite3.connect(Path(args.checkpoint_file))
+            try:
+                task = conn.execute('SELECT status FROM tasks WHERE task_id = ?', ('stop-contract',)).fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(task[0], 'stopped')
+
+    def test_stop_marks_checkpoint_and_resume_skips_completed_document(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stop_file = root / 'stop-requested'
+            first = export_youdao.RemoteNode('first', 'first.md', False)
+            second = export_youdao.RemoteNode('second', 'second.md', False)
+            fake_client = FakeYoudaoClient
+            fake_client.downloaded_ids = []
+
+            def emit_with_stop(_message: str, **fields: object) -> None:
+                if fields.get('event') == 'document.export.completed':
+                    stop_file.write_text('stop', encoding='utf-8')
+
+            with mock.patch.object(export_youdao, 'YoudaoClient', fake_client), mock.patch.object(export_youdao, 'build_remote_tree', return_value=([first, second], 'root')), mock.patch.object(export_youdao, 'emit', side_effect=emit_with_stop), mock.patch.dict(os.environ, {'WANDAO_STOP_FILE': str(stop_file)}, clear=False):
+                report = export_youdao.export_youdao(export_args(root))
+
+            self.assertTrue(report['stopped'])
+            self.assertEqual(report['exportedDocs'], 1)
+            self.assertEqual(fake_client.downloaded_ids, ['first'])
+            conn = sqlite3.connect(root / 'checkpoint.sqlite')
+            try:
+                task = conn.execute('SELECT status FROM tasks WHERE task_id = ?', ('stop-contract',)).fetchone()
+                item_rows = conn.execute('SELECT item_key, status FROM items WHERE task_id = ? ORDER BY item_key', ('stop-contract',)).fetchall()
+            finally:
+                conn.close()
+            self.assertEqual(task[0], 'stopped')
+            self.assertEqual(item_rows, [('youdao:node:first', 'completed'), ('youdao:node:second', 'failed')])
+
+            stop_file.unlink()
+            fake_client.downloaded_ids = []
+            with mock.patch.object(export_youdao, 'YoudaoClient', fake_client), mock.patch.object(export_youdao, 'build_remote_tree', return_value=([first, second], 'root')), mock.patch.dict(os.environ, {'WANDAO_STOP_FILE': str(stop_file)}, clear=False):
+                resumed = export_youdao.export_youdao(export_args(root, resume=True))
+
+            self.assertFalse(resumed['stopped'])
+            self.assertEqual(resumed['exportedDocs'], 1)
+            self.assertEqual(resumed['skippedDocs'], 1)
+            self.assertEqual(fake_client.downloaded_ids, ['second'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #33 and #39. This Draft PR is the focused, rebased replacement for the unrebased scope of #40; it does not close any issue.

## Scope

This PR is intentionally limited to the Youdao backend and its behavior tests:

- Treat cooperative stop signals as a controlled `stopped` result rather than an export failure.
- Check for stop requests before each document, after content download, and after resource localization.
- Record the active document as retryable when stopped; preserve completed items for resume.
- When a stop is raised while building the remote tree, write a desensitized `stopped` report, mark an established checkpoint task as `stopped`, close the SQLite checkpoint connection, and return CLI exit code `130`.

## Stop/resume contract sample

```json
{
  "task": {"id": "stop-contract", "status": "stopped"},
  "items": [
    {"key": "youdao:node:first", "status": "completed"},
    {"key": "youdao:node:second", "status": "failed", "lastError": "stopped"}
  ],
  "result": {"stopped": true, "exitCode": 130}
}
```

On `--resume`, completed items are skipped and the pending/failed item is retried. This is a synthetic/desensitized contract fixture; no user data, cookies, or tokens are included.

## Automated verification

Passed on this branch:

```text
python -m unittest tests.test_youdao_stop  # 3/3
node --test tests_js/toc_tree.test.js      # 7/7
python -m unittest                         # 125 tests
python scripts/quality_check.py
python scripts/validate_providers.py
git diff --check
```

The new tests cover both normal loop-stage stop/resume and a stop raised by `build_remote_tree()` before document enumeration. The latter asserts `stopped: true`, checkpoint task status `stopped`, closed SQLite access, and CLI exit `130`.

## Still requiring manual authenticated acceptance

Use a real Youdao account with several notes:

1. Start an export and stop during/after a document download.
2. Confirm the UI treats exit 130 as stopped rather than as a resource failure.
3. Continue and confirm completed notes are not redownloaded.
4. Retry failed items and confirm the preserved selection is used.
5. Stop while the remote directory is loading and confirm the next run remains usable.

This PR does not modify shared Electron/runtime code, first-batch providers, or release artifacts.
