### PR TITLE
fix: merge second-batch TOC and Youdao stop stability fixes

### DIFF
--- a/plugins/ima/providers/ima-export/provider.json
+++ b/plugins/ima/providers/ima-export/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": false, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "name", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "client_id", "label": "ima Client ID", "type": "text", "arg": "--client-id", "actions": ["saveConfig", "list", "scan", "export"] },
     { "name": "api_key", "label": "ima API Key", "type": "password", "arg": "--api-key", "actions": ["saveConfig", "list", "scan", "export"] },

--- a/plugins/onenote/providers/onenote/provider.json
+++ b/plugins/onenote/providers/onenote/provider.json
@@ -16,7 +16,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": false, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "title", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },

--- a/plugins/yinxiang/backend/export_yinxiang.py
+++ b/plugins/yinxiang/backend/export_yinxiang.py
@@ -502,6 +502,12 @@ def note_markdown(note_el: ET.Element, md_path: Path) -> tuple[str, str]:
     return "\n".join(lines), guid
 
 
+def select_enex_notes(notes: list[ET.Element], selected_doc_ids: set[str]) -> list[ET.Element]:
+    if not selected_doc_ids:
+        return notes
+    return [note_el for note_el in notes if (note_el.findtext("guid") or "") in selected_doc_ids]
+
+
 def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
     output = args.output
     output.mkdir(parents=True, exist_ok=True)
@@ -568,13 +574,14 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
                     checkpoint.skip_item(item_key, "empty-enex")
                 skipped += 1
                 continue
-            note_el = notes[0]
-            guid = note_el.findtext("guid") or ""
-            if selected and guid not in selected:
+            selected_notes = select_enex_notes(notes, selected)
+            if not selected_notes:
                 if checkpoint:
                     checkpoint.skip_item(item_key, "not-selected")
                 skipped += 1
                 continue
+            note_el = selected_notes[0]
+            guid = note_el.findtext("guid") or ""
             if args.incremental and md_path.exists():
                 if checkpoint:
                     checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"guid": guid, "skippedExisting": True})

--- a/plugins/yinxiang/providers/yinxiang/provider.json
+++ b/plugins/yinxiang/providers/yinxiang/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "guid", "exportIdKey": "guid", "titleKey": "title", "parentIdKey": "parentGuid", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "adapter": "yinxiang-notebooks", "itemsPath": "notebooks", "selectionArg": "--doc-id" },
   "fields": [
     { "name": "username", "label": "印象笔记账号", "type": "text", "arg": "--username", "actions": ["initAuth"] },
     { "name": "database", "label": "本地同步库", "type": "file", "arg": "--database", "advanced": true, "actions": ["scan", "export"] },

--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -119,6 +119,11 @@ class RemoteNode:
             return None
 
 
+def select_export_documents(nodes: list[RemoteNode], selected_doc_ids: list[str] | set[str] | None) -> list[RemoteNode]:
+    selected = set(selected_doc_ids or [])
+    return [node for node in nodes if not node.is_dir and (not selected or node.id in selected)]
+
+
 @dataclass
 class DownloadedContent:
     content: bytes
@@ -1052,14 +1057,13 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     checkpoint = open_checkpoint_from_args(args, "youdao", "export")
     client = YoudaoClient(auth_path_from_args(args), args)
     nodes, root_id = build_remote_tree(client)
-    selected = set(args.selected_doc_ids or [])
     counters: dict[str, int] = {}
     local_paths = {
         node.id: path_for_node(output, node, counters, create_dirs=False)
         for node in nodes
         if not node.is_dir
     }
-    docs = [node for node in nodes if not node.is_dir and (not selected or node.id in selected)]
+    docs = select_export_documents(nodes, args.selected_doc_ids)
     if checkpoint:
         checkpoint.start_task(
             {

--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -40,6 +40,8 @@ from wandao_core.browser import (
     CDPClient,
     DEFAULT_PORT,
     ExportError,
+    ExportStopped,
+    check_stopped,
     chrome_debug_available,
     default_data_dir,
     default_state_path,
@@ -1055,8 +1057,45 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     output = Path(args.output).expanduser().resolve()
     output.mkdir(parents=True, exist_ok=True)
     checkpoint = open_checkpoint_from_args(args, "youdao", "export")
-    client = YoudaoClient(auth_path_from_args(args), args)
-    nodes, root_id = build_remote_tree(client)
+    client: YoudaoClient | None = None
+    try:
+        client = YoudaoClient(auth_path_from_args(args), args)
+        nodes, root_id = build_remote_tree(client)
+    except ExportStopped as exc:
+        report = {
+            "provider": "youdao",
+            "rootId": "",
+            "output": str(output),
+            "totalDocs": 0,
+            "exportedDocs": 0,
+            "skippedDocs": 0,
+            "failureCount": 0,
+            "failures": [],
+            "stopped": True,
+            "requestCount": client.request_count if client else 0,
+            "imageSuccess": 0,
+            "imageFailureCount": 0,
+            "attachmentSuccess": 0,
+            "attachmentFailureCount": 0,
+        }
+        if checkpoint:
+            checkpoint.start_task(
+                {
+                    "source": YOUDAO_WEB_URL,
+                    "outputDir": str(output),
+                    "stage": "scanning",
+                    "resume": bool(getattr(args, "resume", False)),
+                    "retryFailed": bool(getattr(args, "retry_failed", False)),
+                }
+            )
+            checkpoint.fail_task("stopped", status="stopped")
+            report["checkpoint"] = checkpoint.stats()
+            checkpoint.close()
+        report_path = output / "00-导出报告.json"
+        report = finalize_report(report, provider="youdao", mode="export", report_file=report_path, output=output)
+        report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        emit("有道云笔记导出已停止", event="task.stopped", level="warn", reportFile=str(report_path))
+        return report
     counters: dict[str, int] = {}
     local_paths = {
         node.id: path_for_node(output, node, counters, create_dirs=False)
@@ -1090,6 +1129,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     exported = 0
     skipped = 0
     failures: list[dict[str, Any]] = []
+    stopped = False
     rows: list[dict[str, Any]] = []
     stats = {
         "imageSuccess": 0,
@@ -1108,6 +1148,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         md_or_file_path = local_paths[node.id]
         item_key = f"youdao:node:{node.id}"
         try:
+            check_stopped(args)
             if checkpoint and getattr(args, "resume", False) and not args.update_existing and checkpoint.item_status(item_key) == "completed":
                 row_file = md_or_file_path.with_suffix(".md") if node.is_note_like else md_or_file_path
                 skipped += 1
@@ -1145,12 +1186,14 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 doc={"id": node.id, "title": node.title, "index": index, "path": "/".join(node.path_parts)},
             )
             downloaded = client.download_file(node.id)
+            check_stopped(args)
             markdown, is_markdown = convert_note_to_markdown(node, downloaded)
             resource_failures_before = stats["imageFailureCount"] + stats["attachmentFailureCount"]
             if is_markdown:
                 md_path = md_or_file_path.with_suffix(".md")
                 md_path.parent.mkdir(parents=True, exist_ok=True)
                 markdown = localize_links(client, markdown, md_path, args, stats)
+                check_stopped(args)
                 md_path.write_text(clean_markdown(markdown, node.title), encoding="utf-8")
                 apply_remote_file_time(md_path, node)
                 row_file = md_path
@@ -1183,6 +1226,12 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
                 event="document.export.completed",
                 doc={"id": node.id, "title": node.title, "index": index, "path": str(row_file)},
             )
+        except ExportStopped:
+            stopped = True
+            if checkpoint:
+                checkpoint.fail_item(item_key, "stopped")
+            emit(f"有道云笔记导出已停止：{node.title}", event="task.stopped", level="warn")
+            break
         except Exception as exc:
             if checkpoint:
                 checkpoint.fail_item(item_key, str(exc))
@@ -1207,6 +1256,7 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
         "skippedDocs": skipped,
         "failureCount": len(failures),
         "failures": failures,
+        "stopped": stopped,
         "requestCount": client.request_count,
         **stats,
     }
@@ -1217,7 +1267,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
     report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     if checkpoint:
         resource_failure_count = stats["imageFailureCount"] + stats["attachmentFailureCount"]
-        if failures or resource_failure_count:
+        if stopped:
+            checkpoint.fail_task("stopped", status="stopped")
+        elif failures or resource_failure_count:
             checkpoint.fail_task(
                 f"{len(failures)} 个文档失败，{resource_failure_count} 个资源失败",
                 status="failed",
@@ -1226,9 +1278,9 @@ def export_youdao(args: argparse.Namespace) -> dict[str, Any]:
             checkpoint.complete_task(report)
         checkpoint.close()
     emit(
-        "有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项",
-        event="task.completed",
-        level="success" if not failures and not (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "warn",
+        "有道云笔记导出已停止" if stopped else ("有道云笔记导出完成" if not failures else f"有道云笔记导出完成，但有 {len(failures)} 个失败项"),
+        event="task.stopped" if stopped else "task.completed",
+        level="warn" if stopped or failures or (stats["imageFailureCount"] + stats["attachmentFailureCount"]) else "success",
         reportFile=str(report_path),
         stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures), **stats},
     )
@@ -1361,7 +1413,7 @@ def main(argv: list[str]) -> int:
         print(f"Export failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(result, ensure_ascii=False, indent=2))
-    return 0
+    return 130 if result.get("stopped") else 0
 
 
 if __name__ == "__main__":

--- a/plugins/youdao/providers/youdao/provider.json
+++ b/plugins/youdao/providers/youdao/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": false },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "id", "exportIdKey": "id", "titleKey": "title", "parentIdKey": "parentId", "selectionArg": "--doc-id", "selectableWhenExportId": true },
+  "toc": { "itemsPath": "nodes", "idKey": "nodeId", "exportIdKey": "exportId", "titleKey": "title", "parentIdKey": "parentNodeId", "selectableKey": "selectable", "selectionArg": "--doc-id", "selectableWhenExportId": false },
   "fields": [
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },
     { "name": "incremental", "label": "增量导出", "type": "checkbox", "arg": "--incremental", "default": true, "advanced": true, "actions": ["export"] },

--- a/plugins/zsxq/providers/zsxq-column/provider.json
+++ b/plugins/zsxq/providers/zsxq-column/provider.json
@@ -15,7 +15,7 @@
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": true },
   "retryFailures": { "arg": "--retry-failed", "label": "只重试失败项" },
-  "toc": { "itemsPath": "ordered", "idKey": "key", "exportIdKey": "key", "titleKey": "title", "parentIdKey": "parentKey", "selectionArg": "--toc-key", "selectableWhenExportId": true },
+  "toc": { "adapter": "zsxq-column-groups", "itemsPath": "groups", "selectionPrefixArgs": ["--toc-mode", "toc"], "selectionArg": "--toc-key" },
   "fields": [
     { "name": "entry_url", "label": "知识星球专栏 URL", "type": "text", "arg": "--entry-url", "required": true, "actions": ["login", "scan", "export"] },
     { "name": "output", "label": "输出目录", "type": "directory", "arg": "--output", "required": true, "actions": ["export"] },

--- a/tests/test_second_batch_toc_contract.py
+++ b/tests/test_second_batch_toc_contract.py
@@ -1,0 +1,47 @@
+import argparse
+import unittest
+import xml.etree.ElementTree as ET
+
+from plugins.ima.backend.ima_knowledge import KnowledgeEntry, selected_entries
+from plugins.onenote.backend.export_onenote import TocNode, selected_pages
+from plugins.youdao.backend.export_youdao import RemoteNode, select_export_documents
+from plugins.yinxiang.backend.export_yinxiang import select_enex_notes
+from plugins.zsxq.backend.export_zsxq import select_toc_items
+
+
+class SecondBatchTocContractTests(unittest.TestCase):
+    def test_ima_filters_the_export_id_emitted_by_the_nodes_toc(self) -> None:
+        folder = KnowledgeEntry('kb', 'KB', 'folder', 'Folder', '', [], True)
+        doc = KnowledgeEntry('kb', 'KB', 'doc', 'Document', 'folder', [], False)
+
+        self.assertEqual([entry.export_id for entry in selected_entries([folder, doc], [doc.export_id])], [doc.export_id])
+
+    def test_onenote_filters_the_page_export_id_emitted_by_the_nodes_toc(self) -> None:
+        folder = TocNode('', 'notebook', 'notebook', 'Notebook', '', False, 0, [])
+        page = TocNode('page-id', 'page', 'page', 'Page', 'notebook', True, 1, [])
+        args = argparse.Namespace(selected_doc_ids=['page-id'])
+
+        self.assertEqual([node.id for node in selected_pages(args, [folder, page])], ['page-id'])
+
+    def test_youdao_filters_only_selected_non_folder_export_ids(self) -> None:
+        folder = RemoteNode('folder-id', 'Folder', True)
+        doc = RemoteNode('doc-id', 'Note.note', False, parent_id='folder-id', raw={'createTime': '123'})
+
+        self.assertEqual([node.id for node in select_export_documents([folder, doc], ['doc-id'])], ['doc-id'])
+        self.assertEqual(doc.created_time, 123.0)
+
+    def test_yinxiang_filters_enex_notes_by_the_guid_emitted_by_the_toc(self) -> None:
+        first = ET.fromstring('<note><guid>first-guid</guid></note>')
+        selected = ET.fromstring('<note><guid>selected-guid</guid></note>')
+
+        self.assertEqual(select_enex_notes([first, selected], {'selected-guid'}), [selected])
+
+    def test_zsxq_column_filters_the_toc_key_emitted_by_the_group_adapter(self) -> None:
+        toc = {'groups': [{'groupTitle': 'Section', 'topics': [{'key': 'toc:3:0', 'title': 'Article'}, {'key': 'toc:3:1', 'title': 'Other'}]}]}
+        args = argparse.Namespace(selected_toc_keys=['toc:3:0'], toc_group_pattern=None, toc_title_pattern=None, link_pattern=None, limit=0)
+
+        self.assertEqual([item['key'] for item in select_toc_items(toc, args)], ['toc:3:0'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_youdao_stop.py
+++ b/tests/test_youdao_stop.py
@@ -1,0 +1,99 @@
+import argparse
+import contextlib
+import io
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from plugins.youdao.backend import export_youdao
+
+
+def export_args(root: Path, *, resume: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        output=root / 'output', auth_file='', selected_doc_ids=[], checkpoint_file=str(root / 'checkpoint.sqlite'),
+        checkpoint_task_id='stop-contract', reset_checkpoint=False, resume=resume, retry_failed=False,
+        update_existing=False, incremental=False, progress_every=1, download_timeout=1, keep_remote_images=True,
+    )
+
+
+class FakeYoudaoClient:
+    request_count = 0
+    downloaded_ids: list[str] = []
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def download_file(self, node_id: str) -> export_youdao.DownloadedContent:
+        self.request_count += 1
+        self.downloaded_ids.append(node_id)
+        return export_youdao.DownloadedContent(b'# note\n', 'text/markdown', 'https://example.test/note')
+
+
+class YoudaoStopContractTests(unittest.TestCase):
+    def test_cli_main_returns_130_when_export_reports_controlled_stop(self) -> None:
+        args = argparse.Namespace(gui=False, login=False, scan_toc=False, output=Path('output'))
+        with mock.patch.object(export_youdao, 'parse_args', return_value=args), mock.patch.object(export_youdao, 'export_youdao', return_value={'stopped': True}), contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(export_youdao.main(['--output', 'output']), 130)
+
+    def test_cli_main_treats_stop_during_remote_tree_build_as_controlled_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            args = export_args(Path(tmp))
+            args.gui = False
+            args.login = False
+            args.scan_toc = False
+            stdout = io.StringIO()
+            with mock.patch.object(export_youdao, 'parse_args', return_value=args), mock.patch.object(export_youdao, 'YoudaoClient', FakeYoudaoClient), mock.patch.object(export_youdao, 'build_remote_tree', side_effect=export_youdao.ExportStopped('用户已停止当前任务')), contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(export_youdao.main(['--output', str(args.output)]), 130)
+
+            self.assertIn('"stopped": true', stdout.getvalue())
+            conn = sqlite3.connect(Path(args.checkpoint_file))
+            try:
+                task = conn.execute('SELECT status FROM tasks WHERE task_id = ?', ('stop-contract',)).fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(task[0], 'stopped')
+
+    def test_stop_marks_checkpoint_and_resume_skips_completed_document(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stop_file = root / 'stop-requested'
+            first = export_youdao.RemoteNode('first', 'first.md', False)
+            second = export_youdao.RemoteNode('second', 'second.md', False)
+            fake_client = FakeYoudaoClient
+            fake_client.downloaded_ids = []
+
+            def emit_with_stop(_message: str, **fields: object) -> None:
+                if fields.get('event') == 'document.export.completed':
+                    stop_file.write_text('stop', encoding='utf-8')
+
+            with mock.patch.object(export_youdao, 'YoudaoClient', fake_client), mock.patch.object(export_youdao, 'build_remote_tree', return_value=([first, second], 'root')), mock.patch.object(export_youdao, 'emit', side_effect=emit_with_stop), mock.patch.dict(os.environ, {'WANDAO_STOP_FILE': str(stop_file)}, clear=False):
+                report = export_youdao.export_youdao(export_args(root))
+
+            self.assertTrue(report['stopped'])
+            self.assertEqual(report['exportedDocs'], 1)
+            self.assertEqual(fake_client.downloaded_ids, ['first'])
+            conn = sqlite3.connect(root / 'checkpoint.sqlite')
+            try:
+                task = conn.execute('SELECT status FROM tasks WHERE task_id = ?', ('stop-contract',)).fetchone()
+                item_rows = conn.execute('SELECT item_key, status FROM items WHERE task_id = ? ORDER BY item_key', ('stop-contract',)).fetchall()
+            finally:
+                conn.close()
+            self.assertEqual(task[0], 'stopped')
+            self.assertEqual(item_rows, [('youdao:node:first', 'completed'), ('youdao:node:second', 'failed')])
+
+            stop_file.unlink()
+            fake_client.downloaded_ids = []
+            with mock.patch.object(export_youdao, 'YoudaoClient', fake_client), mock.patch.object(export_youdao, 'build_remote_tree', return_value=([first, second], 'root')), mock.patch.dict(os.environ, {'WANDAO_STOP_FILE': str(stop_file)}, clear=False):
+                resumed = export_youdao.export_youdao(export_args(root, resume=True))
+
+            self.assertFalse(resumed['stopped'])
+            self.assertEqual(resumed['exportedDocs'], 1)
+            self.assertEqual(resumed['skippedDocs'], 1)
+            self.assertEqual(fake_client.downloaded_ids, ['second'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests_js/toc_tree.test.js
+++ b/tests_js/toc_tree.test.js
@@ -1,6 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { normalizeStandardTocNodes, tocNodeMaps, selectionArgs } = require('../wandao_electron/renderer/toc_tree.js');
+const {
+  normalizeProviderTocNodes,
+  normalizeStandardTocNodes,
+  tocNodeMaps,
+  selectionArgs
+} = require('../wandao_electron/renderer/toc_tree.js');
 
 test('restores Aliyun parent_id hierarchy when a legacy manifest still points at ordered', () => {
   const provider = { id: 'aliyun', toc: { itemsPath: 'ordered', idKey: 'id', exportIdKey: 'id', titleKey: 'title', parentIdKey: 'parentId' } };
@@ -88,4 +93,89 @@ test('maps Feishu ordered nodes with explicit document selectability', () => {
   assert.deepEqual(tree.children.get('feishu-export:folder').map((node) => node.nodeId), ['feishu-export:non-url', 'feishu-export:doc']);
   assert.deepEqual(nodes.filter((node) => node.selectable).map((node) => node.exportId), ['doc']);
   assert.deepEqual(selectionArgs(provider, ['doc']), ['--doc-id', 'doc']);
+});
+
+test('maps the standard Plugin v1 nodes contracts for ima, OneNote, and Youdao', () => {
+  const fixtures = [
+    {
+      provider: require('../plugins/ima/providers/ima-export/provider.json'),
+      root: { nodeId: 'ima-kb:demo', exportId: '', title: 'Knowledge base', parentNodeId: '', selectable: false },
+      doc: { nodeId: 'ima-media:demo:doc', exportId: 'ima-export-id', title: 'Document', parentNodeId: 'ima-kb:demo', selectable: true }
+    },
+    {
+      provider: require('../plugins/onenote/providers/onenote/provider.json'),
+      root: { nodeId: 'onenote-notebook:demo', exportId: '', title: 'Notebook', parentNodeId: '', selectable: false },
+      doc: { nodeId: 'onenote-page:demo', exportId: 'onenote-page-id', title: 'Page', parentNodeId: 'onenote-notebook:demo', selectable: true }
+    },
+    {
+      provider: require('../plugins/youdao/providers/youdao/provider.json'),
+      root: { nodeId: 'youdao-folder:demo', exportId: '', title: 'Folder', parentNodeId: '', selectable: false, type: 'folder' },
+      doc: { nodeId: 'youdao-doc:demo', exportId: 'youdao-doc-id', title: 'Note', parentNodeId: 'youdao-folder:demo', selectable: true, type: 'document' }
+    }
+  ];
+
+  fixtures.forEach(({ provider, root, doc }) => {
+    assert.equal(provider.toc.itemsPath, 'nodes');
+    assert.equal(provider.toc.idKey, 'nodeId');
+    assert.equal(provider.toc.exportIdKey, 'exportId');
+    assert.equal(provider.toc.parentIdKey, 'parentNodeId');
+    assert.equal(provider.toc.selectableKey, 'selectable');
+    assert.equal(provider.toc.selectionArg, '--doc-id');
+
+    const nodes = normalizeProviderTocNodes(provider, { nodes: [root, doc] });
+    const tree = tocNodeMaps(nodes);
+    assert.deepEqual(tree.children.get('').map((node) => node.nodeId), [root.nodeId]);
+    assert.deepEqual(tree.children.get(root.nodeId).map((node) => node.nodeId), [doc.nodeId]);
+    assert.equal(nodes[0].selectable, false);
+    assert.equal(nodes[1].selectable, true);
+    assert.equal(nodes[1].exportId, doc.exportId);
+    assert.deepEqual(selectionArgs(provider, [nodes[1].exportId]), ['--doc-id', doc.exportId]);
+  });
+});
+
+test('maps Yinxiang notebook scan results through its explicit adapter', () => {
+  const provider = require('../plugins/yinxiang/providers/yinxiang/provider.json');
+  assert.equal(provider.toc.adapter, 'yinxiang-notebooks');
+  assert.equal(provider.toc.itemsPath, 'notebooks');
+  assert.equal(provider.toc.selectionArg, '--doc-id');
+
+  const nodes = normalizeProviderTocNodes(provider, { notebooks: [
+    {
+      guid: 'notebook-guid',
+      name: 'Notebook',
+      stack: 'Stack',
+      notes: [{ guid: 'note-guid', title: 'Selected note' }]
+    }
+  ] });
+  const tree = tocNodeMaps(nodes);
+
+  assert.deepEqual(tree.children.get('').map((node) => node.nodeId), ['yinxiang-stack:Stack']);
+  assert.deepEqual(tree.children.get('yinxiang-stack:Stack').map((node) => node.nodeId), ['yinxiang-notebook:notebook-guid']);
+  assert.deepEqual(tree.children.get('yinxiang-notebook:notebook-guid').map((node) => node.nodeId), ['yinxiang-note:note-guid']);
+  assert.equal(nodes.at(-1).selectable, true);
+  assert.equal(nodes.at(-1).exportId, 'note-guid');
+  assert.deepEqual(selectionArgs(provider, [nodes.at(-1).exportId]), ['--doc-id', 'note-guid']);
+});
+
+test('maps ZSXQ column groups through its explicit adapter', () => {
+  const provider = require('../plugins/zsxq/providers/zsxq-column/provider.json');
+  assert.equal(provider.toc.adapter, 'zsxq-column-groups');
+  assert.equal(provider.toc.itemsPath, 'groups');
+  assert.equal(provider.toc.selectionArg, '--toc-key');
+
+  const nodes = normalizeProviderTocNodes(provider, { groups: [
+    {
+      groupIndex: 3,
+      groupTitle: 'Section',
+      topics: [{ key: 'toc:3:0', title: 'Article' }]
+    }
+  ] });
+  const tree = tocNodeMaps(nodes);
+
+  assert.deepEqual(tree.children.get('').map((node) => node.nodeId), ['zsxq-column-group:3']);
+  assert.deepEqual(tree.children.get('zsxq-column-group:3').map((node) => node.nodeId), ['zsxq-column:toc:3:0']);
+  assert.equal(nodes[0].selectable, false);
+  assert.equal(nodes[1].selectable, true);
+  assert.equal(nodes[1].exportId, 'toc:3:0');
+  assert.deepEqual(selectionArgs(provider, [nodes[1].exportId]), ['--toc-mode', 'toc', '--toc-key', 'toc:3:0']);
 });

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4354,7 +4354,7 @@ function buildExportArgs(toolId, options = {}) {
 }
 
 function normalizeStandardTocNodes(provider, data) {
-  return window.WandaoTocTree.normalizeStandardTocNodes(provider, data);
+  return window.WandaoTocTree.normalizeProviderTocNodes(provider, data);
 }
 
 function normalizeTocNodes(toolId, data) {
@@ -4634,14 +4634,7 @@ function selectedTocArgs(toolId) {
   if (!selected.length) {
     throw new Error('目录已读取，但没有选择任何文档。请至少勾选一篇，或重新读取目录。');
   }
-  const args = [];
-  if (toolId === 'zsxq-column') {
-    args.push('--toc-mode', 'toc');
-    selected.forEach((id) => args.push('--toc-key', id));
-  } else {
-    args.push(...window.WandaoTocTree.selectionArgs(TOOLS[toolId], selected));
-  }
-  return args;
+  return window.WandaoTocTree.selectionArgs(TOOLS[toolId], selected);
 }
 
 async function handleScanToc(toolId) {

--- a/wandao_electron/renderer/toc_tree.js
+++ b/wandao_electron/renderer/toc_tree.js
@@ -49,6 +49,74 @@
     });
   }
 
+  function normalizeYinxiangTocNodes(data) {
+    const nodes = [];
+    (data?.notebooks || []).forEach((notebook, notebookIndex) => {
+      const stack = String(notebook.stack || '');
+      let parentNodeId = '';
+      if (stack) {
+        parentNodeId = `yinxiang-stack:${stack}`;
+        if (!nodes.some((node) => node.nodeId === parentNodeId)) {
+          nodes.push({ nodeId: parentNodeId, exportId: '', title: stack, parentNodeId: '', selectable: false });
+        }
+      }
+      const notebookId = String(notebook.guid || `notebook-${notebookIndex}`);
+      const notebookNodeId = `yinxiang-notebook:${notebookId}`;
+      nodes.push({
+        nodeId: notebookNodeId,
+        exportId: '',
+        title: notebook.name || `Notebook ${notebookIndex + 1}`,
+        parentNodeId,
+        selectable: false
+      });
+      (notebook.notes || []).forEach((note, noteIndex) => {
+        const guid = String(note.guid || '');
+        if (!guid) return;
+        nodes.push({
+          nodeId: `yinxiang-note:${guid}`,
+          exportId: guid,
+          title: note.title || `Untitled note ${noteIndex + 1}`,
+          parentNodeId: notebookNodeId,
+          selectable: true
+        });
+      });
+    });
+    return nodes;
+  }
+
+  function normalizeZsxqColumnTocNodes(data) {
+    const nodes = [];
+    (data?.groups || []).forEach((group, groupIndex) => {
+      const groupIndexValue = group.groupIndex ?? groupIndex;
+      const groupId = `zsxq-column-group:${groupIndexValue}`;
+      nodes.push({
+        nodeId: groupId,
+        exportId: '',
+        title: group.groupTitle || `Group ${groupIndex + 1}`,
+        parentNodeId: '',
+        selectable: false
+      });
+      (group.topics || []).forEach((topic, topicIndex) => {
+        const key = String(topic.key || `toc:${groupIndexValue}:${topic.topicIndex ?? topicIndex}`);
+        nodes.push({
+          nodeId: `zsxq-column:${key}`,
+          exportId: key,
+          title: topic.title || `Untitled article ${topicIndex + 1}`,
+          parentNodeId: groupId,
+          selectable: true
+        });
+      });
+    });
+    return nodes;
+  }
+
+  function normalizeProviderTocNodes(provider, data) {
+    const adapter = provider?.toc?.adapter;
+    if (adapter === 'yinxiang-notebooks') return normalizeYinxiangTocNodes(data);
+    if (adapter === 'zsxq-column-groups') return normalizeZsxqColumnTocNodes(data);
+    return normalizeStandardTocNodes(provider, data);
+  }
+
   function tocNodeMaps(nodes) {
     const byId = new Map(nodes.map((node) => [node.nodeId, node]));
     const children = new Map();
@@ -61,11 +129,21 @@
   }
 
   function selectionArgs(provider, exportIds) {
-    const selectionArg = provider?.toc?.selectionArg || '--doc-id';
-    return (exportIds || [])
+    const toc = provider?.toc || {};
+    const selectionArg = toc.selectionArg || '--doc-id';
+    const prefixArgs = Array.isArray(toc.selectionPrefixArgs) ? toc.selectionPrefixArgs.map(String) : [];
+    return prefixArgs.concat((exportIds || [])
       .filter((exportId) => exportId !== null && exportId !== undefined && String(exportId).trim())
-      .flatMap((exportId) => [selectionArg, String(exportId)]);
+      .flatMap((exportId) => [selectionArg, String(exportId)]));
   }
 
-  return { normalizeStandardTocNodes, tocNodeMaps, selectionArgs, valueAtPath };
+  return {
+    normalizeProviderTocNodes,
+    normalizeStandardTocNodes,
+    normalizeYinxiangTocNodes,
+    normalizeZsxqColumnTocNodes,
+    tocNodeMaps,
+    selectionArgs,
+    valueAtPath
+  };
 });


### PR DESCRIPTION
## 官方稳定性整合批次

整合并解决原 #44（第二批 Plugin v1 目录契约）与 #45（有道停止/继续）在有道后端的冲突；保留原作者提交署名。

### 内容

- IMA、OneNote、有道使用真实 `nodes` 目录契约。
- 印象笔记和知识星球专栏改为 Provider 显式目录适配器。
- 有道停止时记录 checkpoint 状态、恢复时跳过已完成项，并由 CLI 返回 130。

### 验证

- `python scripts/validate_providers.py`
- `node --test tests_js/toc_tree.test.js tests_js/task_resume.test.js`
- `python -m unittest discover -s tests`（130 passed）
- `python scripts/quality_check.py`
- `git diff --check`

不包含发行版或工作流策略放宽。

Supersedes #44 and #45; partially addresses #33 and #39.