### PR TITLE
fix(aliyun): reject stale selected document IDs

### DIFF
--- a/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
+++ b/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
@@ -1384,7 +1384,7 @@ def extract_document_api(
 EXTRACTOR_JS = r"""
 (() => {
   function esc(s) {
-    return (s || "").replace(/ /g, " ").replace(/\n{3,}/g, "\n\n").trim();
+    return (s || "").replace(/\u00a0/g, " ").replace(/\n{3,}/g, "\n\n").trim();
   }
   function compact(md) {
     const lines = (md || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");

--- a/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
+++ b/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
@@ -309,11 +309,17 @@ class Node:
 
 
 def select_document_nodes(nodes: list[Node], selected_doc_ids: set[str] | None = None) -> list[Node]:
-    return [
-        node
-        for node in nodes
-        if node.type == "document" and (not selected_doc_ids or node.id in selected_doc_ids)
-    ]
+    documents = [node for node in nodes if node.type == "document"]
+    if not selected_doc_ids:
+        return documents
+    selected = [node for node in documents if node.id in selected_doc_ids]
+    if documents and not selected:
+        preview = ", ".join(sorted(selected_doc_ids)[:5])
+        raise ExportError(
+            "选择的阿里云 Thoughts 文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
+    return selected
 
 
 def http_json(url: str, timeout: int = 10) -> Any:
@@ -1378,7 +1384,7 @@ def extract_document_api(
 EXTRACTOR_JS = r"""
 (() => {
   function esc(s) {
-    return (s || "").replace(/\u00a0/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+    return (s || "").replace(/ /g, " ").replace(/\n{3,}/g, "\n\n").trim();
   }
   function compact(md) {
     const lines = (md || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");

--- a/plugins/aliyun_thoughts/plugin.json
+++ b/plugins/aliyun_thoughts/plugin.json
@@ -4,7 +4,7 @@
   "id": "aliyun_thoughts",
   "name": "阿里云 Thoughts",
   "description": "阿里云 Thoughts 工作区 Markdown 导出。",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "Wandao Official",
   "license": "AGPL-3.0-only",
   "core": { "minVersion": "1.2.9" },

--- a/tests/test_aliyun_selection_mismatch.py
+++ b/tests/test_aliyun_selection_mismatch.py
@@ -1,0 +1,15 @@
+import unittest
+
+from plugins.aliyun_thoughts.backend.export_aliyun_thoughts import Node, select_document_nodes
+
+
+class AliyunSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        nodes = [Node(id="doc", title="Doc", type="document", parent_id=None, pos=1, raw={})]
+        with self.assertRaises(RuntimeError):
+            select_document_nodes(nodes, {"stale"})
+        self.assertEqual([item.id for item in select_document_nodes(nodes, {"doc", "stale"})], ["doc"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: aliyun_thoughts 1.0.1 -> 1.0.2.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_aliyun_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.