### PR TITLE
fix(feishu): reject stale selected document IDs

### DIFF
--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -510,11 +510,18 @@ def annotate_selectable_toc(ordered: list[dict[str, Any]]) -> list[dict[str, Any
 def select_exportable_docs(
     ordered: list[dict[str, Any]], selected_doc_ids: set[str] | None = None
 ) -> list[dict[str, Any]]:
-    docs = [item for item in ordered if item.get("url") and item.get("obj_type") == 22]
-    if not docs:
-        docs = [item for item in ordered if item.get("url")]
-    if selected_doc_ids:
-        docs = [item for item in docs if item.get("wiki_token") in selected_doc_ids]
+    exportable_docs = [item for item in ordered if item.get("url") and item.get("obj_type") == 22]
+    if not exportable_docs:
+        exportable_docs = [item for item in ordered if item.get("url")]
+    if not selected_doc_ids:
+        return exportable_docs
+    docs = [item for item in exportable_docs if item.get("wiki_token") in selected_doc_ids]
+    if exportable_docs and not docs:
+        preview = ", ".join(sorted(selected_doc_ids)[:5])
+        raise ExportError(
+            "选择的飞书文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
     return docs
 
 
@@ -551,11 +558,11 @@ def order_tree(tree: dict[str, Any]) -> list[dict[str, Any]]:
 FEISHU_CONVERTER_JS = r"""
 async (fallbackTitle) => {
   const images = [];
-  const ZERO = /[\u200b\u200c\u200d\ufeff]/g;
+  const ZERO = /[​‌‍﻿]/g;
   function clean(value) {
     return (value || "")
       .replace(ZERO, "")
-      .replace(/\u00a0/g, " ")
+      .replace(/ /g, " ")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim();

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -558,11 +558,11 @@ def order_tree(tree: dict[str, Any]) -> list[dict[str, Any]]:
 FEISHU_CONVERTER_JS = r"""
 async (fallbackTitle) => {
   const images = [];
-  const ZERO = /[​‌‍﻿]/g;
+  const ZERO = /[\u200b\u200c\u200d\ufeff]/g;
   function clean(value) {
     return (value || "")
       .replace(ZERO, "")
-      .replace(/ /g, " ")
+      .replace(/\u00a0/g, " ")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim();

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_feishu_selection_mismatch.py
+++ b/tests/test_feishu_selection_mismatch.py
@@ -1,0 +1,15 @@
+import unittest
+
+from plugins.feishu.backend.export_feishu import select_exportable_docs
+
+
+class FeishuSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        docs = [{"wiki_token": "doc", "obj_type": 22, "url": "https://example.test/doc"}]
+        with self.assertRaises(RuntimeError):
+            select_exportable_docs(docs, {"stale"})
+        self.assertEqual([item["wiki_token"] for item in select_exportable_docs(docs, {"doc", "stale"})], ["doc"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: feishu 1.0.2 -> 1.0.3.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_feishu_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.