### PR TITLE
fix(ima): reject stale selected document IDs

### DIFF
--- a/plugins/ima/backend/ima_knowledge.py
+++ b/plugins/ima/backend/ima_knowledge.py
@@ -580,7 +580,14 @@ def selected_entries(entries: list[KnowledgeEntry], doc_ids: list[str]) -> list[
     if not doc_ids:
         return media_entries
     selected = set(doc_ids)
-    return [entry for entry in media_entries if entry.export_id in selected or entry.media_id in selected]
+    selected_media = [entry for entry in media_entries if entry.export_id in selected or entry.media_id in selected]
+    if media_entries and not selected_media:
+        preview = ", ".join(sorted(selected)[:5])
+        raise ImaError(
+            "选择的 ima 文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
+    return selected_media
 
 
 def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:

--- a/plugins/ima/plugin.json
+++ b/plugins/ima/plugin.json
@@ -4,7 +4,7 @@
   "id": "ima",
   "name": "ima 知识库",
   "description": "ima 知识库 OpenAPI 导出与本地文件批量导入。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "homepage": "https://ima.qq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_ima_selection_mismatch.py
+++ b/tests/test_ima_selection_mismatch.py
@@ -1,0 +1,15 @@
+import unittest
+
+from plugins.ima.backend.ima_knowledge import KnowledgeEntry, selected_entries
+
+
+class ImaSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        entry = KnowledgeEntry("kb", "KB", "doc", "Document", "", [], False)
+        with self.assertRaises(RuntimeError):
+            selected_entries([entry], ["stale"])
+        self.assertEqual([item.export_id for item in selected_entries([entry], [entry.export_id, "stale"])], [entry.export_id])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: ima 1.0.0 -> 1.0.1.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_ima_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.