### PR TITLE
fix(wiz): reject stale selected document IDs

### DIFF
--- a/plugins/wiz/backend/export_wiz.py
+++ b/plugins/wiz/backend/export_wiz.py
@@ -932,6 +932,19 @@ def scan_wiz(args: argparse.Namespace) -> dict[str, Any]:
             chrome_proc.terminate()
 
 
+def select_wiz_documents(docs: list[WizDoc], selected_doc_ids: set[str] | None = None) -> list[WizDoc]:
+    if not selected_doc_ids:
+        return docs
+    selected = [doc for doc in docs if doc.doc_guid in selected_doc_ids]
+    if docs and not selected:
+        preview = ", ".join(sorted(selected_doc_ids)[:5])
+        raise ExportError(
+            "选择的为知笔记文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
+    return selected
+
+
 def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
     started = time.time()
     output = Path(args.output).resolve()
@@ -943,8 +956,7 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
         snapshot = wait_for_login_state(cdp, timeout=30)
         docs = docs_from_snapshot(snapshot)
         selected_ids = set(args.selected_doc_ids or [])
-        if selected_ids:
-            docs = [doc for doc in docs if doc.doc_guid in selected_ids]
+        docs = select_wiz_documents(docs, selected_ids)
         planner = PathPlanner(output)
         doc_paths = {doc.doc_guid: planner.markdown_path(doc) for doc in docs}
         if checkpoint:

--- a/plugins/wiz/plugin.json
+++ b/plugins/wiz/plugin.json
@@ -4,7 +4,7 @@
   "id": "wiz",
   "name": "为知笔记",
   "description": "导出为知笔记网页版内容，保留目录、正文和本地图片。",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "Wandao Official",
   "homepage": "https://www.wiz.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_wiz_selection_mismatch.py
+++ b/tests/test_wiz_selection_mismatch.py
@@ -1,0 +1,15 @@
+import unittest
+
+from plugins.wiz.backend.export_wiz import WizDoc, select_wiz_documents
+
+
+class WizSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        doc = WizDoc("kb", "doc", "Document", "/", "document", ".md", 0, 0, {})
+        with self.assertRaises(RuntimeError):
+            select_wiz_documents([doc], {"stale"})
+        self.assertEqual([item.doc_guid for item in select_wiz_documents([doc], {"doc", "stale"})], ["doc"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: wiz 1.0.1 -> 1.0.2.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_wiz_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.