### PR TITLE
fix(yinxiang): reject stale selected document IDs

### DIFF
--- a/plugins/yinxiang/backend/export_yinxiang.py
+++ b/plugins/yinxiang/backend/export_yinxiang.py
@@ -508,6 +508,17 @@ def select_enex_notes(notes: list[ET.Element], selected_doc_ids: set[str]) -> li
     return [note_el for note_el in notes if (note_el.findtext("guid") or "") in selected_doc_ids]
 
 
+def validate_enex_selection(
+    selected_doc_ids: set[str], source_note_count: int, matched_selected_count: int
+) -> None:
+    if selected_doc_ids and source_note_count and not matched_selected_count:
+        preview = ", ".join(sorted(selected_doc_ids)[:5])
+        raise ExportError(
+            "选择的印象笔记文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
+
+
 def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
     output = args.output
     output.mkdir(parents=True, exist_ok=True)
@@ -539,6 +550,8 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
     skipped = 0
     failures: list[dict[str, str]] = []
     md_files: list[Path] = []
+    source_note_count = 0
+    matched_selected_count = 0
     total = len(enex_files)
     emit(
         f"开始转换印象笔记 ENEX：共 {total} 篇。",
@@ -555,6 +568,11 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
         md_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
+            root = ET.parse(enex_file).getroot()
+            notes = list(root.findall("note"))
+            source_note_count += len(notes)
+            selected_notes = select_enex_notes(notes, selected)
+            matched_selected_count += len(selected_notes)
             if checkpoint and getattr(args, "resume", False) and checkpoint.item_status(item_key) == "completed":
                 skipped += 1
                 if md_path.exists():
@@ -567,14 +585,11 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
                 event="document.export.started",
                 doc={"path": relative.as_posix(), "index": index, "output": str(md_path)},
             )
-            root = ET.parse(enex_file).getroot()
-            notes = list(root.findall("note"))
             if not notes:
                 if checkpoint:
                     checkpoint.skip_item(item_key, "empty-enex")
                 skipped += 1
                 continue
-            selected_notes = select_enex_notes(notes, selected)
             if not selected_notes:
                 if checkpoint:
                     checkpoint.skip_item(item_key, "not-selected")
@@ -620,6 +635,7 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
                 stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
             )
 
+    validate_enex_selection(selected, source_note_count, matched_selected_count)
     write_index(output, md_files)
     report = {
         "provider": "yinxiang",

--- a/plugins/yinxiang/backend/export_yinxiang.py
+++ b/plugins/yinxiang/backend/export_yinxiang.py
@@ -635,7 +635,13 @@ def convert_enex(args: argparse.Namespace, enex_dir: Path) -> dict[str, Any]:
                 stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
             )
 
-    validate_enex_selection(selected, source_note_count, matched_selected_count)
+    try:
+        validate_enex_selection(selected, source_note_count, matched_selected_count)
+    except ExportError as exc:
+        if checkpoint:
+            checkpoint.fail_task(str(exc), status="failed")
+            checkpoint.close()
+        raise
     write_index(output, md_files)
     report = {
         "provider": "yinxiang",

--- a/plugins/yinxiang/plugin.json
+++ b/plugins/yinxiang/plugin.json
@@ -4,7 +4,7 @@
   "id": "yinxiang",
   "name": "印象笔记",
   "description": "印象笔记 Markdown 导出与本地批量导入。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "homepage": "https://www.yinxiang.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_yinxiang_selection_mismatch.py
+++ b/tests/test_yinxiang_selection_mismatch.py
@@ -1,0 +1,42 @@
+import argparse
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from plugins.yinxiang.backend.export_yinxiang import convert_enex, validate_enex_selection
+
+
+class YinxiangSelectionMismatchTests(unittest.TestCase):
+    def test_source_matches_are_validated_before_incremental_skips(self) -> None:
+        with self.assertRaises(RuntimeError):
+            validate_enex_selection({"stale"}, 2, 0)
+        self.assertIsNone(validate_enex_selection({"matched", "stale"}, 2, 1))
+        self.assertIsNone(validate_enex_selection({"stale"}, 0, 0))
+
+    def test_convert_enex_rejects_stale_selection_before_writing_success_index(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            enex_dir = root / "enex"
+            output = root / "output"
+            enex_dir.mkdir()
+            (enex_dir / "note.enex").write_text(
+                "<en-export><note><guid>present</guid><title>Note</title><content><![CDATA[<div>body</div>]]></content></note></en-export>",
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(
+                output=output,
+                doc_id=["stale"],
+                incremental=True,
+                progress_every=1,
+                database=root / "notes.db",
+                checkpoint_file="",
+                retry_failed=False,
+                resume=False,
+            )
+            with self.assertRaises(RuntimeError):
+                convert_enex(args, enex_dir)
+            self.assertFalse((output / "00-?????.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yinxiang_selection_mismatch.py
+++ b/tests/test_yinxiang_selection_mismatch.py
@@ -1,9 +1,13 @@
 import argparse
+import sqlite3
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
+from plugins.yinxiang.backend import export_yinxiang
 from plugins.yinxiang.backend.export_yinxiang import convert_enex, validate_enex_selection
+from wandao_core.checkpoint import WandaoCheckpoint
 
 
 class YinxiangSelectionMismatchTests(unittest.TestCase):
@@ -35,7 +39,55 @@ class YinxiangSelectionMismatchTests(unittest.TestCase):
             )
             with self.assertRaises(RuntimeError):
                 convert_enex(args, enex_dir)
-            self.assertFalse((output / "00-?????.md").exists())
+            self.assertFalse((output / "00-\u77e5\u8bc6\u5e93\u5165\u53e3.md").exists())
+
+
+    def test_stale_selection_marks_and_closes_checkpoint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            enex_dir = root / "enex"
+            enex_dir.mkdir()
+            (enex_dir / "note.enex").write_text(
+                "<en-export><note><guid>present</guid><title>Note</title><content><![CDATA[<div>body</div>]]></content></note></en-export>",
+                encoding="utf-8",
+            )
+            checkpoint_file = root / "checkpoint.sqlite"
+            actual_checkpoint = WandaoCheckpoint.open(checkpoint_file, "stale-selection", "yinxiang", "export")
+            checkpoint = mock.Mock(wraps=actual_checkpoint)
+            args = argparse.Namespace(
+                output=root / "output",
+                doc_id=["stale"],
+                incremental=False,
+                progress_every=1,
+                database=root / "notes.db",
+                checkpoint_file=str(checkpoint_file),
+                checkpoint_task_id="stale-selection",
+                reset_checkpoint=False,
+                retry_failed=False,
+                resume=False,
+            )
+            try:
+                with mock.patch.object(export_yinxiang, "open_checkpoint_from_args", return_value=checkpoint):
+                    with self.assertRaises(RuntimeError):
+                        convert_enex(args, enex_dir)
+
+                checkpoint.fail_task.assert_called_once()
+                checkpoint.close.assert_called_once()
+                with self.assertRaises(sqlite3.ProgrammingError):
+                    actual_checkpoint.conn.execute("SELECT 1")
+
+                conn = sqlite3.connect(checkpoint_file)
+                try:
+                    row = conn.execute(
+                        "SELECT status, error_summary FROM tasks WHERE task_id = ?", ("stale-selection",)
+                    ).fetchone()
+                finally:
+                    conn.close()
+                self.assertEqual(row[0], "failed")
+                self.assertIn("stale", row[1])
+            finally:
+                if checkpoint.close.call_count == 0:
+                    actual_checkpoint.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: yinxiang 1.0.0 -> 1.0.1.
- Counts source matches before incremental skips, rejects only zero matches, and marks/closes checkpoint state on the validation failure path.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_yinxiang_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.