### PR TITLE
fix(youdao): reject stale selected document IDs

### DIFF
--- a/plugins/youdao/backend/export_youdao.py
+++ b/plugins/youdao/backend/export_youdao.py
@@ -122,8 +122,18 @@ class RemoteNode:
 
 
 def select_export_documents(nodes: list[RemoteNode], selected_doc_ids: list[str] | set[str] | None) -> list[RemoteNode]:
+    documents = [node for node in nodes if not node.is_dir]
     selected = set(selected_doc_ids or [])
-    return [node for node in nodes if not node.is_dir and (not selected or node.id in selected)]
+    if not selected:
+        return documents
+    matched = [node for node in documents if node.id in selected]
+    if documents and not matched:
+        preview = ", ".join(sorted(selected)[:5])
+        raise YoudaoError(
+            "选择的有道云笔记文档未匹配当前目录，"
+            "请重新读取目录后再试。未匹配 ID：" + preview
+        )
+    return matched
 
 
 @dataclass

--- a/plugins/youdao/plugin.json
+++ b/plugins/youdao/plugin.json
@@ -4,7 +4,7 @@
   "id": "youdao",
   "name": "有道云笔记",
   "description": "有道云笔记 Markdown、图片和附件导出。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "Wandao Official",
   "homepage": "https://note.youdao.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_youdao_selection_mismatch.py
+++ b/tests/test_youdao_selection_mismatch.py
@@ -1,0 +1,15 @@
+import unittest
+
+from plugins.youdao.backend.export_youdao import RemoteNode, select_export_documents
+
+
+class YoudaoSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        doc = RemoteNode("doc", "Document", False)
+        with self.assertRaises(RuntimeError):
+            select_export_documents([doc], ["stale"])
+        self.assertEqual([item.id for item in select_export_documents([doc], ["doc", "stale"])], ["doc"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: youdao 1.0.0 -> 1.0.1.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_youdao_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.