### PR TITLE
fix(zsxq): reject stale selected document IDs

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -405,8 +405,8 @@ ZSXQ_CONVERTER_JS = r"""
   const links = [];
   function clean(s) {
     return (s || "")
-      .replace(/ /g, " ")
-      .replace(/[​‌‍﻿]/g, "")
+      .replace(/\u00a0/g, " ")
+      .replace(/[\u200b\u200c\u200d\ufeff]/g, "")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim();
@@ -450,7 +450,7 @@ ZSXQ_CONVERTER_JS = r"""
   }
   function inline(node) {
     if (!node) return "";
-    if (node.nodeType === 3) return node.nodeValue.replace(/[​‌‍﻿]/g, "");
+    if (node.nodeType === 3) return node.nodeValue.replace(/[\u200b\u200c\u200d\ufeff]/g, "");
     if (node.nodeType !== 1) return "";
     if (hidden(node)) return "";
     const tag = node.tagName.toLowerCase();
@@ -579,8 +579,8 @@ ZSXQ_COMMENTS_JS = r"""
 async () => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
   const clean = s => (s || "")
-    .replace(/ /g, " ")
-    .replace(/[​‌‍﻿]/g, "")
+    .replace(/\u00a0/g, " ")
+    .replace(/[\u200b\u200c\u200d\ufeff]/g, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
@@ -694,7 +694,7 @@ async () => {
 ZSXQ_TOC_JS = r"""
 async () => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
-  const clean = s => (s || "").replace(/ /g, " ").replace(/\s+/g, " ").trim();
+  const clean = s => (s || "").replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
   const activate = async el => {
     if (!el) return;
     el.scrollIntoView({block: "center", inline: "nearest"});
@@ -848,7 +848,7 @@ async () => {
 ZSXQ_OPEN_TOC_ITEM_JS = r"""
 async (target) => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
-  const clean = s => (s || "").replace(/ /g, " ").replace(/\s+/g, " ").trim();
+  const clean = s => (s || "").replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
   const visible = el => {
     if (!el || el.nodeType !== 1 || el.hidden || el.getAttribute("aria-hidden") === "true") return false;
     const style = window.getComputedStyle ? window.getComputedStyle(el) : null;

--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -405,8 +405,8 @@ ZSXQ_CONVERTER_JS = r"""
   const links = [];
   function clean(s) {
     return (s || "")
-      .replace(/\u00a0/g, " ")
-      .replace(/[\u200b\u200c\u200d\ufeff]/g, "")
+      .replace(/ /g, " ")
+      .replace(/[​‌‍﻿]/g, "")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim();
@@ -450,7 +450,7 @@ ZSXQ_CONVERTER_JS = r"""
   }
   function inline(node) {
     if (!node) return "";
-    if (node.nodeType === 3) return node.nodeValue.replace(/[\u200b\u200c\u200d\ufeff]/g, "");
+    if (node.nodeType === 3) return node.nodeValue.replace(/[​‌‍﻿]/g, "");
     if (node.nodeType !== 1) return "";
     if (hidden(node)) return "";
     const tag = node.tagName.toLowerCase();
@@ -579,8 +579,8 @@ ZSXQ_COMMENTS_JS = r"""
 async () => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
   const clean = s => (s || "")
-    .replace(/\u00a0/g, " ")
-    .replace(/[\u200b\u200c\u200d\ufeff]/g, "")
+    .replace(/ /g, " ")
+    .replace(/[​‌‍﻿]/g, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
@@ -694,7 +694,7 @@ async () => {
 ZSXQ_TOC_JS = r"""
 async () => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
-  const clean = s => (s || "").replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
+  const clean = s => (s || "").replace(/ /g, " ").replace(/\s+/g, " ").trim();
   const activate = async el => {
     if (!el) return;
     el.scrollIntoView({block: "center", inline: "nearest"});
@@ -848,7 +848,7 @@ async () => {
 ZSXQ_OPEN_TOC_ITEM_JS = r"""
 async (target) => {
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
-  const clean = s => (s || "").replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
+  const clean = s => (s || "").replace(/ /g, " ").replace(/\s+/g, " ").trim();
   const visible = el => {
     if (!el || el.nodeType !== 1 || el.hidden || el.getAttribute("aria-hidden") === "true") return false;
     const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
@@ -1615,7 +1615,14 @@ def select_toc_items(toc: dict[str, Any], args: argparse.Namespace) -> list[dict
     items = flatten_toc(toc)
     selected_keys = set(getattr(args, "selected_toc_keys", None) or [])
     if selected_keys:
-        items = [item for item in items if item.get("key") in selected_keys]
+        selected_items = [item for item in items if item.get("key") in selected_keys]
+        if items and not selected_items:
+            preview = ", ".join(sorted(selected_keys)[:5])
+            raise ExportError(
+                "选择的知识星球专栏文档未匹配当前目录，"
+                "请重新读取目录后再试。未匹配 ID：" + preview
+            )
+        items = selected_items
     group_pattern_text = getattr(args, "toc_group_pattern", None)
     if group_pattern_text:
         group_pattern = re.compile(group_pattern_text)

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_zsxq_selection_mismatch.py
+++ b/tests/test_zsxq_selection_mismatch.py
@@ -1,0 +1,18 @@
+import argparse
+import unittest
+
+from plugins.zsxq.backend.export_zsxq import select_toc_items
+
+
+class ZsxqSelectionMismatchTests(unittest.TestCase):
+    def test_explicit_stale_selection_is_rejected_but_partial_match_exports(self) -> None:
+        toc = {"groups": [{"topics": [{"key": "toc:1:0", "title": "Article"}]}]}
+        stale = argparse.Namespace(selected_toc_keys=["stale"], toc_group_pattern=None, toc_title_pattern=None, link_pattern=None, limit=0)
+        partial = argparse.Namespace(selected_toc_keys=["toc:1:0", "stale"], toc_group_pattern=None, toc_title_pattern=None, link_pattern=None, limit=0)
+        with self.assertRaises(RuntimeError):
+            select_toc_items(toc, stale)
+        self.assertEqual([item["key"] for item in select_toc_items(toc, partial)], ["toc:1:0"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #49.

- This Draft PR changes only one plugin and bumps its patch version: zsxq 1.0.1 -> 1.0.2.
- Adds a zero-match guard while preserving partial-match exports and empty-source exports.
- The regression test executes the platform selection logic; it is not a static-source assertion.

## Validation

- python -m unittest tests.test_zsxq_selection_mismatch
- node scripts/check_plugin_versions.js origin/main
- node scripts/validate_plugins.js
- git diff --check origin/main...HEAD
- python scripts/quality_check.py

Real authenticated-account export validation remains for maintainer/user acceptance.