### PR TITLE
chore(release): v1.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandao"
-version = "1.3.3"
+version = "1.3.4"
 description = "万能导：多平台知识库 Markdown 导出与互转工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wandao_electron/package-lock.json
+++ b/wandao_electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wandao",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wandao",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "electron": "^39.8.5",

--- a/wandao_electron/package.json
+++ b/wandao_electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wandao",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Wandao multi-platform document conversion tool",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
发布 v1.3.4。

- 合并目录选择零匹配防线稳定性批次（#51–#57）
- 同步 Python、Electron 与 lockfile 版本号
- 已运行 python scripts/quality_check.py（143 Python、48 Node 测试通过）