### PR TITLE
fix(release): restore cross-platform gate and limit assets

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -121,7 +121,6 @@ jobs:
           path: |
             wandao_electron/dist/*.exe
             wandao_electron/dist/*.zip
-            wandao_electron/dist/*.blockmap
           if-no-files-found: error
 
   release:
@@ -167,4 +166,10 @@ jobs:
           name: Wandao ${{ github.ref_name }}
           generate_release_notes: true
           make_latest: true
-          files: release-artifacts/*
+          # Keep the public release simple: only the Windows installer and
+          # macOS package are attached. Checksums, SBOM and provenance remain
+          # available through the workflow/attestation rather than cluttering
+          # the download list.
+          files: |
+            release-artifacts/*.exe
+            release-artifacts/*.zip

--- a/tests/test_feishu_import_resume.py
+++ b/tests/test_feishu_import_resume.py
@@ -106,7 +106,7 @@ class FeishuImportResumeTests(unittest.TestCase):
 
             checkpoint = WandaoCheckpoint.open(checkpoint_file, "single", "feishu-import", "import")
             try:
-                self.assertEqual(checkpoint.item_status(f"feishu-import:{source_file}"), "completed")
+                self.assertEqual(checkpoint.item_status(f"feishu-import:{source_file.resolve()}"), "completed")
             finally:
                 checkpoint.close()
 


### PR DESCRIPTION
修复跨平台 checkpoint 测试的路径规范化断言，并将发行附件限制为 Windows 安装程序和 macOS 包。

已运行 python scripts/quality_check.py。