### PR TITLE
fix(aliyun): 修正主动停止的退出码

### DIFF
--- a/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
+++ b/plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py
@@ -2679,7 +2679,7 @@ def main(argv: list[str]) -> int:
             "imageFailureCount",
         )
         print(json.dumps({k: report[k] for k in keys if k in report}, ensure_ascii=False, indent=2))
-    return 0
+    return 130 if report.get("stopped") else 0
 
 
 if __name__ == "__main__":

--- a/plugins/aliyun_thoughts/plugin.json
+++ b/plugins/aliyun_thoughts/plugin.json
@@ -4,7 +4,7 @@
   "id": "aliyun_thoughts",
   "name": "阿里云 Thoughts",
   "description": "阿里云 Thoughts 工作区 Markdown 导出。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Wandao Official",
   "license": "AGPL-3.0-only",
   "core": { "minVersion": "1.2.9" },

--- a/tests/test_aliyun_thoughts_stop_exit.py
+++ b/tests/test_aliyun_thoughts_stop_exit.py
@@ -1,0 +1,26 @@
+﻿import unittest
+from unittest.mock import patch
+
+from plugins.aliyun_thoughts.backend import export_aliyun_thoughts
+
+
+class AliyunThoughtsStopExitTests(unittest.TestCase):
+    def test_export_report_marked_stopped_returns_stop_exit_code(self) -> None:
+        with patch.object(export_aliyun_thoughts, "export_workspace", return_value={"stopped": True}):
+            exit_code = export_aliyun_thoughts.main(
+                ["--workspace-url", "https://thoughts.aliyun.com/workspace/demo", "--output", "out"]
+            )
+
+        self.assertEqual(exit_code, 130)
+
+    def test_completed_export_report_returns_success_exit_code(self) -> None:
+        with patch.object(export_aliyun_thoughts, "export_workspace", return_value={"stopped": False}):
+            exit_code = export_aliyun_thoughts.main(
+                ["--workspace-url", "https://thoughts.aliyun.com/workspace/demo", "--output", "out"]
+            )
+
+        self.assertEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

- Closes #63

## 改动内容

- 阿里云 Thoughts 导出报告带有 `stopped: true` 时，命令行入口返回受控停止退出码 `130`。
- 正常完成仍返回 `0`。
- 插件版本由 `1.0.2` 升至 `1.0.3`。

## 为什么需要这个改动

旧实现已生成“已停止”的报告，却固定以成功退出码结束；调用方可能把用户主动停止误记为完成。修复后报告语义和进程退出码一致。

## 共创流程确认

- [x] 我已经搜索过已有 Issue 和 PR，没有重复实现同一个功能或 Bug。
- [x] 已先创建并认领 Issue #63。
- [x] 这个 PR 仅处理阿里云 Thoughts 的停止退出码。
- [x] 不包含任何凭证、账号或私人内容。

## 测试方式

- [x] 已运行 `python scripts/quality_check.py`。
- [x] 已运行 `python -m unittest tests.test_aliyun_thoughts_stop_exit -v`（2 项通过）。
- [ ] 尚未执行需要真实账号的桌面端人工导出；Draft PR 等待脱敏人工验收。

## 涉及范围

- [x] 阿里云 Thoughts 导出

## 新增或修改在线插件检查

- [x] 改动集中在 `plugins/aliyun_thoughts`。
- [x] 已提升 `plugins/aliyun_thoughts/plugin.json.version` 至 `1.0.3`，未增加权限。
- [x] 已通过插件校验与插件管理器测试。

## 用户影响

用户主动停止后，任务会被一致识别为“已停止”；无需重新登录或重新配置。

## 已知限制

本 PR 只修正停止语义，不改变请求、认证、目录、资源下载或断点续传逻辑。

## 敏感信息检查

- [x] PR 中不包含 Cookie、账号密码、App Secret、Token、API Key 或私人内容。