### PR TITLE
fix(zsxq): 校验正文转换返回结构

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -1683,6 +1683,7 @@ def resolve_toc_item(cdp: CDPClient, source: dict[str, Any], args: argparse.Name
             f"({ZSXQ_CONVERTER_JS})({js_string(source.get('title') or '知识星球文章')}, {js_string('.content.ql-editor')})",
             timeout=90,
         )
+        content = ensure_converter_content(content, source.get("title") or source.get("key") or "目录文章")
         if content_is_rate_limited(content):
             raise ExportError(f"目录条目触发请求频率限制：{source.get('title') or source.get('key')}")
         attach_comments_to_content(content, topic_comments, bool(getattr(args, "include_comments", False)))
@@ -1699,6 +1700,7 @@ def resolve_toc_item(cdp: CDPClient, source: dict[str, Any], args: argparse.Name
         f"({ZSXQ_CONVERTER_JS})({js_string(source.get('title') or '知识星球文档')}, {js_string('.column-topic-detail .talk-content-container, .column-topic-detail .answer-content-container, .column-topic-detail, #topic-detail-container, .topic-detail, [class*=TopicDetail], [class*=topic-detail], .talk-content-container, .answer-content-container')})",
         timeout=90,
     )
+    content = ensure_converter_content(content, source.get("title") or source.get("key") or "目录文章")
     if content_is_rate_limited(content):
         raise ExportError(f"目录条目触发请求频率限制：{source.get('title') or source.get('key')}")
     comments = collect_current_comments(cdp, args)
@@ -2249,6 +2251,7 @@ def collect_article_content(
             f"({ZSXQ_CONVERTER_JS})({js_string(fallback_title or '知识星球文章')}, {js_string('.content.ql-editor')})",
             timeout=90,
         )
+        content = ensure_converter_content(content, fallback_title or article_url)
         if content_is_rate_limited(content):
             pause_for_rate_limit(args, article_url, attempt, retries)
             continue
@@ -2336,6 +2339,14 @@ def should_skip_video_topic(cdp: CDPClient, topic_url: str, args: argparse.Names
         merged.update(dom_info)
         return merged
     return None
+
+
+def ensure_converter_content(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ExportError(
+            f"知识星球正文解析结果异常：{context}。页面可能改版、未加载完成或当前账号无访问权限。"
+        )
+    return value
 
 
 def content_is_rate_limited(content: dict[str, Any]) -> bool:
@@ -2444,6 +2455,7 @@ def resolve_link(cdp: CDPClient, link: dict[str, str], args: argparse.Namespace 
                 f"({ZSXQ_CONVERTER_JS})({js_string(link.get('text') or '知识星球文章')}, {js_string('.content.ql-editor')})",
                 timeout=90,
             )
+            content = ensure_converter_content(content, link.get("text") or href)
             if content_is_rate_limited(content):
                 pause_for_rate_limit(args, article_url, attempt, retries)
                 continue
@@ -2464,6 +2476,7 @@ def resolve_link(cdp: CDPClient, link: dict[str, str], args: argparse.Namespace 
                 f"({ZSXQ_CONVERTER_JS})({js_string(link.get('text') or '知识星球帖子')}, {js_string('.talk-content-container, .answer-content-container')})",
                 timeout=60,
             )
+            content = ensure_converter_content(content, link.get("text") or href)
             if content_is_rate_limited(content):
                 pause_for_rate_limit(args, topic_url, attempt, retries)
                 continue

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_zsxq_content_validation.py
+++ b/tests/test_zsxq_content_validation.py
@@ -1,0 +1,20 @@
+﻿import unittest
+
+from wandao_core.browser import ExportError
+from plugins.zsxq.backend.export_zsxq import ensure_converter_content
+
+
+class ZsxqContentValidationTests(unittest.TestCase):
+    def test_rejects_non_object_converter_result_with_context(self) -> None:
+        for value in (None, "loading", []):
+            with self.subTest(value=value), self.assertRaisesRegex(ExportError, "测试文章"):
+                ensure_converter_content(value, "测试文章")
+
+    def test_accepts_converter_object_unchanged(self) -> None:
+        content = {"title": "测试文章", "markdown": "正文"}
+
+        self.assertIs(ensure_converter_content(content, "测试文章"), content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

- Closes #64

## 改动内容

- 在知识星球全部正文页面转换调用点校验返回值必须是对象。
- 发现 `None`、字符串、列表等异常结果时，抛出包含页面结构、加载状态和访问权限排查提示的受控错误。
- 有效正文对象仍沿用原有导出路径。
- 插件版本由 `1.0.2` 升至 `1.0.3`。

## 为什么需要这个改动

页面改版、未加载完成或账号无权访问正文时，转换器可能返回非对象；旧逻辑随后访问 `content.get(...)`，只会得到难以排查的 `NoneType`/类型异常。

## 共创流程确认

- [x] 我已经搜索过已有 Issue 和 PR，没有重复实现同一个功能或 Bug。
- [x] 已先创建并认领 Issue #64。
- [x] 这个 PR 只处理知识星球正文转换返回值校验。
- [x] 不包含任何凭证、账号或私人内容。

## 测试方式

- [x] 已运行 `python scripts/quality_check.py`。
- [x] 已运行 `python -m unittest tests.test_zsxq_content_validation -v`（2 项通过）。
- [ ] 尚未执行需要真实账号的桌面端人工导出；Draft PR 等待脱敏人工验收。

## 涉及范围

- [x] 知识星球导出

## 新增或修改在线插件检查

- [x] 改动集中在 `plugins/zsxq`。
- [x] 已提升 `plugins/zsxq/plugin.json.version` 至 `1.0.3`，未增加权限。
- [x] 已通过插件校验与插件管理器测试。

## 用户影响

无需重新登录或重新配置。异常页面会得到可读的导出错误提示，而不是底层 `NoneType` 异常。

## 已知限制

本 PR 不绕过页面访问权限，也不适配未知的新页面结构；它会明确报告需要检查页面加载、权限或后续适配的情形。

## 敏感信息检查

- [x] PR 中不包含 Cookie、账号密码、App Secret、Token、API Key 或私人内容。