### PR TITLE
fix(zsxq): validate every converter result before export

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -1049,6 +1049,7 @@ def collect_entry_links(
         f"({ZSXQ_CONVERTER_JS})({js_string('知识星球专栏正文')}, {js_string('.column-topic-detail .talk-content-container, .column-topic-detail .answer-content-container, .talk-content-container, .answer-content-container')})",
         timeout=60,
     )
+    result = ensure_converter_content(result, "知识星球专栏正文")
     comments = collect_current_comments(cdp, args)
     attach_comments_to_content(result, comments, bool(getattr(args, "include_comments", False)))
     links = result.get("zsxqLinks") or []

--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -1683,6 +1683,7 @@ def resolve_toc_item(cdp: CDPClient, source: dict[str, Any], args: argparse.Name
             f"({ZSXQ_CONVERTER_JS})({js_string(source.get('title') or '知识星球文章')}, {js_string('.content.ql-editor')})",
             timeout=90,
         )
+        content = ensure_converter_content(content, source.get("title") or source.get("key") or "目录文章")
         if content_is_rate_limited(content):
             raise ExportError(f"目录条目触发请求频率限制：{source.get('title') or source.get('key')}")
         attach_comments_to_content(content, topic_comments, bool(getattr(args, "include_comments", False)))
@@ -1699,6 +1700,7 @@ def resolve_toc_item(cdp: CDPClient, source: dict[str, Any], args: argparse.Name
         f"({ZSXQ_CONVERTER_JS})({js_string(source.get('title') or '知识星球文档')}, {js_string('.column-topic-detail .talk-content-container, .column-topic-detail .answer-content-container, .column-topic-detail, #topic-detail-container, .topic-detail, [class*=TopicDetail], [class*=topic-detail], .talk-content-container, .answer-content-container')})",
         timeout=90,
     )
+    content = ensure_converter_content(content, source.get("title") or source.get("key") or "目录文章")
     if content_is_rate_limited(content):
         raise ExportError(f"目录条目触发请求频率限制：{source.get('title') or source.get('key')}")
     comments = collect_current_comments(cdp, args)
@@ -2249,6 +2251,7 @@ def collect_article_content(
             f"({ZSXQ_CONVERTER_JS})({js_string(fallback_title or '知识星球文章')}, {js_string('.content.ql-editor')})",
             timeout=90,
         )
+        content = ensure_converter_content(content, fallback_title or article_url)
         if content_is_rate_limited(content):
             pause_for_rate_limit(args, article_url, attempt, retries)
             continue
@@ -2336,6 +2339,14 @@ def should_skip_video_topic(cdp: CDPClient, topic_url: str, args: argparse.Names
         merged.update(dom_info)
         return merged
     return None
+
+
+def ensure_converter_content(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ExportError(
+            f"知识星球正文解析结果异常：{context}。页面可能改版、未加载完成或当前账号无访问权限。"
+        )
+    return value
 
 
 def content_is_rate_limited(content: dict[str, Any]) -> bool:
@@ -2444,6 +2455,7 @@ def resolve_link(cdp: CDPClient, link: dict[str, str], args: argparse.Namespace 
                 f"({ZSXQ_CONVERTER_JS})({js_string(link.get('text') or '知识星球文章')}, {js_string('.content.ql-editor')})",
                 timeout=90,
             )
+            content = ensure_converter_content(content, link.get("text") or href)
             if content_is_rate_limited(content):
                 pause_for_rate_limit(args, article_url, attempt, retries)
                 continue
@@ -2464,6 +2476,7 @@ def resolve_link(cdp: CDPClient, link: dict[str, str], args: argparse.Namespace 
                 f"({ZSXQ_CONVERTER_JS})({js_string(link.get('text') or '知识星球帖子')}, {js_string('.talk-content-container, .answer-content-container')})",
                 timeout=60,
             )
+            content = ensure_converter_content(content, link.get("text") or href)
             if content_is_rate_limited(content):
                 pause_for_rate_limit(args, topic_url, attempt, retries)
                 continue

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_zsxq_content_validation.py
+++ b/tests/test_zsxq_content_validation.py
@@ -1,6 +1,8 @@
-﻿import unittest
+import unittest
+from unittest.mock import patch
 
 from wandao_core.browser import ExportError
+from plugins.zsxq.backend import export_zsxq
 from plugins.zsxq.backend.export_zsxq import ensure_converter_content
 
 
@@ -14,6 +16,28 @@ class ZsxqContentValidationTests(unittest.TestCase):
         content = {"title": "测试文章", "markdown": "正文"}
 
         self.assertIs(ensure_converter_content(content, "测试文章"), content)
+
+    def test_column_entry_rejects_a_non_object_converter_result(self) -> None:
+        class ConverterReturnsNone:
+            def evaluate(self, _expression: str, timeout: int):
+                self.assertEqual(timeout, 60)
+                return None
+
+            def assertEqual(self, left, right):
+                if left != right:
+                    raise AssertionError(f"{left!r} != {right!r}")
+
+        with (
+            patch.object(export_zsxq, "navigate_with_retry"),
+            patch.object(export_zsxq, "wait_eval"),
+            patch.object(export_zsxq, "expand_current_content"),
+        ):
+            with self.assertRaisesRegex(ExportError, "知识星球专栏正文"):
+                export_zsxq.collect_entry_links(
+                    ConverterReturnsNone(),
+                    "https://wx.zsxq.com/columns/demo",
+                    None,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_zsxq_content_validation.py
+++ b/tests/test_zsxq_content_validation.py
@@ -1,0 +1,20 @@
+﻿import unittest
+
+from wandao_core.browser import ExportError
+from plugins.zsxq.backend.export_zsxq import ensure_converter_content
+
+
+class ZsxqContentValidationTests(unittest.TestCase):
+    def test_rejects_non_object_converter_result_with_context(self) -> None:
+        for value in (None, "loading", []):
+            with self.subTest(value=value), self.assertRaisesRegex(ExportError, "测试文章"):
+                ensure_converter_content(value, "测试文章")
+
+    def test_accepts_converter_object_unchanged(self) -> None:
+        content = {"title": "测试文章", "markdown": "正文"}
+
+        self.assertIs(ensure_converter_content(content, "测试文章"), content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
替代 #67：保留知识星球正文转换结果校验，并补齐专栏正文路径。

- 所有正文转换调用点在访问内容前验证返回对象。
- 专栏正文转换异常会返回可读错误，不再出现 `NoneType` / `.get()` 崩溃。
- 新增专栏路径回归测试。

验证：`python scripts/quality_check.py`、知识星球内容校验测试。
