### PR TITLE
fix: apply TOC indentation under CSP

### DIFF
--- a/tests_js/toc_rendering.test.js
+++ b/tests_js/toc_rendering.test.js
@@ -23,18 +23,76 @@ const descendantExportIdsSource = appSource.slice(
   appSource.indexOf('function descendantExportIds(nodes, nodeId) {'),
   appSource.indexOf('\nfunction selectableTocIds(nodes) {')
 );
+const selectableTocIdsSource = appSource.slice(
+  appSource.indexOf('function selectableTocIds(nodes) {'),
+  appSource.indexOf('\nfunction renderToc(toolId) {')
+);
 const descendantExportIds = vm.runInNewContext(
   `${tocNodeMapsSource}\n${descendantExportIdsSource}\ndescendantExportIds;`,
   { window: { WandaoTocTree: require(path.join(repoRoot, 'wandao_electron', 'renderer', 'toc_tree.js')) } }
 );
 
-test('shared TOC renderer emits explicit depth markers and pixel indentation', () => {
-  assert.match(renderTocSource, /class="toc-item toc-depth-\$\{depth\}/);
-  assert.match(
-    renderTocSource,
-    /data-node-id="\$\{escapeHtml\(node\.nodeId\)\}"\s+data-depth="\$\{depth\}"/
+function createTocList() {
+  const list = {
+    _items: [],
+    _html: '',
+    querySelectorAll(selector) {
+      assert.equal(selector, '.toc-item[data-depth]');
+      return this._items;
+    }
+  };
+
+  Object.defineProperty(list, 'innerHTML', {
+    get() { return this._html; },
+    set(html) {
+      this._html = html;
+      this._items = Array.from(html.matchAll(/<button\b([^>]*)>/g), ([, attributes]) => {
+        const depth = attributes.match(/data-depth="([^"]+)"/)?.[1] || '';
+        const values = new Map();
+        return {
+          dataset: { depth },
+          style: {
+            setProperty(name, value) { values.set(name, value); },
+            getPropertyValue(name) { return values.get(name) || ''; }
+          }
+        };
+      });
+    }
+  });
+  return list;
+}
+
+test('shared TOC renderer applies depth indentation through CSSOM after rendering', () => {
+  const list = createTocList();
+  const status = { textContent: '' };
+  const tocStates = {
+    test: {
+      loaded: true,
+      selected: new Set(['child-export', 'grandchild-export']),
+      nodes: [
+        { nodeId: 'root', parentNodeId: '', title: 'Root', selectable: false, exportId: '' },
+        { nodeId: 'child', parentNodeId: 'root', title: 'Child', selectable: true, exportId: 'child-export' },
+        { nodeId: 'grandchild', parentNodeId: 'child', title: 'Grandchild', selectable: true, exportId: 'grandchild-export' }
+      ]
+    }
+  };
+  const renderToc = vm.runInNewContext(
+    `${tocNodeMapsSource}\n${descendantExportIdsSource}\n${selectableTocIdsSource}\n${renderTocSource}\nrenderToc;`,
+    {
+      tocStates,
+      window: { WandaoTocTree: require(path.join(repoRoot, 'wandao_electron', 'renderer', 'toc_tree.js')) },
+      document: { getElementById: (id) => (id === 'test-toc-list' ? list : (id === 'test-toc-status' ? status : null)) },
+      escapeHtml: (value) => String(value ?? '')
+    }
   );
-  assert.match(renderTocSource, /style="--depth:\$\{depth\};--toc-indent:\$\{depth \* 30\}px"/);
+
+  renderToc('test');
+  assert.deepEqual(
+    list._items.map((item) => item.style.getPropertyValue('--toc-indent')),
+    ['0px', '40px', '80px']
+  );
+  assert.match(renderTocSource, /data-depth="\$\{depth\}"/);
+  assert.doesNotMatch(renderTocSource, /style="--depth:/);
 });
 
 test('TOC selection includes a document itself and all selectable descendants', () => {

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4628,7 +4628,7 @@ function renderToc(toolId) {
     const childHtml = (children.get(node.nodeId) || []).map((child) => renderNode(child, depth + 1)).join('');
     return `
       <div class="toc-node">
-        <button class="toc-item toc-depth-${depth}${hasSelectableItems ? '' : ' toc-item-empty'}" type="button" data-node-id="${escapeHtml(node.nodeId)}" data-depth="${depth}" style="--depth:${depth};--toc-indent:${depth * 30}px"${selectionAttributes}>
+        <button class="toc-item toc-depth-${depth}${hasSelectableItems ? '' : ' toc-item-empty'}" type="button" data-node-id="${escapeHtml(node.nodeId)}" data-depth="${depth}"${selectionAttributes}>
           <span class="toc-box ${checkClass}"></span>
           <span class="toc-title">${escapeHtml(node.title)}</span>
           ${count}
@@ -4640,6 +4640,13 @@ function renderToc(toolId) {
 
   const html = (children.get('') || []).map((node) => renderNode(node, 0)).join('');
   list.innerHTML = html || '<div class="toc-empty">没有读取到可选择的目录。</div>';
+  // The renderer CSP blocks style attributes in generated HTML. Set the shared
+  // CSS variable through the CSSOM after the trusted renderer has created nodes.
+  list.querySelectorAll('.toc-item[data-depth]').forEach((item) => {
+    const depth = Number.parseInt(item.dataset.depth, 10);
+    const indent = Number.isFinite(depth) && depth > 0 ? depth * 40 : 0;
+    item.style.setProperty('--toc-indent', `${indent}px`);
+  });
 }
 
 function selectedTocArgs(toolId) {


### PR DESCRIPTION
## 修复内容\n\n- 去除目录节点 HTML 中会被桌面端 CSP 拦截的内联 style 属性。\n- 由受信任的渲染器在节点生成后通过 CSSOM 写入缩进变量，恢复所有平台的目录层级展示。\n- 新增根目录、一级、二级节点的回归测试，并断言生成 HTML 不再携带内联样式。\n\n## 根因\n\n1.3.3 的目录树使用内联 style 保存深度缩进；应用 CSP 为 style-src 'self'，因此浏览器拒绝该属性，导致目录数据正确但视觉上平铺。\n\n替代并保留原 #71 的修复意图；本 PR 刻意不携带其中无关的历史改动。\n\n## 验证\n\n- 
pm --prefix wandao_electron run check\n- python scripts/quality_check.py（156 Python + 55 Node）