### PR TITLE
ci: scope click audit exception

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Audit Python dependencies
         run: |
           python -m pip install --disable-pip-version-check pip-audit
-          python -m pip_audit -r requirements.txt
+          # evernote-backup 1.13.1 pins click==8.1.8.  PYSEC-2026-2132 is
+          # reachable only through click.edit(), which neither Wandao nor
+          # evernote-backup invokes.  Keep auditing every other advisory;
+          # remove this narrowly-scoped exception when upstream releases a
+          # compatible evernote-backup version with Click >= 8.3.3.
+          python -m pip_audit -r requirements.txt --ignore-vuln PYSEC-2026-2132
 
   codeql:
     name: CodeQL (${{ matrix.language }})


### PR DESCRIPTION
## 变更\n\n保留 Python 依赖审计，仅忽略 PYSEC-2026-2132。\n\n## 原因\n\nvernote-backup 1.13.1 严格依赖 click==8.1.8，直接升级到修复版本会让依赖解析失败。该漏洞仅在 click.edit() 调用外部编辑器时可触发；已检查 Wandao 与 evernote-backup，均不调用该 API。\n\n例外仅针对这一个编号；其他任何依赖漏洞仍会让 CI 失败。上游发布兼容 Click >= 8.3.3 的版本后应移除此例外。\n\n## 验证\n\n- python -m pip_audit -r requirements.txt --ignore-vuln PYSEC-2026-2132\n- python scripts/quality_check.py（156 Python + 55 Node）