### PR TITLE
ci: 修复 Ruleset Quality Gate 错误阻塞

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -39,9 +39,24 @@ jobs:
       - name: Run project quality checks
         run: python scripts/quality_check.py
 
+  quality-gate:
+    name: Quality Gate
+    needs: quality
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every quality matrix job to pass
+        shell: bash
+        run: |
+          if [ "${{ needs.quality.result }}" != "success" ]; then
+            echo "Quality matrix result: ${{ needs.quality.result }}" >&2
+            exit 1
+          fi
+          echo "All quality matrix jobs passed."
+
   package-smoke:
     name: PR Windows Package Smoke
-    needs: quality
+    needs: quality-gate
     if: github.event_name == 'pull_request'
     runs-on: windows-latest
     steps:
@@ -69,7 +84,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.name }}
-    needs: quality
+    needs: quality-gate
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## 修复内容

- 增加固定名称的 `Quality Gate` 汇总任务。
- 汇总任务依赖完整的 Windows、Ubuntu、macOS × Python 3.10/3.11 质量矩阵。
- 任意矩阵任务失败、取消或跳过时，汇总门禁都会失败。
- Windows 打包冒烟和正式构建改为依赖汇总门禁。

## 根因

仓库 Ruleset 要求名为 `Quality Gate` 的检查，但原工作流只产生带矩阵后缀的检查名，例如 `Quality Gate (windows-latest, Python 3.11)`，导致所有实际检查通过后仍无法满足 Ruleset。

## 验证

- 工作流 YAML 解析及依赖关系断言通过。
- `python scripts/quality_check.py` 通过：Python 178 项、Node 55 项。
- `git diff --check` 通过。