### PR TITLE
fix(xiliu): 补充/修复 #60 的可靠性问题

### DIFF
--- a/plugins/xiliu/backend/export_xiliu.py
+++ b/plugins/xiliu/backend/export_xiliu.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import hashlib
 import json
 import os
 import random
@@ -59,6 +60,7 @@ from wandao_core.browser import (
     http_json,
     sanitize_filename,
     wait_for_debug_port,
+    wait_with_stop,
 )
 
 
@@ -171,7 +173,7 @@ def connect_flowus_browser(args: argparse.Namespace) -> tuple[CDPClient, subproc
     page = page_for_flowus(args.port)
     if not page:
         open_tab(args.port, FLOWUS_WEB_URL)
-        time.sleep(2)
+        wait_with_stop(args, 2)
         page = page_for_flowus(args.port)
     if not page:
         pages = http_json(f"http://127.0.0.1:{args.port}/json/list", timeout=5)
@@ -229,10 +231,10 @@ def login_and_save_auth(args: argparse.Namespace) -> dict[str, Any]:
         wait_seconds = float(getattr(args, "login_wait_seconds", 0) or 0)
         if wait_seconds > 0:
             emit(f"请在浏览器中完成登录，工具将在 {int(wait_seconds)} 秒后自动保存凭证。")
-            time.sleep(wait_seconds)
+            wait_with_stop(args, wait_seconds)
         else:
             input("After login is complete and the FlowUs workspace is visible, press Enter...")
-        time.sleep(1)
+        wait_with_stop(args, 1)
         result = save_auth_state(cdp, auth_file)
         emit(f"Saved FlowUs auth token to {auth_file}")
         return result
@@ -262,7 +264,7 @@ def throttle_request(args: argparse.Namespace | None) -> None:
     jitter = max(0.0, float(getattr(args, "request_jitter", 0) or 0))
     total = delay + (random.random() * jitter if jitter else 0)
     if total > 0:
-        time.sleep(total)
+        wait_with_stop(args, total)
 
 
 def _friendly_network_error(exc: Exception) -> str:
@@ -338,6 +340,7 @@ class FlowUsClient:
         last_error: Exception | None = None
 
         for attempt in range(1, attempts + 1):
+            check_stopped(self.args)
             try:
                 with urllib.request.urlopen(req, timeout=timeout) as response:
                     raw = response.read()
@@ -356,7 +359,7 @@ class FlowUsClient:
                 if attempt >= attempts:
                     raise FlowUsError(_friendly_network_error(exc.reason)) from exc
                 last_error = exc
-            time.sleep(min(5.0, 0.8 * attempt))
+            wait_with_stop(self.args, min(5.0, 0.8 * attempt))
 
         raise FlowUsError(_friendly_network_error(last_error))
 
@@ -398,6 +401,7 @@ def get_signed_url(client: FlowUsClient, block_id: str, oss_name: str) -> str:
         }
 
         # Call create_urls API
+        check_stopped(getattr(client, "__dict__", {}).get("args"))
         response_data = client.request("POST", FLOWUS_FILE_URLS_API, data=payload, timeout=30)
         response = json.loads(response_data.decode("utf-8", errors="replace"))
 
@@ -407,6 +411,8 @@ def get_signed_url(client: FlowUsClient, block_id: str, oss_name: str) -> str:
                 signed_url = data[0].get("url", "")
                 if signed_url:
                     return signed_url
+    except ExportStopped:
+        raise
     except Exception as exc:
         emit(f"获取签名URL失败: {_friendly_network_error(exc)}", level="warn")
 
@@ -417,9 +423,11 @@ def get_signed_url(client: FlowUsClient, block_id: str, oss_name: str) -> str:
 def download_image_data(client: FlowUsClient, block_id: str, oss_name: str) -> bytes | None:
     """Download image data, handling both base64 and binary responses."""
     # Try to get signed URL first
+    check_stopped(getattr(client, "__dict__", {}).get("args"))
     url = get_signed_url(client, block_id, oss_name)
 
     try:
+        check_stopped(getattr(client, "__dict__", {}).get("args"))
         response = client.request("GET", url, timeout=30)
         if not response:
             return None
@@ -439,6 +447,8 @@ def download_image_data(client: FlowUsClient, block_id: str, oss_name: str) -> b
 
         # Return raw binary data
         return response
+    except ExportStopped:
+        raise
     except Exception:
         return None
 
@@ -874,7 +884,7 @@ def _stable_output_components(nodes: list[FlowUsNode]) -> dict[str, str]:
     for siblings in groups.values():
         collision = len(siblings) > 1
         for node in siblings:
-            suffix = sanitize_filename(node.id, fallback="id", max_len=12)
+            suffix = hashlib.sha256(node.id.encode("utf-8")).hexdigest()
             components[node.id] = f"{node.safe_title}-{suffix}" if collision else node.safe_title
     return components
 
@@ -970,13 +980,15 @@ def _export_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
         if node.is_dir:
             file_path = file_path / f"{components[node.id]}.md"
         try:
-            if args.incremental and file_path.exists() and not args.update_existing:
+            item_status = checkpoint.item_status(item_key) if checkpoint else ""
+            retrying_failed = is_retry_failed and item_status == "failed"
+            if args.incremental and file_path.exists() and not args.update_existing and not retrying_failed:
                 skipped += 1
                 if checkpoint:
                     checkpoint.upsert_item(item_key, title=node.title, metadata={"docId": node.id, "stage": "completed"})
                     checkpoint.complete_item(item_key, local_path=str(file_path), metadata={"docId": node.id, "skippedExisting": True})
                 continue
-            if checkpoint and (is_resume or is_retry_failed) and checkpoint.item_status(item_key) == "completed" and file_path.exists():
+            if checkpoint and (is_resume or is_retry_failed) and item_status == "completed" and file_path.exists():
                 skipped += 1
                 continue
             if checkpoint:
@@ -1007,9 +1019,9 @@ def _export_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
             if _has_markdown_body(markdown, node.title):
                 if args.incremental and args.update_existing and file_path.exists():
                     try:
-                        if file_path.read_text(encoding="utf-8") == markdown:
+                        if file_path.read_text(encoding="utf-8") == markdown and not node_resource_failures:
                             skipped += 1
-                            if checkpoint and not node_resource_failures:
+                            if checkpoint:
                                 checkpoint.upsert_item(item_key, title=node.title, metadata={"docId": node.id, "stage": "completed"})
                                 checkpoint.complete_item(item_key, local_path=str(file_path), metadata={"docId": node.id, "skippedExisting": True})
                             continue

--- a/plugins/xiliu/backend/import_flowus.py
+++ b/plugins/xiliu/backend/import_flowus.py
@@ -70,6 +70,10 @@ MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^\n)]+)\)")
 MARKDOWN_DOC_EXTENSIONS = {".md", ".markdown", ".mdown"}
 
 
+class ImportTaskTerminalFailure(FlowUsError):
+    """Raised only when FlowUs explicitly reports a terminal import failure."""
+
+
 def emit(message: str, *, event: str = "log.message", level: str = "info", **fields: Any) -> None:
     emit_legacy("flowus-import", message, event=event, level=level, **fields)
 
@@ -231,15 +235,21 @@ def create_empty_page(
     parent_id: str,
     title: str,
     after: str | None = None,
+    *,
+    page_id: str = "",
+    request_id: str = "",
+    transaction_id: str = "",
 ) -> str:
-    """Create an empty page block under parent. Returns new page ID."""
-    page_id = generate_uuid()
+    """Create an empty page block under parent using stable client IDs."""
+    page_id = page_id or generate_uuid()
+    request_id = request_id or generate_uuid()
+    transaction_id = transaction_id or generate_uuid()
 
     operations = {
-        "requestId": generate_uuid(),
+        "requestId": request_id,
         "transactions": [
             {
-                "id": generate_uuid(),
+                "id": transaction_id,
                 "spaceId": space_id,
                 "operations": [
                     {
@@ -333,8 +343,18 @@ def upload_html_content(client: FlowUsClient, html_content: str) -> str:
     return oss_name
 
 
-def enqueue_import_task(client: FlowUsClient, block_id: str, space_id: str, oss_name: str) -> str:
-    """Enqueue an import task. Returns task ID."""
+def enqueue_import_task(
+    client: FlowUsClient,
+    block_id: str,
+    space_id: str,
+    oss_name: str,
+    *,
+    request_id: str = "",
+) -> str:
+    """Enqueue an import task with a stable request identifier."""
+    # FlowUs currently returns taskId only in the response and exposes no client-id field.
+    # request_id is persisted locally to identify this uncertain enqueue operation.
+    _ = request_id
     payload = {
         "eventName": "import",
         "request": {
@@ -395,10 +415,10 @@ def poll_task_result(
             if inner.get("status") == "success":
                 return task_result
             msg = inner.get("msg", "未知错误")
-            raise FlowUsError(f"导入任务失败：{msg}")
+            raise ImportTaskTerminalFailure(f"导入任务失败：{msg}")
         elif status in ("failed", "error"):
             msg = task_result.get("result", {}).get("msg", "未知错误")
-            raise FlowUsError(f"导入任务失败：{msg}")
+            raise ImportTaskTerminalFailure(f"导入任务失败：{msg}")
 
         # Still processing, wait
         wait_with_stop(args, interval)
@@ -724,6 +744,55 @@ def fetch_page_blocks(client: FlowUsClient, page_id: str) -> dict[str, Any]:
     if data.get("code") != 200:
         raise FlowUsError(f"获取页面 blocks 失败：{_api_error_msg(data)}")
     return data.get("data", {}).get("blocks", {})
+
+
+def page_exists(client: FlowUsClient, page_id: str) -> bool:
+    """Return page existence; only an explicit not-found response becomes False."""
+    url = DOCS_API.format(doc_id=page_id)
+    referer = f"https://flowus.cn/{page_id}"
+    data = client.get_json(url, referer=referer)
+    code = data.get("code")
+    if code == 200:
+        blocks = data.get("data", {}).get("blocks")
+        if not isinstance(blocks, dict):
+            raise FlowUsError("确认页面是否存在失败：响应中缺少 blocks")
+        return page_id in blocks
+    if str(code) == "404":
+        return False
+    raise FlowUsError(f"确认页面是否存在失败：{_api_error_msg(data)}")
+
+
+def page_has_imported_content(client: FlowUsClient, page_id: str) -> bool:
+    """Return whether an empty import page has received content blocks."""
+    blocks = fetch_page_blocks(client, page_id)
+    page = blocks.get(page_id)
+    if not isinstance(page, dict):
+        raise FlowUsError("确认导入结果失败：响应中缺少目标页面")
+    sub_nodes = page.get("subNodes")
+    if isinstance(sub_nodes, list) and sub_nodes:
+        return True
+    return any(str(block_id) != page_id for block_id in blocks)
+
+
+def poll_page_import_result(
+    client: FlowUsClient,
+    page_id: str,
+    *,
+    timeout: int,
+    interval: float,
+    args: argparse.Namespace | None = None,
+) -> None:
+    """Safely recover an enqueue whose response did not reveal its taskId."""
+    start = time.time()
+    while True:
+        check_stopped(args)
+        if page_has_imported_content(client, page_id):
+            return
+        if time.time() - start > timeout:
+            raise FlowUsError(
+                "导入任务入队结果不确定，且页面尚未出现内容；为避免重复任务，本次不会自动重新入队"
+            )
+        wait_with_stop(args, interval)
 
 
 def create_image_block(
@@ -1208,26 +1277,67 @@ def _ensure_parent_pages(
         parts.append(folder)
         relative = Path(*parts).as_posix()
         item_key = f"xiliu:folder:{relative}"
+        existing = checkpoint_metadata.get(item_key, {})
         metadata = {
-            **checkpoint_metadata.get(item_key, {}),
+            **existing,
             "kind": "folder",
             "relativePath": relative,
             "parentRelative": Path(*parts[:-1]).as_posix() if len(parts) > 1 else "",
             "parentPageId": current_parent,
-            "stage": "listed",
+            "stage": str(existing.get("stage") or "listed"),
         }
         page_id = folder_pages.get(relative) or str(metadata.get("pageId") or "")
-        if checkpoint:
-            checkpoint.upsert_item(item_key, title=folder, parent_key=parent_key, source_id=relative, metadata=metadata)
-        if not page_id:
+        try:
+            if page_id and metadata.get("stage") == "creating-page":
+                check_stopped(args)
+                if page_exists(client, page_id):
+                    metadata["stage"] = "folder-created"
+                else:
+                    create_empty_page(
+                        client, space_id, current_parent, folder,
+                        page_id=page_id, request_id=str(metadata.get("createRequestId") or ""),
+                    transaction_id=str(metadata.get("createTransactionId") or ""),
+                    )
+                    metadata["stage"] = "folder-created"
+            elif not page_id:
+                page_id = generate_uuid()
+                metadata.update({
+                    "pageId": page_id,
+                    "createRequestId": generate_uuid(),
+                    "createTransactionId": generate_uuid(),
+                    "stage": "creating-page",
+                })
+                if checkpoint:
+                    checkpoint.upsert_item(
+                        item_key, title=folder, parent_key=parent_key,
+                        source_id=relative, metadata=metadata,
+                    )
+                    checkpoint.start_item(item_key, "creating-page")
+                check_stopped(args)
+                create_empty_page(
+                    client, space_id, current_parent, folder,
+                    page_id=page_id, request_id=str(metadata["createRequestId"]),
+                transaction_id=str(metadata["createTransactionId"]),
+                )
+                metadata["stage"] = "folder-created"
+
             if checkpoint:
-                checkpoint.start_item(item_key, "create-folder")
-            check_stopped(args)
-            page_id = create_empty_page(client, space_id, current_parent, folder)
-            metadata.update({"pageId": page_id, "stage": "folder-created"})
-            if checkpoint:
-                checkpoint.upsert_item(item_key, title=folder, parent_key=parent_key, source_id=relative, metadata=metadata)
+                checkpoint.upsert_item(
+                    item_key, title=folder, parent_key=parent_key,
+                    source_id=relative, metadata=metadata,
+                )
                 checkpoint.complete_item(item_key, target_id=page_id, metadata=metadata)
+        except Exception as exc:
+            metadata["failureStage"] = str(metadata.get("stage") or "creating-page")
+            if checkpoint:
+                checkpoint.upsert_item(
+                    item_key, title=folder, parent_key=parent_key,
+                    source_id=relative, metadata=metadata,
+                )
+                checkpoint.fail_item(item_key, str(exc))
+            checkpoint_metadata[item_key] = metadata
+            raise
+
         folder_pages[relative] = page_id
         checkpoint_metadata[item_key] = metadata
         current_parent = page_id
@@ -1323,10 +1433,12 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
                 client, checkpoint, args, space_id, parent_id, list(doc["folders"]),
                 folder_pages, checkpoint_metadata,
             )
-            metadata.update({"parentPageId": parent_page_id, "stage": "preparing"})
+            metadata["parentPageId"] = parent_page_id
+            if str(metadata.get("stage") or "") in ("", "listed"):
+                metadata["stage"] = "preparing"
             _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
             if checkpoint:
-                checkpoint.start_item(item_key, "preparing")
+                checkpoint.start_item(item_key, str(metadata.get("stage") or "preparing"))
 
             doc_dir = Path(doc["path"]).parent
             image_count = len(extract_local_images(doc["content"], doc_dir))
@@ -1339,38 +1451,93 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
                 page_id = parent_page_id
                 metadata.update({"pageId": page_id, "stage": "folder-page-reused"})
                 _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
-            elif not page_id:
+            elif page_id and metadata.get("stage") == "creating-page":
                 check_stopped(args)
-                page_id = create_empty_page(client, space_id, parent_page_id, title)
-                metadata.update({"pageId": page_id, "stage": "page-created"})
+                if not page_exists(client, page_id):
+                    create_empty_page(
+                        client, space_id, parent_page_id, title,
+                        page_id=page_id, request_id=str(metadata.get("createRequestId") or ""),
+                    transaction_id=str(metadata.get("createTransactionId") or ""),
+                    )
+                metadata["stage"] = "page-created"
+                _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
+            elif not page_id:
+                page_id = generate_uuid()
+                metadata.update({
+                    "pageId": page_id,
+                    "createRequestId": generate_uuid(),
+                    "createTransactionId": generate_uuid(),
+                    "stage": "creating-page",
+                })
+                _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
+                check_stopped(args)
+                create_empty_page(
+                    client, space_id, parent_page_id, title,
+                    page_id=page_id, request_id=str(metadata["createRequestId"]),
+                transaction_id=str(metadata["createTransactionId"]),
+                )
+                metadata["stage"] = "page-created"
                 _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
 
             task_timeout = int(getattr(args, "task_timeout", 120) or 120)
             task_id = str(metadata.get("taskId") or "")
+            import_confirmed = False
+            if (
+                not task_id
+                and metadata.get("stage") == "enqueueing-import"
+                and metadata.get("enqueueRequestId")
+            ):
+                poll_page_import_result(
+                    client, page_id, timeout=task_timeout, interval=3.0, args=args,
+                )
+                import_confirmed = True
+                metadata["stage"] = "import-confirmed"
+                _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
+
             if task_id:
                 try:
                     poll_task_result(client, task_id, timeout=task_timeout, interval=3.0, args=args)
-                except FlowUsError:
+                except ImportTaskTerminalFailure:
                     metadata.pop("taskId", None)
+                    metadata.pop("enqueueRequestId", None)
                     metadata["stage"] = "task-failed"
                     _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
                     if not is_retry_failed:
                         raise
                     task_id = ""
 
-            if not task_id:
-                check_stopped(args)
-                metadata["stage"] = "uploading-content"
-                _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
-                oss_name = upload_html_content(client, html_content)
+            if not task_id and not import_confirmed:
+                oss_name = str(metadata.get("ossName") or "")
+                if not oss_name:
+                    check_stopped(args)
+                    metadata["stage"] = "uploading-content"
+                    _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
+                    oss_name = upload_html_content(client, html_content)
+                    metadata.update({"ossName": oss_name, "stage": "content-uploaded"})
+                    _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
 
                 check_stopped(args)
-                metadata["stage"] = "enqueueing-import"
+                enqueue_request_id = str(metadata.get("enqueueRequestId") or "") or generate_uuid()
+                metadata.update({
+                    "enqueueRequestId": enqueue_request_id,
+                    "pageId": page_id,
+                    "ossName": oss_name,
+                    "stage": "enqueueing-import",
+                })
                 _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
-                task_id = enqueue_import_task(client, page_id, space_id, oss_name)
+                task_id = enqueue_import_task(
+                    client, page_id, space_id, oss_name, request_id=enqueue_request_id,
+                )
                 metadata.update({"taskId": task_id, "stage": "polling-import"})
                 _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
-                poll_task_result(client, task_id, timeout=task_timeout, interval=3.0, args=args)
+                try:
+                    poll_task_result(client, task_id, timeout=task_timeout, interval=3.0, args=args)
+                except ImportTaskTerminalFailure:
+                    metadata.pop("taskId", None)
+                    metadata.pop("enqueueRequestId", None)
+                    metadata["stage"] = "task-failed"
+                    _persist_import_item(checkpoint, item_key, doc, metadata, parent_key=parent_key)
+                    raise
 
             check_stopped(args)
             update_page_title(client, space_id, page_id, title)
@@ -1382,13 +1549,15 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
                 checkpoint.complete_item(item_key, target_id=page_id, metadata=metadata)
             emit(f"[{index}/{total}] 导入成功: {title}" + (f" (含 {image_count} 张图片)" if image_count else ""))
         except ExportStopped:
-            metadata["stage"] = "stopped"
+            metadata["stopped"] = True
+            metadata["stoppedStage"] = str(metadata.get("stage") or "preparing")
             _persist_import_item(checkpoint, item_key, doc, metadata)
             if checkpoint:
                 checkpoint.fail_item(item_key, "用户已停止当前任务")
             raise
         except Exception as exc:
-            metadata["stage"] = "failed"
+            failure_stage = str(metadata.get("stage") or "preparing")
+            metadata["failureStage"] = failure_stage
             _persist_import_item(checkpoint, item_key, doc, metadata)
             if checkpoint:
                 checkpoint.fail_item(item_key, str(exc))
@@ -1396,7 +1565,7 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
                 "itemKey": item_key,
                 "relativePath": doc["relative"],
                 "title": title,
-                "stage": metadata["stage"],
+                "stage": failure_stage,
                 "pageId": str(metadata.get("pageId") or ""),
                 "error": str(exc),
             }

--- a/plugins/xiliu/plugin.json
+++ b/plugins/xiliu/plugin.json
@@ -3,7 +3,7 @@
   "id": "xiliu",
   "name": "息流",
   "description": "导出/导入 FlowUs (息流) 文档，保留目录结构。",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "tllovesxs",
   "core": { "minVersion": "1.3.2" },
   "entrypoints": {

--- a/tests/test_xiliu_import_idempotency.py
+++ b/tests/test_xiliu_import_idempotency.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND = REPO_ROOT / "plugins" / "xiliu" / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+import import_flowus
+
+
+def target_list() -> list[dict]:
+    return [{
+        "id": "root-page",
+        "name": "Root",
+        "spaceId": "space-1",
+        "spaceName": "Space",
+        "role": "editor",
+    }]
+
+
+def import_args(source: Path, checkpoint: Path, *extra: str):
+    return import_flowus.parse_args([
+        "--source-dir", str(source),
+        "--parent-id", "root-page",
+        "--space-id", "space-1",
+        "--checkpoint-file", str(checkpoint),
+        "--checkpoint-task-id", "xiliu-idempotency-test",
+        *extra,
+    ])
+
+
+def item_metadata(checkpoint: Path, item_key: str) -> tuple[str, dict]:
+    connection = sqlite3.connect(checkpoint)
+    connection.row_factory = sqlite3.Row
+    try:
+        row = connection.execute(
+            "SELECT status, metadata_json FROM items WHERE item_key = ?", (item_key,),
+        ).fetchone()
+        assert row is not None
+        return str(row["status"]), json.loads(str(row["metadata_json"] or "{}"))
+    finally:
+        connection.close()
+
+
+class StatefulImportServer:
+    def __init__(self) -> None:
+        self.args = None
+        self.pages: dict[str, dict] = {
+            "root-page": {"id": "root-page", "title": "Root", "parentId": ""},
+        }
+        self.page_request_calls = 0
+        self.page_requests: list[dict[str, str]] = []
+        self.page_lookup_calls = 0
+        self.upload_calls = 0
+        self.enqueue_calls = 0
+        self.tasks_by_request: dict[str, str] = {}
+        self.task_status_calls = 0
+        self.create_timeout_title = ""
+        self.create_timeout_fired = False
+        self.create_fail_before_write_title = ""
+        self.create_fail_before_write_fired = False
+        self.enqueue_timeout_once = False
+        self.enqueue_timeout_fired = False
+        self.processing_once = False
+
+    def get_json(self, url: str, **_kwargs):
+        self.page_lookup_calls += 1
+        page_id = url.rstrip("/").rsplit("/", 1)[-1]
+        if page_id in self.pages:
+            return {"code": 200, "data": {"blocks": {page_id: self.pages[page_id]}}}
+        return {"code": 404, "msg": "not found"}
+
+    def request(self, method: str, url: str, data=None, **_kwargs) -> bytes:
+        del method
+        if url == import_flowus.BLOCKS_TRANSACTIONS_API:
+            operations = data["transactions"][0]["operations"]
+            create = next((op for op in operations if op.get("command") == "set"), None)
+            if create is not None:
+                self.page_request_calls += 1
+                args = create["args"]
+                page_id = str(create["id"])
+                title = str(args.get("data", {}).get("segments", [{}])[0].get("text", ""))
+                self.page_requests.append({
+                    "pageId": page_id,
+                    "requestId": str(data.get("requestId") or ""),
+                    "transactionId": str(data["transactions"][0].get("id") or ""),
+                    "title": title,
+                })
+                if title == self.create_fail_before_write_title and not self.create_fail_before_write_fired:
+                    self.create_fail_before_write_fired = True
+                    raise import_flowus.FlowUsError("创建请求发送失败且服务端未写入")
+                self.pages.setdefault(page_id, {
+                    "id": page_id,
+                    "title": title,
+                    "parentId": str(args.get("parentId") or ""),
+                })
+                if title == self.create_timeout_title and not self.create_timeout_fired:
+                    self.create_timeout_fired = True
+                    raise import_flowus.FlowUsError("创建成功后的响应超时")
+            return json.dumps({"code": 200, "data": {}}).encode()
+
+        if url.startswith(import_flowus.IMPORT_TEMP_FILE_API):
+            self.upload_calls += 1
+            return json.dumps({
+                "code": 200,
+                "data": {"ossName": "oss/import-content.html"},
+            }).encode()
+
+        if url == import_flowus.ENQUEUE_TASK_API:
+            self.enqueue_calls += 1
+            task_id = f"task-{len(self.tasks_by_request) + 1}"
+            self.tasks_by_request[task_id] = task_id
+            block_id = str(data["request"]["blockId"])
+            self.pages[block_id]["subNodes"] = ["imported-block"]
+            if self.enqueue_timeout_once and not self.enqueue_timeout_fired:
+                self.enqueue_timeout_fired = True
+                raise import_flowus.FlowUsError("入队成功后的响应超时")
+            return json.dumps({"code": 200, "data": {"taskId": task_id}}).encode()
+
+        if url == import_flowus.GET_TASKS_API:
+            self.task_status_calls += 1
+            task_id = str(data["taskIds"][0])
+            if self.processing_once and self.task_status_calls == 1:
+                task = {"status": "processing", "result": {}}
+            else:
+                task = {"status": "success", "result": {"status": "success"}}
+            return json.dumps({
+                "code": 200,
+                "data": {"results": {task_id: task}},
+            }).encode()
+
+        raise AssertionError(f"unexpected request: {url}")
+
+
+class XiliuImportIdempotencyTests(unittest.TestCase):
+    def run_import(self, server: StatefulImportServer, args):
+        with (
+            patch.object(import_flowus, "FlowUsClient", lambda *_: server),
+            patch.object(import_flowus, "list_import_targets", lambda _client: target_list()),
+        ):
+            return import_flowus.import_flowus(args)
+
+    def test_document_create_response_timeout_reuses_created_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            source.mkdir()
+            (source / "doc.md").write_text("# Doc\ncontent", encoding="utf-8")
+            checkpoint = root / "checkpoint.sqlite"
+            server = StatefulImportServer()
+            server.create_timeout_title = "Doc"
+
+            first = self.run_import(server, import_args(source, checkpoint, "--resume"))
+            second = self.run_import(server, import_args(source, checkpoint, "--resume"))
+
+            self.assertEqual(first["outcome"], "partial")
+            self.assertEqual(second["outcome"], "completed")
+            created = [page for key, page in server.pages.items() if key != "root-page"]
+            self.assertEqual([page["title"] for page in created], ["Doc"])
+            self.assertEqual(server.page_request_calls, 1)
+            self.assertEqual(server.page_lookup_calls, 1)
+            status, metadata = item_metadata(checkpoint, "xiliu:import:doc.md")
+            self.assertEqual(status, "completed")
+            self.assertEqual(metadata["stage"], "completed")
+            self.assertTrue(metadata["pageId"])
+            self.assertTrue(metadata["createRequestId"])
+            self.assertTrue(metadata["createTransactionId"])
+
+    def test_create_request_failure_reuses_ids_before_recreating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            source.mkdir()
+            (source / "doc.md").write_text("# Doc\ncontent", encoding="utf-8")
+            checkpoint = root / "checkpoint.sqlite"
+            server = StatefulImportServer()
+            server.create_fail_before_write_title = "Doc"
+
+            first = self.run_import(server, import_args(source, checkpoint, "--resume"))
+            failed_status, failed_metadata = item_metadata(checkpoint, "xiliu:import:doc.md")
+            second = self.run_import(server, import_args(source, checkpoint, "--resume"))
+
+            self.assertEqual(first["outcome"], "partial")
+            self.assertEqual(failed_status, "failed")
+            self.assertEqual(failed_metadata["stage"], "creating-page")
+            self.assertEqual(second["outcome"], "completed")
+            self.assertEqual(server.page_request_calls, 2)
+            self.assertEqual(server.page_lookup_calls, 1)
+            self.assertEqual(len(server.pages) - 1, 1)
+            first_request, second_request = server.page_requests
+            self.assertEqual(first_request["pageId"], second_request["pageId"])
+            self.assertEqual(first_request["requestId"], second_request["requestId"])
+            self.assertEqual(first_request["transactionId"], second_request["transactionId"])
+
+    def test_enqueue_response_timeout_reuses_upload_and_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            source.mkdir()
+            (source / "doc.md").write_text("# Doc\ncontent", encoding="utf-8")
+            checkpoint = root / "checkpoint.sqlite"
+            server = StatefulImportServer()
+            server.enqueue_timeout_once = True
+
+            first = self.run_import(server, import_args(source, checkpoint, "--resume"))
+            _status, failed_metadata = item_metadata(checkpoint, "xiliu:import:doc.md")
+            second = self.run_import(server, import_args(source, checkpoint, "--resume"))
+
+            self.assertEqual(first["outcome"], "partial")
+            self.assertEqual(second["outcome"], "completed")
+            self.assertEqual(server.upload_calls, 1)
+            self.assertEqual(server.enqueue_calls, 1)
+            self.assertEqual(len(server.tasks_by_request), 1)
+            self.assertTrue(failed_metadata["enqueueRequestId"])
+
+    def test_poll_timeout_resume_keeps_task_and_does_not_reenqueue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            source.mkdir()
+            (source / "doc.md").write_text("# Doc\ncontent", encoding="utf-8")
+            checkpoint = root / "checkpoint.sqlite"
+            server = StatefulImportServer()
+            server.processing_once = True
+
+            with patch.object(import_flowus, "wait_with_stop", lambda _args, _seconds: time.sleep(1.05)):
+                first = self.run_import(
+                    server, import_args(source, checkpoint, "--resume", "--task-timeout", "1"),
+                )
+            failed_status, failed_metadata = item_metadata(checkpoint, "xiliu:import:doc.md")
+            second = self.run_import(server, import_args(source, checkpoint, "--resume"))
+
+            self.assertEqual(first["outcome"], "partial")
+            self.assertEqual(failed_status, "failed")
+            self.assertEqual(failed_metadata["stage"], "polling-import")
+            self.assertTrue(failed_metadata["taskId"])
+            self.assertEqual(second["outcome"], "completed")
+            self.assertEqual(server.upload_calls, 1)
+            self.assertEqual(server.enqueue_calls, 1)
+            self.assertEqual(len(server.tasks_by_request), 1)
+
+    def test_folder_create_response_timeout_reuses_folder_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            folder = source / "A"
+            folder.mkdir(parents=True)
+            (folder / "doc.md").write_text("# Doc\ncontent", encoding="utf-8")
+            checkpoint = root / "checkpoint.sqlite"
+            server = StatefulImportServer()
+            server.create_timeout_title = "A"
+
+            first = self.run_import(server, import_args(source, checkpoint, "--resume"))
+            second = self.run_import(server, import_args(source, checkpoint, "--resume"))
+
+            self.assertEqual(first["outcome"], "partial")
+            self.assertEqual(second["outcome"], "completed")
+            created = [page for key, page in server.pages.items() if key != "root-page"]
+            self.assertEqual(sorted(page["title"] for page in created), ["A", "Doc"])
+            self.assertEqual(server.page_request_calls, 2)
+            self.assertEqual(server.page_lookup_calls, 1)
+            folder_status, folder_metadata = item_metadata(checkpoint, "xiliu:folder:A")
+            self.assertEqual(folder_status, "completed")
+            self.assertEqual(folder_metadata["stage"], "folder-created")
+            doc = next(page for page in created if page["title"] == "Doc")
+            folder_page = next(page for page in created if page["title"] == "A")
+            self.assertEqual(doc["parentId"], folder_page["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xiliu_reliability.py
+++ b/tests/test_xiliu_reliability.py
@@ -7,6 +7,7 @@ import tempfile
 import threading
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -72,8 +73,8 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
             created: list[tuple[str, str, str]] = []
             uploads = {"count": 0}
 
-            def create_page(_client, _space, parent, title):
-                page_id = f"page-{len(created) + 1}"
+            def create_page(_client, _space, parent, title, **kwargs):
+                page_id = kwargs["page_id"]
                 created.append((parent, title, page_id))
                 return page_id
 
@@ -88,7 +89,7 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
                 patch.object(import_flowus, "list_import_targets", lambda _client: target_list()),
                 patch.object(import_flowus, "create_empty_page", create_page),
                 patch.object(import_flowus, "upload_html_content", upload),
-                patch.object(import_flowus, "enqueue_import_task", lambda *_: "task-1"),
+                patch.object(import_flowus, "enqueue_import_task", lambda *_, **_kwargs: "task-1"),
                 patch.object(import_flowus, "poll_task_result", lambda *_args, **_kwargs: {"status": "success"}),
                 patch.object(import_flowus, "update_page_title", lambda *_: None),
             )
@@ -124,15 +125,16 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
             uploads = {"count": 0}
             enqueues = {"count": 0}
 
-            def create_page(*_args):
-                created.append("page-1")
-                return "page-1"
+            def create_page(*_args, **kwargs):
+                page_id = kwargs["page_id"]
+                created.append(page_id)
+                return page_id
 
             def upload(*_args):
                 uploads["count"] += 1
                 return "oss/content.html"
 
-            def enqueue(*_args):
+            def enqueue(*_args, **_kwargs):
                 enqueues["count"] += 1
                 return "task-1"
 
@@ -151,7 +153,9 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
             with patch.object(import_flowus, "FlowUsClient", lambda *_: FakeClient()),                  patch.object(import_flowus, "list_import_targets", lambda _client: target_list()),                  patch.object(import_flowus, "create_empty_page", create_page),                  patch.object(import_flowus, "upload_html_content", upload),                  patch.object(import_flowus, "enqueue_import_task", enqueue),                  patch.object(import_flowus, "poll_task_result", lambda *_args, **_kwargs: {"status": "success"}),                  patch.object(import_flowus, "update_page_title", lambda *_: None):
                 resumed = import_flowus.import_flowus(import_args(source, checkpoint, "--resume"))
             self.assertEqual(resumed["outcome"], "completed")
-            self.assertEqual(created, ["page-1"])
+            self.assertEqual(len(created), 1)
+            resumed_item = checkpoint_rows(checkpoint, "items")[0]
+            self.assertEqual(resumed_item["target_id"], created[0])
             self.assertEqual(uploads["count"], 1)
             self.assertEqual(enqueues["count"], 1)
 
@@ -165,8 +169,8 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
             checkpoint = root / "checkpoint.sqlite"
             created: list[tuple[str, str, str]] = []
 
-            def create_page(_client, _space, parent, title):
-                page_id = f"page-{len(created) + 1}"
+            def create_page(_client, _space, parent, title, **kwargs):
+                page_id = kwargs["page_id"]
                 created.append((parent, title, page_id))
                 return page_id
 
@@ -175,19 +179,21 @@ class XiliuImportCheckpointBehaviorTests(unittest.TestCase):
                 patch.object(import_flowus, "list_import_targets", lambda _client: target_list()),
                 patch.object(import_flowus, "create_empty_page", create_page),
                 patch.object(import_flowus, "upload_html_content", lambda *_: "oss/content.html"),
-                patch.object(import_flowus, "enqueue_import_task", lambda *_: "task-1"),
+                patch.object(import_flowus, "enqueue_import_task", lambda *_, **_kwargs: "task-1"),
                 patch.object(import_flowus, "poll_task_result", lambda *_args, **_kwargs: {"status": "success"}),
                 patch.object(import_flowus, "update_page_title", lambda *_: None),
             ):
                 result = import_flowus.import_flowus(import_args(source, checkpoint, "--resume"))
 
             self.assertEqual(result["outcome"], "completed")
-            self.assertEqual(created, [("root-page", "A", "page-1")])
+            self.assertEqual(len(created), 1)
+            self.assertEqual(created[0][:2], ("root-page", "A"))
+            page_id = created[0][2]
             items = {row["item_key"]: row for row in checkpoint_rows(checkpoint, "items")}
             folder_item = items["xiliu:folder:A"]
             doc_key = next(key for key in items if key.startswith("xiliu:import:A"))
-            self.assertEqual(folder_item["target_id"], "page-1")
-            self.assertEqual(items[doc_key]["target_id"], "page-1")
+            self.assertEqual(folder_item["target_id"], page_id)
+            self.assertEqual(items[doc_key]["target_id"], page_id)
 
     def test_import_requires_an_explicit_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -277,7 +283,93 @@ class XiliuExportReliabilityTests(unittest.TestCase):
             with patch.object(export_xiliu, "FlowUsClient", lambda *_: FakeClient()),                  patch.object(export_xiliu, "build_toc_tree", lambda *_args, **_kwargs: collision_nodes):
                 export_xiliu.export_flowus(args)
             files = sorted(path.name for path in (collision_output / "Root").glob("A-B*.md"))
-            self.assertEqual(files, ["A-B-doc-one.md", "A-B-doc-two.md"])
+            collision_components = export_xiliu._stable_output_components(collision_nodes)
+            self.assertEqual(
+                files,
+                sorted([
+                    f"{collision_components['doc-one']}.md",
+                    f"{collision_components['doc-two']}.md",
+                ]),
+            )
+
+    def test_collision_paths_do_not_overwrite_ids_with_the_same_12_character_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            first_id = "123456789012-alpha"
+            second_id = "123456789012-beta"
+            nodes = [
+                export_xiliu.FlowUsNode("root", "Root", True),
+                export_xiliu.FlowUsNode(first_id, "A/B", False, parent_id="root"),
+                export_xiliu.FlowUsNode(second_id, "A:B", False, parent_id="root"),
+            ]
+            args = export_xiliu.parse_args([
+                "--doc-url", "https://flowus.cn/root", "--output", str(output),
+            ])
+            with (
+                patch.object(export_xiliu, "FlowUsClient", lambda *_: FakeClient()),
+                patch.object(export_xiliu, "build_toc_tree", lambda *_args, **_kwargs: nodes),
+            ):
+                result = export_xiliu.export_flowus(args)
+
+            files = sorted((output / "Root").glob("A-B*.md"))
+            self.assertEqual(result["exported"], 3)
+            self.assertEqual(len(files), 2)
+            self.assertEqual(len({path.name.casefold() for path in files}), 2)
+            contents = {path.read_text(encoding="utf-8").strip() for path in files}
+            self.assertEqual(contents, {f"# {first_id}", f"# {second_id}"})
+            self.assertEqual(
+                export_xiliu._stable_output_components(nodes),
+                export_xiliu._stable_output_components(list(reversed(nodes))),
+            )
+
+    def test_image_download_checks_stop_before_each_request(self) -> None:
+        calls: list[str] = []
+
+        class ImageClient:
+            args = SimpleNamespace()
+
+            def request(self, method, *_args, **_kwargs):
+                calls.append(method)
+                return json.dumps({"code": 200, "data": [{"url": "https://example.test/image.png"}]}).encode()
+
+        client = ImageClient()
+        with patch.object(export_xiliu, "check_stopped", side_effect=ExportStopped("controlled stop")):
+            with self.assertRaises(ExportStopped):
+                export_xiliu.download_image_data(client, "block", "oss/image.png")
+        self.assertEqual(calls, [])
+
+        calls.clear()
+        with patch.object(
+            export_xiliu,
+            "check_stopped",
+            side_effect=[None, None, ExportStopped("controlled stop before image GET")],
+        ):
+            with self.assertRaises(ExportStopped):
+                export_xiliu.download_image_data(client, "block", "oss/image.png")
+        self.assertEqual(calls, ["POST"])
+
+    def test_throttle_and_retry_backoff_use_wait_with_stop(self) -> None:
+        args = SimpleNamespace(request_delay=1.25, request_jitter=0, retry=2)
+        client = export_xiliu.FlowUsClient.__new__(export_xiliu.FlowUsClient)
+        client.args = args
+        client.request_count = 0
+        client.token = "token"
+        client.cookies = []
+
+        with (
+            patch.object(export_xiliu, "wait_with_stop") as wait,
+            patch.object(
+                export_xiliu.urllib.request,
+                "urlopen",
+                side_effect=export_xiliu.urllib.error.URLError("controlled network failure"),
+            ),
+        ):
+            with self.assertRaises(export_xiliu.FlowUsError):
+                client.request("GET", "https://example.test/data")
+
+        self.assertEqual(wait.call_args_list[0].args, (args, 1.25))
+        self.assertEqual(wait.call_args_list[1].args, (args, 0.8))
+        self.assertEqual(wait.call_count, 2)
 
     def test_root_failure_is_fatal_and_child_failure_is_structured(self) -> None:
         with self.assertRaisesRegex(export_xiliu.FlowUsError, "读取根目录失败"):
@@ -408,34 +500,62 @@ class XiliuExportReliabilityTests(unittest.TestCase):
             completed = {row["item_key"]: row for row in checkpoint_rows(checkpoint, "items")}
             self.assertEqual(completed["xiliu:doc:child"]["status"], "completed")
 
-    def test_image_failure_marks_document_retryable_and_retry_completes(self) -> None:
+    def test_incremental_retry_failed_restores_image_and_completes_checkpoint(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             checkpoint = root / "checkpoint.sqlite"
             output = root / "out"
             node = export_xiliu.FlowUsNode("doc", "Doc", False)
-            calls = {"count": 0}
+            documents = {
+                "doc": {
+                    "code": 200,
+                    "data": {"blocks": {
+                        "doc": {
+                            "type": 0,
+                            "title": "Doc",
+                            "data": {"segments": [{"type": 0, "text": "Doc", "enhancer": {}}]},
+                            "subNodes": ["image"],
+                        },
+                        "image": {
+                            "type": 14,
+                            "data": {"ossName": "oss/image.png", "segments": []},
+                            "subNodes": [],
+                        },
+                    }},
+                },
+            }
+            downloads = {"count": 0}
 
-            def convert(*_args):
-                calls["count"] += 1
-                if calls["count"] == 1:
-                    return "# Doc\n\n![image](图片下载失败)", 1, [{"url": "oss/image.png", "error": "controlled image failure"}]
-                return "# Doc\n\n![image](images/image.png)", 1, []
+            def download(*_args):
+                downloads["count"] += 1
+                return None if downloads["count"] == 1 else b"restored-image"
 
             def run(extra: list[str]):
                 args = export_xiliu.parse_args([
                     "--doc-url", "https://flowus.cn/doc", "--output", str(output),
                     "--checkpoint-file", str(checkpoint), "--checkpoint-task-id", "xiliu-export-test", *extra,
                 ])
-                with patch.object(export_xiliu, "FlowUsClient", lambda *_: FakeClient()),                      patch.object(export_xiliu, "build_toc_tree", lambda *_args, **_kwargs: [node]),                      patch.object(export_xiliu, "convert_flowus_blocks_to_markdown", convert):
+                with (
+                    patch.object(export_xiliu, "FlowUsClient", lambda *_: FakeClient(documents)),
+                    patch.object(export_xiliu, "build_toc_tree", lambda *_args, **_kwargs: [node]),
+                    patch.object(export_xiliu, "download_image_data", download),
+                ):
                     return export_xiliu.export_flowus(args)
 
             first = run(["--resume"])
-            second = run(["--retry-failed"])
+            placeholder = (output / "Doc.md").read_text(encoding="utf-8")
+            second = run(["--incremental", "--retry-failed"])
+            restored = (output / "Doc.md").read_text(encoding="utf-8")
+
             self.assertEqual(first["outcome"], "partial")
             self.assertEqual(first["resourceFailureCount"], 1)
+            self.assertIn("图片下载失败: oss/image.png", placeholder)
             self.assertEqual(second["outcome"], "completed")
             self.assertEqual(second["resourceFailureCount"], 0)
+            self.assertEqual(downloads["count"], 2)
+            self.assertIn("assets/001-image.png", restored)
+            self.assertNotIn("图片下载失败", restored)
+            self.assertEqual((output / "assets" / "001-image.png").read_bytes(), b"restored-image")
             self.assertEqual(checkpoint_rows(checkpoint, "items")[0]["status"], "completed")
             self.assertEqual(second["kind"], "wandao.result")
 


### PR DESCRIPTION
## 补充/修复 #60

这是基于最新 `main`（`bb2792a`）的后续修复 PR，补充已合并 PR #60 中遗漏的 FlowUs（息流）可靠性整改。

### 变更摘要

- 导入页面/文件夹创建前持久化稳定 `pageId`、请求 ID、事务 ID；恢复先查询页面，避免超时后重复创建。
- 已知 `taskId` 的轮询超时或查询异常会保留任务，不重复入队；入队响应不确定且没有 taskId 时轮询目标页面结果，避免盲目重复任务。
- 修复 `--incremental --retry-failed` 跳过失败 Markdown 的问题，图片失败可重试补齐并完成 checkpoint。
- 导出等待、退避和图片请求支持全局停止；输出路径冲突使用完整 SHA-256，避免覆盖。

### 验证结果

```text
python -m unittest discover -s tests -p test_xiliu_reliability.py
Ran 13 tests
OK

python -m unittest discover -s tests -p test_xiliu_import_idempotency.py
Ran 5 tests
OK

python -m unittest discover -s tests -p test_xiliu_plugin.py
Ran 151 tests
OK (skipped=1)

python scripts/quality_check.py
Quality check passed.
```

按约定，本 PR 未处理外部图片请求携带 Cookie/Bearer Token 问题。