### PR TITLE
fix(onenote): restore checkpoint export metadata

### DIFF
--- a/plugins/onenote/backend/export_onenote.py
+++ b/plugins/onenote/backend/export_onenote.py
@@ -799,10 +799,16 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
             checkpoint.upsert_item(
                 f"onenote:page:{page.id}",
                 title=page.title,
-                source_url=page.path,
+                source_url="/".join(page.path_parts),
                 source_id=page.id,
-                parent_key=page.parent_id,
-                metadata={"id": page.id, "path": page.path, "level": page.level},
+                parent_key=page.parent_node_id,
+                metadata={
+                    "id": page.id,
+                    "path": page.path_parts,
+                    "level": page.page_level,
+                    "parentNodeId": page.parent_node_id,
+                    "sectionId": page.section_id,
+                },
             )
         if getattr(args, "retry_failed", False):
             selected = [page for page in selected if checkpoint.item_status(f"onenote:page:{page.id}") == "failed"]

--- a/plugins/onenote/plugin.json
+++ b/plugins/onenote/plugin.json
@@ -4,7 +4,7 @@
   "id": "onenote",
   "name": "OneNote",
   "description": "Windows 桌面版 OneNote 本地 Markdown 导出。",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "Wandao Official",
   "homepage": "https://www.onenote.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_onenote_checkpoint_contract.py
+++ b/tests/test_onenote_checkpoint_contract.py
@@ -1,0 +1,79 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from plugins.onenote.backend import export_onenote as onenote
+
+
+class _Checkpoint:
+    def __init__(self) -> None:
+        self.upserts: list[tuple[str, dict]] = []
+        self.completed_task = None
+        self.closed = False
+
+    def start_task(self, _metadata):
+        return None
+
+    def upsert_item(self, item_key, **kwargs):
+        self.upserts.append((item_key, kwargs))
+
+    def item_status(self, _item_key):
+        return "completed"
+
+    def complete_task(self, report):
+        self.completed_task = report
+
+    def stats(self):
+        return {"items": {"completed": 1}}
+
+    def close(self):
+        self.closed = True
+
+
+class OneNoteCheckpointContractTests(unittest.TestCase):
+    def test_checkpoint_uses_current_toc_node_fields_before_resume_skip(self):
+        page = onenote.TocNode(
+            id="page-id",
+            node_id="onenote-page:page-id",
+            type="page",
+            title="Page",
+            parent_node_id="onenote-section:section-id",
+            selectable=True,
+            order=1,
+            path_parts=["Notebook", "Section"],
+            page_level=2,
+            section_id="section-id",
+        )
+        checkpoint = _Checkpoint()
+        with tempfile.TemporaryDirectory() as tmp:
+            args = onenote.parse_args([
+                "--output", str(Path(tmp) / "export"),
+                "--doc-id", page.id,
+                "--resume",
+            ])
+            with mock.patch.object(onenote, "open_checkpoint_from_args", return_value=checkpoint):
+                report = onenote.export_onenote(args, [page], [page])
+
+        self.assertEqual(report["exported"], 0)
+        self.assertEqual(report["skipped"], 1)
+        self.assertTrue(checkpoint.closed)
+        self.assertEqual(len(checkpoint.upserts), 1)
+        item_key, item = checkpoint.upserts[0]
+        self.assertEqual(item_key, "onenote:page:page-id")
+        self.assertEqual(item["source_url"], "Notebook/Section")
+        self.assertEqual(item["parent_key"], "onenote-section:section-id")
+        self.assertEqual(
+            item["metadata"],
+            {
+                "id": "page-id",
+                "path": ["Notebook", "Section"],
+                "level": 2,
+                "parentNodeId": "onenote-section:section-id",
+                "sectionId": "section-id",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容

修复 OneNote 导出在创建断点任务时读取已废弃 `TocNode` 字段的问题，并将插件版本提升至 `1.0.2`。

目录扫描已使用 `path_parts`、`parent_node_id`、`page_level`，但导出入口仍读取旧的 `path`、`parent_id`、`level`，导致目录读取成功后，一点击导出就报 `TocNode object has no attribute path`。

现在断点元数据统一使用当前节点字段：目录路径、父节点 ID、页面层级和分区 ID。

## 验证

- 新增回归测试，覆盖断点记录和“继续任务时跳过已完成页面”的路径。
- 在本机真实 OneNote 中完成单页导出：MHT 生成、Markdown 转换、图片处理、断点记录均成功，0 失败。
- `python scripts/quality_check.py` 通过：Python 503 项、Node 100 项。
- `node scripts/validate_plugins.js` 通过。