### PR TITLE
fix(onenote): isolate publish failures

### DIFF
--- a/plugins/onenote/backend/export_onenote.py
+++ b/plugins/onenote/backend/export_onenote.py
@@ -10,6 +10,7 @@ in Python.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import html
 import json
@@ -43,11 +44,39 @@ FORBIDDEN_FILENAME_CHARS = r'<>:"/\|?*'
 CSHARP_BRIDGE_SOURCE = r'''
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using Microsoft.Office.Interop.OneNote;
 
 public static class WandaoOneNoteBridge
 {
+    private const int RpcCallFailed = unchecked((int)0x800706BE);
+
+    private static bool HasPublishedFile(string outputPath)
+    {
+        return File.Exists(outputPath) && new FileInfo(outputPath).Length > 0;
+    }
+
+    private static void ReleaseApplication(Application app)
+    {
+        if (app != null && Marshal.IsComObject(app))
+        {
+            Marshal.FinalReleaseComObject(app);
+        }
+    }
+
+    private static string EncodeMessage(Exception ex)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(ex.Message ?? ex.ToString()));
+    }
+
+    private static void WritePublishResult(string pageId, string status, Exception error = null)
+    {
+        string message = error == null ? "" : EncodeMessage(error);
+        Console.WriteLine("publish-result\t" + pageId + "\t" + status + "\t" + message);
+    }
+
     public static int Main(string[] args)
     {
         try
@@ -58,18 +87,26 @@ public static class WandaoOneNoteBridge
                 return 2;
             }
 
-            var app = new Application();
             if (args[0] == "hierarchy")
             {
-                string xml;
-                app.GetHierarchy(null, HierarchyScope.hsPages, out xml, XMLSchema.xs2013);
-                File.WriteAllText(args[1], xml, new UTF8Encoding(false));
+                var app = new Application();
+                try
+                {
+                    string xml;
+                    app.GetHierarchy(null, HierarchyScope.hsPages, out xml, XMLSchema.xs2013);
+                    File.WriteAllText(args[1], xml, new UTF8Encoding(false));
+                }
+                finally
+                {
+                    ReleaseApplication(app);
+                }
                 return 0;
             }
 
             if (args[0] == "publish-list")
             {
                 int index = 0;
+                Application app = null;
                 foreach (string rawLine in File.ReadLines(args[1], Encoding.UTF8))
                 {
                     if (String.IsNullOrWhiteSpace(rawLine)) continue;
@@ -80,8 +117,64 @@ public static class WandaoOneNoteBridge
                     Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                     index++;
                     Console.WriteLine("publish\t" + index + "\t" + outputPath);
-                    app.Publish(pageId, outputPath, PublishFormat.pfMHTML, "");
+                    try
+                    {
+                        if (File.Exists(outputPath)) File.Delete(outputPath);
+                        if (app == null) app = new Application();
+                        app.Publish(pageId, outputPath, PublishFormat.pfMHTML, "");
+                        if (!HasPublishedFile(outputPath))
+                        {
+                            throw new Exception("OneNote Publish returned without creating an MHT file.");
+                        }
+                        WritePublishResult(pageId, "ok");
+                    }
+                    catch (COMException ex)
+                    {
+                        if (ex.ErrorCode != RpcCallFailed)
+                        {
+                            ReleaseApplication(app);
+                            app = null;
+                            WritePublishResult(pageId, "failed", ex);
+                            continue;
+                        }
+                        if (HasPublishedFile(outputPath))
+                        {
+                            ReleaseApplication(app);
+                            app = null;
+                            WritePublishResult(pageId, "recovered-output", ex);
+                            continue;
+                        }
+
+                        try
+                        {
+                            if (File.Exists(outputPath)) File.Delete(outputPath);
+                            ReleaseApplication(app);
+                            app = null;
+                            Console.WriteLine("publish-retry\t" + index + "\t" + pageId);
+                            Thread.Sleep(3000);
+                            app = new Application();
+                            app.Publish(pageId, outputPath, PublishFormat.pfMHTML, "");
+                            if (!HasPublishedFile(outputPath))
+                            {
+                                throw new Exception("OneNote Publish retry returned without creating an MHT file.");
+                            }
+                            WritePublishResult(pageId, "retried", ex);
+                        }
+                        catch (Exception retryEx)
+                        {
+                            ReleaseApplication(app);
+                            app = null;
+                            WritePublishResult(pageId, "failed", retryEx);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        ReleaseApplication(app);
+                        app = null;
+                        WritePublishResult(pageId, "failed", ex);
+                    }
                 }
+                ReleaseApplication(app);
                 return 0;
             }
 
@@ -776,6 +869,49 @@ def write_publish_list(items: list[tuple[TocNode, Path]], path: Path) -> None:
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
+def parse_publish_results(output: str) -> dict[str, dict[str, str]]:
+    results: dict[str, dict[str, str]] = {}
+    for line in output.splitlines():
+        parts = line.split("\t", 3)
+        if len(parts) < 3 or parts[0] != "publish-result":
+            continue
+        page_id, status = parts[1], parts[2]
+        encoded_message = parts[3] if len(parts) > 3 else ""
+        try:
+            message = base64.b64decode(encoded_message, validate=True).decode("utf-8", errors="replace") if encoded_message else ""
+        except (ValueError, UnicodeError):
+            message = "OneNote bridge returned an invalid diagnostic payload."
+        results[page_id] = {"status": status, "message": message}
+    return results
+
+
+def publish_mht_items(
+    items: list[tuple[TocNode, Path]],
+    list_path: Path,
+    *,
+    helper_dir: Path | None,
+) -> dict[str, dict[str, str]]:
+    try:
+        for _page, mht_path in items:
+            if mht_path.exists():
+                mht_path.unlink()
+        write_publish_list(items, list_path)
+        output = run_bridge(["publish-list", str(list_path)], helper_dir=helper_dir, stream=True)
+    except (ExportError, OSError) as exc:
+        return {page.id: {"status": "failed", "message": str(exc)} for page, _mht in items}
+
+    results = parse_publish_results(output)
+    for page, _mht in items:
+        results.setdefault(
+            page.id,
+            {
+                "status": "failed",
+                "message": "OneNote bridge ended before reporting the page publish result.",
+            },
+        )
+    return results
+
+
 def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[TocNode]) -> dict[str, Any]:
     output = Path(args.output).expanduser().resolve() if args.output else default_output_dir()
     output.mkdir(parents=True, exist_ok=True)
@@ -862,38 +998,70 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
 
         if publish_items:
             list_path = mht_root / "publish-list.tsv"
-            write_publish_list(publish_items, list_path)
             emit(f"开始调用 OneNote 导出 MHT：{len(publish_items)} 篇")
-            run_bridge(["publish-list", str(list_path)], helper_dir=helper_dir, stream=True)
+            for page, _mht_path in publish_items:
+                if checkpoint:
+                    checkpoint.start_item(f"onenote:page:{page.id}", "publish")
+            publish_results = publish_mht_items(publish_items, list_path, helper_dir=helper_dir)
+        else:
+            publish_results = {}
 
         mht_by_id = {page.id: mht for page, mht in publish_items}
         total = len(targets)
         for index, (page, md_path) in enumerate(targets, start=1):
             item_key = f"onenote:page:{page.id}"
+            publish_result = publish_results.get(page.id, {"status": "failed", "message": "Missing OneNote publish result."})
+            if publish_result["status"] == "failed":
+                error_message = publish_result["message"] or "OneNote did not create an MHT file for this page."
+                if checkpoint:
+                    checkpoint.fail_item(item_key, error_message)
+                failures.append({
+                    "id": page.id,
+                    "title": page.title,
+                    "path": str(md_path),
+                    "stage": "publish",
+                    "error": error_message,
+                })
+                emit(
+                    f"OneNote 页面 MHT 导出失败，已跳过并继续后续页面：{page.title}：{error_message}",
+                    event="document.export.failed",
+                    level="error",
+                    doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                    error={"type": "OneNotePublishError", "message": error_message},
+                )
+            else:
+                if publish_result["status"] in {"recovered-output", "retried"}:
+                    emit(
+                        f"OneNote 页面发布已恢复：{page.title}（{publish_result['status']}）",
+                        event="document.export.recovered",
+                        level="warn",
+                        doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                    )
             try:
-                if checkpoint:
-                    checkpoint.start_item(item_key, "convert")
-                emit(
-                    f"开始转换 OneNote 页面：{page.title}",
-                    event="document.export.started",
-                    doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
-                )
-                stats = convert_mht_to_markdown(mht_by_id[page.id], md_path)
-                image_success += stats["images"]
-                attachment_success += stats["attachments"]
-                exported += 1
-                if checkpoint:
-                    checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"id": page.id})
-                emit(
-                    f"OneNote 页面导出完成：{page.title}",
-                    event="document.export.completed",
-                    doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
-                    stats={
-                        "imageSuccessInDoc": stats["images"],
-                        "attachmentSuccessInDoc": stats["attachments"],
-                        "chars": stats["chars"],
-                    },
-                )
+                if publish_result["status"] != "failed":
+                    if checkpoint:
+                        checkpoint.start_item(item_key, "convert")
+                    emit(
+                        f"开始转换 OneNote 页面：{page.title}",
+                        event="document.export.started",
+                        doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                    )
+                    stats = convert_mht_to_markdown(mht_by_id[page.id], md_path)
+                    image_success += stats["images"]
+                    attachment_success += stats["attachments"]
+                    exported += 1
+                    if checkpoint:
+                        checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"id": page.id})
+                    emit(
+                        f"OneNote 页面导出完成：{page.title}",
+                        event="document.export.completed",
+                        doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                        stats={
+                            "imageSuccessInDoc": stats["images"],
+                            "attachmentSuccessInDoc": stats["attachments"],
+                            "chars": stats["chars"],
+                        },
+                    )
             except Exception as exc:  # noqa: BLE001 - keep exporting other pages.
                 if checkpoint:
                     checkpoint.fail_item(item_key, str(exc))

--- a/plugins/onenote/plugin.json
+++ b/plugins/onenote/plugin.json
@@ -4,7 +4,7 @@
   "id": "onenote",
   "name": "OneNote",
   "description": "Windows 桌面版 OneNote 本地 Markdown 导出。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "Wandao Official",
   "homepage": "https://www.onenote.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_onenote_publish_recovery.py
+++ b/tests/test_onenote_publish_recovery.py
@@ -1,0 +1,123 @@
+import base64
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from plugins.onenote.backend import export_onenote as onenote
+
+
+class _Checkpoint:
+    def __init__(self) -> None:
+        self.failed_items: list[tuple[str, str]] = []
+        self.completed_items: list[str] = []
+        self.started_items: list[tuple[str, str]] = []
+        self.closed = False
+
+    def start_task(self, _metadata):
+        return None
+
+    def upsert_item(self, _item_key, **_kwargs):
+        return None
+
+    def item_status(self, _item_key):
+        return ""
+
+    def start_item(self, item_key, stage):
+        self.started_items.append((item_key, stage))
+
+    def fail_item(self, item_key, error):
+        self.failed_items.append((item_key, error))
+
+    def complete_item(self, item_key, **_kwargs):
+        self.completed_items.append(item_key)
+
+    def stats(self):
+        return {"items": {"completed": len(self.completed_items), "failed": len(self.failed_items)}}
+
+    def fail_task(self, *_args, **_kwargs):
+        return None
+
+    def complete_task(self, _report):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+def _page(page_id: str, title: str) -> onenote.TocNode:
+    return onenote.TocNode(
+        id=page_id,
+        node_id=f"onenote-page:{page_id}",
+        type="page",
+        title=title,
+        parent_node_id="onenote-section:section",
+        selectable=True,
+        order=1,
+        path_parts=["Notebook", "Section"],
+        section_id="section",
+    )
+
+
+class OneNotePublishRecoveryTests(unittest.TestCase):
+    def test_publish_result_parser_decodes_recovery_and_failure_details(self):
+        detail = base64.b64encode("0x800706BE".encode("utf-8")).decode("ascii")
+        results = onenote.parse_publish_results(
+            f"publish-result\tpage-a\tretried\t{detail}\n"
+            f"publish-result\tpage-b\tfailed\t{detail}"
+        )
+
+        self.assertEqual(results["page-a"], {"status": "retried", "message": "0x800706BE"})
+        self.assertEqual(results["page-b"], {"status": "failed", "message": "0x800706BE"})
+
+    def test_failed_publish_is_checkpointed_while_later_page_is_converted(self):
+        failed = _page("failed-page", "Failed")
+        recovered = _page("recovered-page", "Recovered")
+        checkpoint = _Checkpoint()
+
+        def fake_bridge(args, **_kwargs):
+            rows = Path(args[1]).read_text(encoding="utf-8").splitlines()
+            output_lines = []
+            for row in rows:
+                page_id, output_path = row.split("\t", 1)
+                if page_id == failed.id:
+                    detail = base64.b64encode("0x800706BE after retry".encode("utf-8")).decode("ascii")
+                    output_lines.append(f"publish-result\t{page_id}\tfailed\t{detail}")
+                else:
+                    Path(output_path).write_bytes(b"published MHT")
+                    detail = base64.b64encode("0x800706BE recovered".encode("utf-8")).decode("ascii")
+                    output_lines.append(f"publish-result\t{page_id}\tretried\t{detail}")
+            return "\n".join(output_lines)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            args = onenote.parse_args(["--output", str(root / "export")])
+            with mock.patch.object(onenote, "open_checkpoint_from_args", return_value=checkpoint), mock.patch.object(
+                onenote, "run_bridge", side_effect=fake_bridge
+            ), mock.patch.object(
+                onenote, "convert_mht_to_markdown", return_value={"images": 0, "attachments": 0, "chars": 4}
+            ) as convert:
+                report = onenote.export_onenote(args, [failed, recovered], [failed, recovered])
+
+        self.assertEqual(report["exported"], 1)
+        self.assertEqual(len(report["failures"]), 1)
+        self.assertEqual(report["failures"][0]["id"], failed.id)
+        self.assertEqual(report["failures"][0]["stage"], "publish")
+        self.assertEqual(checkpoint.failed_items, [(f"onenote:page:{failed.id}", "0x800706BE after retry")])
+        self.assertEqual(checkpoint.completed_items, [f"onenote:page:{recovered.id}"])
+        self.assertEqual(convert.call_count, 1)
+        self.assertTrue(checkpoint.closed)
+
+    def test_bridge_source_isolates_rpc_publish_failures_and_recreates_com(self):
+        source = onenote.CSHARP_BRIDGE_SOURCE
+
+        self.assertIn("catch (COMException ex)", source)
+        self.assertIn("if (ex.ErrorCode != RpcCallFailed)", source)
+        self.assertIn("HasPublishedFile(outputPath)", source)
+        self.assertIn("ReleaseApplication(app)", source)
+        self.assertIn("Thread.Sleep(3000)", source)
+        self.assertIn('WritePublishResult(pageId, "failed", retryEx)', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容

- 将 OneNote 的 MHT 发布改为逐页独立处理；每页均记录页面 ID、标题和发布状态。
- 单页 `Publish` 失败后继续导出后续页面，不再让整批导出提前终止。
- 对 `0x800706BE`：先确认 MHT 是否已经写出；若没有，释放并重建 OneNote COM 客户端，等待 3 秒后仅谨慎重试该页一次。
- 仍失败的页面会写入 checkpoint 的可重试失败项，报告会标明失败阶段为 `publish`。
- 桥接源码兼容旧版 Windows C# 编译器，避免使用不被支持的异常筛选语法。

## 验证

- `python scripts/quality_check.py`：506 Python 测试、100 Node 测试、插件校验、语法检查全部通过。
- 本机真实 OneNote：完成一页实际 `Application.Publish`、MHT 转 Markdown 与图片资源导出验证。
- 新增回归测试：模拟第一页持续 `0x800706BE`、第二页重试成功，确认后续页面仍会导出，失败页保留为可重试项。

插件版本：`onenote@1.0.3`