### PR TITLE
fix(onenote): pause safely when COM fails

### DIFF
--- a/plugins/onenote/backend/export_onenote.py
+++ b/plugins/onenote/backend/export_onenote.py
@@ -52,6 +52,8 @@ using Microsoft.Office.Interop.OneNote;
 public static class WandaoOneNoteBridge
 {
     private const int RpcCallFailed = unchecked((int)0x800706BE);
+    private const int RpcServerUnavailable = unchecked((int)0x800706BA);
+    private const int ComServerExecutionFailed = unchecked((int)0x80080005);
 
     private static bool HasPublishedFile(string outputPath)
     {
@@ -130,42 +132,55 @@ public static class WandaoOneNoteBridge
                     }
                     catch (COMException ex)
                     {
-                        if (ex.ErrorCode != RpcCallFailed)
+                        if (ex.ErrorCode == RpcCallFailed)
                         {
+                            // The call reached OneNote but the RPC channel then failed.  A
+                            // retry can duplicate a partially completed publish, so keep a
+                            // completed file when present and otherwise defer this page.
+                            bool published = HasPublishedFile(outputPath);
                             ReleaseApplication(app);
                             app = null;
-                            WritePublishResult(pageId, "failed", ex);
-                            continue;
-                        }
-                        if (HasPublishedFile(outputPath))
-                        {
-                            ReleaseApplication(app);
-                            app = null;
-                            WritePublishResult(pageId, "recovered-output", ex);
+                            WritePublishResult(pageId, published ? "recovered-output" : "failed", ex);
                             continue;
                         }
 
-                        try
+                        if (ex.ErrorCode == ComServerExecutionFailed)
                         {
-                            if (File.Exists(outputPath)) File.Delete(outputPath);
                             ReleaseApplication(app);
                             app = null;
-                            Console.WriteLine("publish-retry\t" + index + "\t" + pageId);
-                            Thread.Sleep(3000);
-                            app = new Application();
-                            app.Publish(pageId, outputPath, PublishFormat.pfMHTML, "");
-                            if (!HasPublishedFile(outputPath))
+                            WritePublishResult(pageId, "service-unavailable", ex);
+                            continue;
+                        }
+
+                        if (ex.ErrorCode == RpcServerUnavailable)
+                        {
+                            try
                             {
-                                throw new Exception("OneNote Publish retry returned without creating an MHT file.");
+                                if (File.Exists(outputPath)) File.Delete(outputPath);
+                                ReleaseApplication(app);
+                                app = null;
+                                Console.WriteLine("publish-retry\t" + index + "\t" + pageId);
+                                Thread.Sleep(10000);
+                                app = new Application();
+                                app.Publish(pageId, outputPath, PublishFormat.pfMHTML, "");
+                                if (!HasPublishedFile(outputPath))
+                                {
+                                    throw new Exception("OneNote Publish retry returned without creating an MHT file.");
+                                }
+                                WritePublishResult(pageId, "retried", ex);
                             }
-                            WritePublishResult(pageId, "retried", ex);
+                            catch (Exception retryEx)
+                            {
+                                ReleaseApplication(app);
+                                app = null;
+                                WritePublishResult(pageId, "failed", retryEx);
+                            }
+                            continue;
                         }
-                        catch (Exception retryEx)
-                        {
-                            ReleaseApplication(app);
-                            app = null;
-                            WritePublishResult(pageId, "failed", retryEx);
-                        }
+
+                        ReleaseApplication(app);
+                        app = null;
+                        WritePublishResult(pageId, "failed", ex);
                     }
                     catch (Exception ex)
                     {
@@ -912,10 +927,17 @@ def publish_mht_items(
     return results
 
 
+def is_onenote_service_unavailable(result: dict[str, str]) -> bool:
+    """Return whether OneNote itself could not be started for this page."""
+    return result.get("status") == "service-unavailable" or "0x80080005" in result.get("message", "")
+
+
 def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[TocNode]) -> dict[str, Any]:
     output = Path(args.output).expanduser().resolve() if args.output else default_output_dir()
     output.mkdir(parents=True, exist_ok=True)
-    checkpoint = open_checkpoint_from_args(args, "onenote", "export")
+    # OneNote can take several minutes to recover its COM server.  Each page
+    # still renews the lease, while the longer lease protects one slow call.
+    checkpoint = open_checkpoint_from_args(args, "onenote", "export", lease_seconds=15 * 60)
     pages_by_id = {page.id: page for page in pages}
     planner = PathPlanner(output, pages_by_id, child_page_ids(pages))
     selected = selected_pages(args, pages)
@@ -990,29 +1012,53 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
         temp_dir = tempfile.TemporaryDirectory(prefix="wandao-onenote-mht-")
         mht_root = Path(temp_dir.name)
 
+    deferred: list[dict[str, str]] = []
     try:
-        publish_items: list[tuple[TocNode, Path]] = []
-        for index, (page, _md_path) in enumerate(targets, start=1):
-            mht_path = mht_root / f"{index:04d}-{short_hash(page.id)}.mht"
-            publish_items.append((page, mht_path))
-
-        if publish_items:
-            list_path = mht_root / "publish-list.tsv"
-            emit(f"开始调用 OneNote 导出 MHT：{len(publish_items)} 篇")
-            for page, _mht_path in publish_items:
-                if checkpoint:
-                    checkpoint.start_item(f"onenote:page:{page.id}", "publish")
-            publish_results = publish_mht_items(publish_items, list_path, helper_dir=helper_dir)
-        else:
-            publish_results = {}
-
-        mht_by_id = {page.id: mht for page, mht in publish_items}
         total = len(targets)
+        if targets:
+            emit(f"开始逐页调用 OneNote 导出 MHT：{total} 篇")
         for index, (page, md_path) in enumerate(targets, start=1):
             item_key = f"onenote:page:{page.id}"
-            publish_result = publish_results.get(page.id, {"status": "failed", "message": "Missing OneNote publish result."})
+            mht_path = mht_root / f"{index:04d}-{short_hash(page.id)}.mht"
+            if checkpoint:
+                checkpoint.heartbeat()
+                checkpoint.start_item(item_key, "publish")
+            emit(
+                f"开始调用 OneNote 导出页面 MHT：{page.title}",
+                event="document.publish.started",
+                doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+            )
+            publish_result = publish_mht_items(
+                [(page, mht_path)],
+                mht_root / f"publish-{index:04d}.tsv",
+                helper_dir=helper_dir,
+            ).get(page.id, {"status": "failed", "message": "Missing OneNote publish result."})
+            error_message = publish_result["message"] or "OneNote did not create an MHT file for this page."
+
+            if is_onenote_service_unavailable(publish_result):
+                if checkpoint:
+                    checkpoint.fail_item(item_key, error_message)
+                failures.append({
+                    "id": page.id,
+                    "title": page.title,
+                    "path": str(md_path),
+                    "stage": "onenote-service",
+                    "error": error_message,
+                })
+                deferred = [
+                    {"id": remaining.id, "title": remaining.title, "path": str(remaining_path)}
+                    for remaining, remaining_path in targets[index:]
+                ]
+                emit(
+                    "OneNote 本地服务无法启动，已保留其余 "
+                    f"{len(deferred)} 篇为待续传项。请关闭并重新打开 Windows 桌面版 OneNote 后继续任务。",
+                    event="task.paused",
+                    level="error",
+                    error={"type": "OneNoteServiceUnavailable", "message": error_message},
+                )
+                break
+
             if publish_result["status"] == "failed":
-                error_message = publish_result["message"] or "OneNote did not create an MHT file for this page."
                 if checkpoint:
                     checkpoint.fail_item(item_key, error_message)
                 failures.append({
@@ -1030,23 +1076,23 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
                     error={"type": "OneNotePublishError", "message": error_message},
                 )
             else:
-                if publish_result["status"] in {"recovered-output", "retried"}:
-                    emit(
-                        f"OneNote 页面发布已恢复：{page.title}（{publish_result['status']}）",
-                        event="document.export.recovered",
-                        level="warn",
-                        doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
-                    )
-            try:
-                if publish_result["status"] != "failed":
+                try:
+                    if publish_result["status"] in {"recovered-output", "retried"}:
+                        emit(
+                            f"OneNote 页面发布已恢复：{page.title}（{publish_result['status']}）",
+                            event="document.export.recovered",
+                            level="warn",
+                            doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                        )
                     if checkpoint:
+                        checkpoint.heartbeat()
                         checkpoint.start_item(item_key, "convert")
                     emit(
                         f"开始转换 OneNote 页面：{page.title}",
                         event="document.export.started",
                         doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
                     )
-                    stats = convert_mht_to_markdown(mht_by_id[page.id], md_path)
+                    stats = convert_mht_to_markdown(mht_path, md_path)
                     image_success += stats["images"]
                     attachment_success += stats["attachments"]
                     exported += 1
@@ -1062,27 +1108,28 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
                             "chars": stats["chars"],
                         },
                     )
-            except Exception as exc:  # noqa: BLE001 - keep exporting other pages.
-                if checkpoint:
-                    checkpoint.fail_item(item_key, str(exc))
-                failures.append({
-                    "id": page.id,
-                    "title": page.title,
-                    "path": str(md_path),
-                    "error": str(exc),
-                })
-                emit(
-                    f"OneNote 页面导出失败：{page.title}：{exc}",
-                    event="document.export.failed",
-                    level="error",
-                    doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
-                    error={"type": type(exc).__name__, "message": str(exc)},
-                )
+                except Exception as exc:  # noqa: BLE001 - keep exporting other pages.
+                    if checkpoint:
+                        checkpoint.fail_item(item_key, str(exc))
+                    failures.append({
+                        "id": page.id,
+                        "title": page.title,
+                        "path": str(md_path),
+                        "stage": "convert",
+                        "error": str(exc),
+                    })
+                    emit(
+                        f"OneNote 页面导出失败：{page.title}：{exc}",
+                        event="document.export.failed",
+                        level="error",
+                        doc={"id": page.id, "title": page.title, "index": index, "path": str(md_path)},
+                        error={"type": type(exc).__name__, "message": str(exc)},
+                    )
             if index % max(1, args.progress_every) == 0 or index == total:
                 emit(
                     "progress "
                     f"{index}/{total} exported={exported} skipped={skipped} "
-                    f"image_success={image_success} failures={len(failures)}",
+                    f"image_success={image_success} failures={len(failures)} deferred={len(deferred)}",
                     event="task.progress",
                     progress={"current": index, "total": total},
                     stats={
@@ -1091,6 +1138,7 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
                         "imageSuccess": image_success,
                         "attachmentSuccess": attachment_success,
                         "failureCount": len(failures),
+                        "deferredCount": len(deferred),
                     },
                 )
     finally:
@@ -1104,6 +1152,7 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
         "exported": exported,
         "skipped": skipped,
         "failures": failures,
+        "deferred": deferred,
         "imageSuccess": image_success,
         "attachmentSuccess": attachment_success,
         "elapsedSeconds": round(time.time() - started, 2),

--- a/plugins/onenote/plugin.json
+++ b/plugins/onenote/plugin.json
@@ -4,7 +4,7 @@
   "id": "onenote",
   "name": "OneNote",
   "description": "Windows 桌面版 OneNote 本地 Markdown 导出。",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "Wandao Official",
   "homepage": "https://www.onenote.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_onenote_publish_recovery.py
+++ b/tests/test_onenote_publish_recovery.py
@@ -12,6 +12,7 @@ class _Checkpoint:
         self.failed_items: list[tuple[str, str]] = []
         self.completed_items: list[str] = []
         self.started_items: list[tuple[str, str]] = []
+        self.heartbeats = 0
         self.closed = False
 
     def start_task(self, _metadata):
@@ -25,6 +26,9 @@ class _Checkpoint:
 
     def start_item(self, item_key, stage):
         self.started_items.append((item_key, stage))
+
+    def heartbeat(self):
+        self.heartbeats += 1
 
     def fail_item(self, item_key, error):
         self.failed_items.append((item_key, error))
@@ -75,13 +79,16 @@ class OneNotePublishRecoveryTests(unittest.TestCase):
         recovered = _page("recovered-page", "Recovered")
         checkpoint = _Checkpoint()
 
+        publish_batch_sizes: list[int] = []
+
         def fake_bridge(args, **_kwargs):
             rows = Path(args[1]).read_text(encoding="utf-8").splitlines()
+            publish_batch_sizes.append(len(rows))
             output_lines = []
             for row in rows:
                 page_id, output_path = row.split("\t", 1)
                 if page_id == failed.id:
-                    detail = base64.b64encode("0x800706BE after retry".encode("utf-8")).decode("ascii")
+                    detail = base64.b64encode("0x800706BE".encode("utf-8")).decode("ascii")
                     output_lines.append(f"publish-result\t{page_id}\tfailed\t{detail}")
                 else:
                     Path(output_path).write_bytes(b"published MHT")
@@ -103,19 +110,49 @@ class OneNotePublishRecoveryTests(unittest.TestCase):
         self.assertEqual(len(report["failures"]), 1)
         self.assertEqual(report["failures"][0]["id"], failed.id)
         self.assertEqual(report["failures"][0]["stage"], "publish")
-        self.assertEqual(checkpoint.failed_items, [(f"onenote:page:{failed.id}", "0x800706BE after retry")])
+        self.assertEqual(checkpoint.failed_items, [(f"onenote:page:{failed.id}", "0x800706BE")])
         self.assertEqual(checkpoint.completed_items, [f"onenote:page:{recovered.id}"])
+        self.assertEqual(publish_batch_sizes, [1, 1])
+        self.assertGreaterEqual(checkpoint.heartbeats, 3)
         self.assertEqual(convert.call_count, 1)
         self.assertTrue(checkpoint.closed)
 
-    def test_bridge_source_isolates_rpc_publish_failures_and_recreates_com(self):
+    def test_service_start_failure_defers_remaining_pages_without_publishing_them(self):
+        unavailable = _page("unavailable-page", "Unavailable")
+        pending = _page("pending-page", "Pending")
+        checkpoint = _Checkpoint()
+
+        def fake_bridge(args, **_kwargs):
+            row = Path(args[1]).read_text(encoding="utf-8").strip()
+            page_id, _output_path = row.split("\t", 1)
+            detail = base64.b64encode("0x80080005 CO_E_SERVER_EXEC_FAILURE".encode("utf-8")).decode("ascii")
+            return f"publish-result\t{page_id}\tservice-unavailable\t{detail}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            args = onenote.parse_args(["--output", str(Path(tmp) / "export")])
+            with mock.patch.object(onenote, "open_checkpoint_from_args", return_value=checkpoint), mock.patch.object(
+                onenote, "run_bridge", side_effect=fake_bridge
+            ), mock.patch.object(onenote, "convert_mht_to_markdown") as convert:
+                report = onenote.export_onenote(args, [unavailable, pending], [unavailable, pending])
+
+        self.assertEqual(report["exported"], 0)
+        self.assertEqual(len(report["failures"]), 1)
+        self.assertEqual(report["failures"][0]["stage"], "onenote-service")
+        self.assertEqual(report["deferred"], [{"id": pending.id, "title": pending.title, "path": mock.ANY}])
+        self.assertEqual(checkpoint.failed_items, [(f"onenote:page:{unavailable.id}", "0x80080005 CO_E_SERVER_EXEC_FAILURE")])
+        convert.assert_not_called()
+
+    def test_bridge_source_isolates_rpc_failures_and_only_retries_server_unavailable(self):
         source = onenote.CSHARP_BRIDGE_SOURCE
 
         self.assertIn("catch (COMException ex)", source)
-        self.assertIn("if (ex.ErrorCode != RpcCallFailed)", source)
+        self.assertIn("if (ex.ErrorCode == RpcCallFailed)", source)
+        self.assertIn("RpcServerUnavailable", source)
+        self.assertIn("ComServerExecutionFailed", source)
         self.assertIn("HasPublishedFile(outputPath)", source)
         self.assertIn("ReleaseApplication(app)", source)
-        self.assertIn("Thread.Sleep(3000)", source)
+        self.assertIn("Thread.Sleep(10000)", source)
+        self.assertIn('WritePublishResult(pageId, "service-unavailable", ex)', source)
         self.assertIn('WritePublishResult(pageId, "failed", retryEx)', source)
 
 

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const test = require('node:test');
 const {
   buildResumeArgs,
+  hasDeferredDocuments,
   isInterruptedTask,
   providerCheckpointArgs,
   providerCheckpointFile,
@@ -105,6 +106,17 @@ test('a real failed task still retries only its failed items when supported', ()
   const task = { status: 'failed', args: ['--resume'] };
   assert.deepEqual(buildResumeArgs(task, '--retry-failed', 2), ['--resume', '--retry-failed']);
   assert.equal(shouldRetryFailureItems(task, '--retry-failed', 2), true);
+});
+
+test('a service-paused task continues pending pages instead of narrowing to failed items', () => {
+  const task = {
+    status: 'partial',
+    args: ['--resume', '--retry-failed'],
+    report: { deferred: [{ id: 'pending-page' }] }
+  };
+  assert.equal(hasDeferredDocuments(task), true);
+  assert.deepEqual(buildResumeArgs(task, '--retry-failed', 1), ['--resume']);
+  assert.equal(shouldRetryFailureItems(task, '--retry-failed', 1), false);
 });
 
 test('the renderer loads and uses the resume helper before app startup', () => {

--- a/wandao_core/checkpoint.py
+++ b/wandao_core/checkpoint.py
@@ -801,6 +801,7 @@ def open_checkpoint_from_args(
     action: str,
     *,
     default_task_id: str = "default",
+    lease_seconds: float = DEFAULT_LEASE_SECONDS,
 ) -> WandaoCheckpoint | None:
     checkpoint_file = str(getattr(args, "checkpoint_file", "") or "").strip()
     if not checkpoint_file:
@@ -810,6 +811,7 @@ def open_checkpoint_from_args(
         task_id=str(getattr(args, "checkpoint_task_id", "") or os.environ.get("WANDAO_JOB_ID") or default_task_id),
         provider_id=provider_id,
         action=action,
+        lease_seconds=lease_seconds,
     )
     if getattr(args, "reset_checkpoint", False):
         checkpoint.reset_task()

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -911,6 +911,13 @@ function providerRetryFailureArg(provider) {
   return provider.retryFailures?.arg || '--retry-failures';
 }
 
+function taskHasDeferredDocuments(task) {
+  const helper = window.WandaoTaskResume?.hasDeferredDocuments;
+  if (typeof helper === 'function') return helper(task);
+  const report = task?.report || task?.resultData || {};
+  return Array.isArray(report?.deferred) && report.deferred.length > 0;
+}
+
 function canResumeTask(task) {
   if (!task) return false;
   if (task.argsUnavailable) return false;
@@ -951,7 +958,7 @@ function resumeTaskArgs(task) {
   }
   const args = Array.isArray(task?.args) ? [...task.args] : [];
   const interrupted = ['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase());
-  if (interrupted && retryArg) return args.filter((arg) => arg !== retryArg);
+  if ((interrupted || taskHasDeferredDocuments(task)) && retryArg) return args.filter((arg) => arg !== retryArg);
   if (retryArg && taskDocumentFailureCount(task) > 0 && !args.includes(retryArg)) {
     args.push(retryArg);
   }
@@ -961,6 +968,10 @@ function resumeTaskArgs(task) {
 function taskResumeActionLabel(task) {
   const status = taskDisplayStatus(task);
   const documentFailures = taskDocumentFailureCount(task);
+  if (taskHasDeferredDocuments(task)) {
+    const count = (task.report?.deferred || task.resultData?.deferred || []).length;
+    return `继续任务（${count} 篇待处理）`;
+  }
   if ((status === 'completed' || status === 'partial') && documentFailures > 0) {
     return `重试失败文档${documentFailures > 1 ? `（${documentFailures}）` : ''}`;
   }
@@ -1497,6 +1508,7 @@ async function resumeTask(task) {
     : Boolean(
       retryArg
       && !['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase())
+      && !taskHasDeferredDocuments(task)
       && documentFailures > 0
       && args.includes(retryArg)
     );

--- a/wandao_electron/renderer/task_resume.js
+++ b/wandao_electron/renderer/task_resume.js
@@ -4,16 +4,21 @@
     return status === 'stopped' || status === 'interrupted';
   }
 
+  function hasDeferredDocuments(task) {
+    const report = task?.report || task?.resultData || {};
+    return Array.isArray(report?.deferred) && report.deferred.length > 0;
+  }
+
   function buildResumeArgs(task, retryArg, failureCount = 0) {
     const args = Array.isArray(task?.args) ? [...task.args] : [];
-    if (isInterruptedTask(task)) return args.filter((arg) => arg !== retryArg);
+    if (isInterruptedTask(task) || hasDeferredDocuments(task)) return args.filter((arg) => arg !== retryArg);
     if (!retryArg || !Number.isFinite(Number(failureCount)) || Number(failureCount) <= 0) return args;
     if (!args.includes(retryArg)) args.push(retryArg);
     return args;
   }
 
   function shouldRetryFailureItems(task, retryArg, failureCount = 0) {
-    return Boolean(retryArg && !isInterruptedTask(task) && Number(failureCount) > 0);
+    return Boolean(retryArg && !isInterruptedTask(task) && !hasDeferredDocuments(task) && Number(failureCount) > 0);
   }
 
   function providerCheckpointFile(provider, values = {}) {
@@ -34,6 +39,7 @@
 
   const api = {
     buildResumeArgs,
+    hasDeferredDocuments,
     isInterruptedTask,
     providerCheckpointArgs,
     providerCheckpointFile,


### PR DESCRIPTION
## 修复内容

- OneNote MHT 发布由一个批量桥接进程改为每页独立桥接调用；每页前后刷新 checkpoint，OneNote 专用租约扩展为 15 分钟。
- `0x800706BE` 仅标记当前页面可重试失败并继续下一页；若 MHT 已实际写出则继续转换。
- `0x800706BA` 才会释放 COM、等待 10 秒、重建 COM 后仅重试当前页一次。
- `0x80080005` 识别为 OneNote 服务无法启动：立即暂停本批剩余页面为待处理项，不再让每页重复卡住；任务中心“继续任务”会保留 `--resume`，不会错误收窄为仅重试首个失败页。
- OneNote 插件版本升至 `1.0.4`。

## 根因

此前多页 Publish 在同一个桥接进程中串行执行；OneNote COM 每页卡住数分钟时，checkpoint 在整批结束前无法续租，导致租约过期并覆盖原本可重试的逐页结果。

## 验证

- 本机真实 OneNote 单页：完成 COM Publish、MHT 转 Markdown 与图片资源导出。
- 新增覆盖：逐页隔离、`0x800706BE` 后继续、`0x80080005` 暂停并保留待处理页、任务中心继续不追加 `--retry-failed`。
- `python scripts/quality_check.py`：506 Python 测试、101 Node 测试、插件校验和语法检查全部通过。