### PR TITLE
fix(zsxq): interrupted Group export resumes cursor

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -1847,7 +1847,29 @@ def fetch_group_topics_page(
         check_stopped(args)
         ensure_zsxq_api_origin(cdp, args, f"https://wx.zsxq.com/group/{group_id}")
         throttle_request(args)
-        result = cdp.evaluate(expression, timeout=60) or {}
+        try:
+            result = cdp.evaluate(expression, timeout=60) or {}
+        except (TimeoutError, OSError, ConnectionError) as exc:
+            # A lost/slow DevTools response is not a failed export item.  The
+            # cursor was written after the previous page, so one bounded cool
+            # down and retry is safe; a later resume continues from that page.
+            if attempt < retries:
+                pause = min(30.0, 10.0 * (attempt + 1))
+                emit(
+                    args,
+                    f"知识星球目录请求暂时超时，暂停 {format_duration(pause)} 后重试：{exc}",
+                    event="task.paused",
+                    level="warn",
+                    stats={"groupRequestTimeouts": attempt + 1, "retryDelaySeconds": pause},
+                )
+                wait_with_stop(args, pause)
+                continue
+            return {
+                "ok": False,
+                "transient": True,
+                "text": f"知识星球目录请求超时；断点已保存，可继续任务：{exc}",
+                "attempts": [{"error": str(exc)}],
+            }
         if result.get("rateLimited"):
             pause_for_rate_limit(args, f"知识星球 group topics {group_id}", attempt, retries)
             continue
@@ -3836,11 +3858,10 @@ def export_entry(args: argparse.Namespace) -> dict[str, Any]:
                         )
                 overview_path.write_text(markdown, encoding="utf-8")
                 if checkpoint and overview_item_key:
-                    if img_errors:
-                        checkpoint.complete_item(overview_item_key, local_path=str(overview_path), metadata={"source": overview_key})
-                        checkpoint.fail_item(overview_item_key, f"{len(img_errors)} 个图片下载失败")
-                    else:
-                        checkpoint.complete_item(overview_item_key, local_path=str(overview_path), metadata={"source": overview_key})
+                    # Resource failures are tracked by the resource table.
+                    # The Markdown document itself is complete and must not be
+                    # reclassified as a failed document on "继续任务".
+                    checkpoint.complete_item(overview_item_key, local_path=str(overview_path), metadata={"source": overview_key})
                 exported_rows.append({"title": entry.get("title") or "专栏正文", "path": str(overview_path)})
                 record_exported_item(
                     str(entry.get("title") or "专栏正文"),
@@ -4531,22 +4552,14 @@ def export_entry(args: argparse.Namespace) -> dict[str, Any]:
                 if topic_id:
                     existing_topic_ids.setdefault(topic_id, md_path)
                 if checkpoint and checkpoint_item_key:
-                    if img_errors or file_errors:
-                        checkpoint.complete_item(
-                            checkpoint_item_key,
-                            local_path=str(md_path),
-                            metadata={"source": item, "contentCompleteness": item.get("contentCompleteness") or "full"},
-                        )
-                        checkpoint.fail_item(
-                            checkpoint_item_key,
-                            f"{len(img_errors)} 个图片、{len(file_errors)} 个附件下载失败",
-                        )
-                    else:
-                        checkpoint.complete_item(
-                            checkpoint_item_key,
-                            local_path=str(md_path),
-                            metadata={"source": item, "contentCompleteness": item.get("contentCompleteness") or "full"},
-                        )
+                    # Resource failures remain visible in report/resources,
+                    # but do not turn an otherwise written Markdown document
+                    # into a retry-failed item.
+                    checkpoint.complete_item(
+                        checkpoint_item_key,
+                        local_path=str(md_path),
+                        metadata={"source": item, "contentCompleteness": item.get("contentCompleteness") or "full"},
+                    )
                 if depth == 1:
                     exported_rows.append({"title": title, "path": str(md_path)})
                 record_exported_item(

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_checkpoint_provider_args.py
+++ b/tests/test_checkpoint_provider_args.py
@@ -81,19 +81,29 @@ class CheckpointProviderArgsTests(unittest.TestCase):
 
                     self.assertEqual(getattr(args, attr)[-2:], ["doc-a", "doc-b"])
 
-    def test_resource_failures_keep_export_items_resumable(self) -> None:
+    def test_resource_failures_are_explicitly_tracked_for_retry_policies(self) -> None:
         expected_markers = {
             "plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py": "checkpoint.fail_item(item_key, f\"{len(img_errors)} 个图片或附件下载失败\")",
             "plugins/feishu/backend/export_feishu.py": "checkpoint.fail_item(item_key, f\"{len(img_errors)} 个图片下载失败\")",
             "plugins/yuque/backend/export_yuque.py": "checkpoint.fail_item(item_key, f\"{len(resource_errors)} 个图片或附件下载失败\")",
             "plugins/wiz/backend/export_wiz.py": "checkpoint.fail_item(item_key, f\"{len(img_failures)} 个图片下载失败\")",
             "plugins/youdao/backend/export_youdao.py": "checkpoint.fail_item(item_key, f\"{resource_failures_in_doc} 个图片或附件下载失败\")",
-            "plugins/zsxq/backend/export_zsxq.py": "checkpoint.fail_item(\n                            checkpoint_item_key",
         }
         for filename, marker in expected_markers.items():
             with self.subTest(script=filename):
                 source = (REPO_ROOT / filename).read_text(encoding="utf-8")
                 self.assertIn(marker, source)
+
+        # Group exports use a cursor.  A timed-out image must remain a resource
+        # warning, otherwise the desktop's generic retry action narrows a
+        # previously interrupted 800-post run to that one document instead of
+        # continuing the saved cursor.
+        zsxq_source = (REPO_ROOT / "plugins/zsxq/backend/export_zsxq.py").read_text(encoding="utf-8")
+        self.assertIn("Resource failures remain visible in report/resources", zsxq_source)
+        self.assertNotIn(
+            "checkpoint.fail_item(\n                            checkpoint_item_key,\n                            f\"{len(img_errors)} 个图片、{len(file_errors)} 个附件下载失败\"",
+            zsxq_source,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_zsxq_group_export.py
+++ b/tests/test_zsxq_group_export.py
@@ -428,6 +428,26 @@ class ZsxqGroupExportTests(unittest.TestCase):
         self.assertEqual(cdp.evaluate.call_count, 2)
         self.assertEqual(wait.call_count, 1)
 
+    def test_group_api_retries_a_transient_devtools_timeout_before_failing_the_page(self) -> None:
+        args = argparse.Namespace(
+            _rate_limit_events=0,
+            rate_limit_retries=1,
+            request_delay=0,
+            request_jitter=0,
+        )
+        cdp = mock.Mock()
+        cdp.evaluate.side_effect = [TimeoutError("timed out"), {"ok": True, "topics": []}]
+        with (
+            mock.patch.object(export_zsxq, "ensure_zsxq_api_origin"),
+            mock.patch.object(export_zsxq, "throttle_request"),
+            mock.patch.object(export_zsxq, "wait_with_stop") as wait,
+        ):
+            result = export_zsxq.fetch_group_topics_page(cdp, "15288445111222", "digests", "", 20, args)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(cdp.evaluate.call_count, 2)
+        wait.assert_called_once_with(args, 10.0)
+
     def test_rate_limit_pause_ends_group_run_without_retry_loop(self) -> None:
         class FakeCdp:
             def close(self) -> None:
@@ -761,10 +781,13 @@ class ZsxqGroupExportTests(unittest.TestCase):
                 overview_key = zsxq_item_key_from_source({"href": "https://wx.zsxq.com/columns/15288445111222", "key": "overview"})
                 resource_key = zsxq_resource_key("image", "https://example.com/cover.png")
 
-                self.assertEqual(checkpoint.item_status(overview_key), "failed")
+                # A resource timeout must not make the Markdown document a
+                # retry-failed item.  The resource itself remains retryable.
+                self.assertEqual(checkpoint.item_status(overview_key), "completed")
                 resource = checkpoint.resource_record(resource_key)
                 self.assertIsNotNone(resource)
                 self.assertEqual(resource["item_key"], overview_key)
+                self.assertEqual(resource["status"], "failed")
             finally:
                 checkpoint.close()
 

--- a/tests/test_zsxq_issue43.py
+++ b/tests/test_zsxq_issue43.py
@@ -245,7 +245,7 @@ class ZsxqIssue43Tests(unittest.TestCase):
             self.assertTrue((output / "00-导出报告.json").exists())
             self.assertTrue((output / ".wandao" / "reports" / f"zsxq-{report['runId']}.json").exists())
 
-    def test_resource_retry_reuses_original_markdown_path(self) -> None:
+    def test_resource_failure_does_not_turn_completed_markdown_into_a_retry_item(self) -> None:
         class FakeCdp:
             def close(self) -> None:
                 return None
@@ -319,9 +319,8 @@ class ZsxqIssue43Tests(unittest.TestCase):
             second_report = run(resume=True, task_id="job-2", image_errors=[])
 
             self.assertEqual(first_report["exportedItems"][0]["sequence"], 1)
-            self.assertEqual(len(first_report["failedItems"]), 1)
-            self.assertEqual(second_report["exportedItems"][0]["sequence"], 1)
-            self.assertEqual(first_report["exportedItems"][0]["localPath"], second_report["exportedItems"][0]["localPath"])
+            self.assertEqual(first_report["failedItems"], [])
+            self.assertEqual(second_report["exportedItems"], [])
             self.assertEqual(len([path for path in output.glob("*.md") if export_sequence_from_name(path.name)]), 1)
 
 

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -108,6 +108,13 @@ test('a real failed task still retries only its failed items when supported', ()
   assert.equal(shouldRetryFailureItems(task, '--retry-failed', 2), true);
 });
 
+test('a failed cursor-based Group export continues from its saved cursor instead of narrowing to retry-failed items', () => {
+  const task = { status: 'failed', args: ['--resume'] };
+  const provider = { checkpoint: { supported: true, strategy: 'cursor' } };
+  assert.deepEqual(buildResumeArgs(task, '--retry-failed', 12, provider), ['--resume']);
+  assert.equal(shouldRetryFailureItems(task, '--retry-failed', 12, provider), false);
+});
+
 test('a service-paused task continues pending pages instead of narrowing to failed items', () => {
   const task = {
     status: 'partial',
@@ -176,6 +183,23 @@ test('resource warnings are not converted into retry-failed document commands', 
   assert.match(resumeArgs, /taskDocumentFailureCount\(task\)/);
   assert.match(resumeTaskHandler, /const documentFailures = taskDocumentFailureCount\(task\)/);
   assert.match(resumeTaskHandler, /失败文档，共 \$\{documentFailures\} 个/);
+});
+
+test('resource diagnostics are not duplicated after reports are finalized', () => {
+  const report = require('../wandao_electron/renderer/task_report');
+  const resource = {
+    type: 'image',
+    document: '示例文档',
+    path: 'out/example.md',
+    failures: [{ url: 'https://images.zsxq.com/example', error: 'timed out' }]
+  };
+  const diagnostics = report.collectFailureDiagnostics({
+    imageFailureCount: 1,
+    imageFailures: [resource],
+    resourceFailures: [resource]
+  });
+  assert.equal(diagnostics.filter((line) => line.includes('https://images.zsxq.com/example')).length, 1);
+  assert.ok(!diagnostics.some((line) => line.includes('脚本没有返回逐项图片失败原因')));
 });
 
 test('latest task result card is persistent, actionable, and never overlays long forms', () => {

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -191,14 +191,14 @@ test('resource diagnostics are not duplicated after reports are finalized', () =
     type: 'image',
     document: '示例文档',
     path: 'out/example.md',
-    failures: [{ url: 'https://images.zsxq.com/example', error: 'timed out' }]
+    failures: [{ url: 'https://image.example.test/resource.png', error: 'timed out' }]
   };
   const diagnostics = report.collectFailureDiagnostics({
     imageFailureCount: 1,
     imageFailures: [resource],
     resourceFailures: [resource]
   });
-  assert.equal(diagnostics.filter((line) => line.includes('https://images.zsxq.com/example')).length, 1);
+  assert.equal(diagnostics.filter((line) => line.includes('https://image.example.test/resource.png')).length, 1);
   assert.ok(!diagnostics.some((line) => line.includes('脚本没有返回逐项图片失败原因')));
 });
 

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -954,7 +954,7 @@ function resumeTaskArgs(task) {
   const retryArg = providerRetryFailureArg(provider);
   const helper = window.WandaoTaskResume?.buildResumeArgs;
   if (typeof helper === 'function') {
-    return helper(task, retryArg, taskDocumentFailureCount(task));
+    return helper(task, retryArg, taskDocumentFailureCount(task), provider);
   }
   const args = Array.isArray(task?.args) ? [...task.args] : [];
   const interrupted = ['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase());
@@ -1504,7 +1504,7 @@ async function resumeTask(task) {
   const documentFailures = taskDocumentFailureCount(task);
   const shouldRetry = window.WandaoTaskResume?.shouldRetryFailureItems;
   const retryingFailures = typeof shouldRetry === 'function'
-    ? shouldRetry(task, retryArg, documentFailures)
+    ? shouldRetry(task, retryArg, documentFailures, provider)
     : Boolean(
       retryArg
       && !['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase())

--- a/wandao_electron/renderer/task_report.js
+++ b/wandao_electron/renderer/task_report.js
@@ -61,6 +61,7 @@
 
   function collectFailureItems(data, limit = 100) {
     const items = [];
+    const seen = new Set();
     const visit = (value, source = '') => {
       if (!value || items.length >= limit) return;
       if (Array.isArray(value)) {
@@ -69,13 +70,32 @@
       }
       if (typeof value !== 'object') return;
       const looksLikeFailure = value.error || value.reason || value.message || value.relativePath || value.url || value.title;
-      if (looksLikeFailure) items.push({ source, ...value });
+      if (looksLikeFailure) {
+        const fingerprint = [
+          value.type,
+          value.url,
+          value.error,
+          value.reason,
+          value.message,
+          value.document,
+          value.path,
+          value.relativePath,
+          value.title
+        ].map((part) => String(part || '')).join('\u0000');
+        if (!seen.has(fingerprint)) {
+          seen.add(fingerprint);
+          items.push({ source, ...value });
+        }
+      }
       Object.entries(value).forEach(([key, child]) => {
         if (/fail|error/i.test(key)) visit(child, key);
       });
     };
     if (data && typeof data === 'object') {
-      ['failures', 'resourceFailures', 'imageFailures', 'attachmentFailures', 'errors'].forEach((key) => {
+      const resourceKeys = Array.isArray(data.resourceFailures) && data.resourceFailures.length
+        ? ['failures', 'resourceFailures', 'errors']
+        : ['failures', 'imageFailures', 'attachmentFailures', 'errors'];
+      resourceKeys.forEach((key) => {
         visit(data[key], key);
       });
     }
@@ -177,6 +197,7 @@
 
   function collectFailureDiagnostics(data, limit = 80) {
     const lines = [];
+    const source = data && typeof data === 'object' ? data : {};
     const report = normalizeTaskReport(data);
     const pushLine = (label, text) => {
       const content = compact(text, 700);
@@ -198,10 +219,14 @@
     if (report.stats.failed > 0 && !lines.length) {
       pushLine('失败统计', `failureCount=${report.stats.failed}，脚本没有返回逐项失败原因，请查看 Python 原始日志。`);
     }
-    if (report.stats.imageFailed > 0 && !lines.some((line) => line.includes('图片'))) {
+    const hasImageDetails = asArray(source.resourceFailures).some((item) => item?.type === 'image')
+      || asArray(source.imageFailures).length > 0;
+    const hasAttachmentDetails = asArray(source.resourceFailures).some((item) => item?.type === 'attachment')
+      || asArray(source.attachmentFailures).length > 0;
+    if (report.stats.imageFailed > 0 && !hasImageDetails) {
       pushLine('图片失败统计', `imageFailureCount=${report.stats.imageFailed}，脚本没有返回逐项图片失败原因。`);
     }
-    if (report.stats.attachmentFailed > 0 && !lines.some((line) => line.includes('\u9644\u4ef6'))) {
+    if (report.stats.attachmentFailed > 0 && !hasAttachmentDetails) {
       pushLine('\u9644\u4ef6\u5931\u8d25\u7edf\u8ba1', `attachmentFailureCount=${report.stats.attachmentFailed}\uff0c\u811a\u672c\u6ca1\u6709\u8fd4\u56de\u9010\u9879\u9644\u4ef6\u5931\u8d25\u539f\u56e0\u3002`);
     }
     if (lines.length >= limit) {

--- a/wandao_electron/renderer/task_resume.js
+++ b/wandao_electron/renderer/task_resume.js
@@ -9,16 +9,35 @@
     return Array.isArray(report?.deferred) && report.deferred.length > 0;
   }
 
-  function buildResumeArgs(task, retryArg, failureCount = 0) {
+  function isCursorContinuation(task, provider = {}) {
+    const checkpoint = provider?.checkpoint || {};
+    const args = Array.isArray(task?.args) ? task.args : [];
+    return Boolean(
+      checkpoint.supported
+      && checkpoint.strategy === 'cursor'
+      && args.includes('--resume')
+      && !args.includes(provider?.retryFailures?.arg || '--retry-failed')
+    );
+  }
+
+  function buildResumeArgs(task, retryArg, failureCount = 0, provider = {}) {
     const args = Array.isArray(task?.args) ? [...task.args] : [];
-    if (isInterruptedTask(task) || hasDeferredDocuments(task)) return args.filter((arg) => arg !== retryArg);
+    if (isInterruptedTask(task) || hasDeferredDocuments(task) || isCursorContinuation(task, provider)) {
+      return args.filter((arg) => arg !== retryArg);
+    }
     if (!retryArg || !Number.isFinite(Number(failureCount)) || Number(failureCount) <= 0) return args;
     if (!args.includes(retryArg)) args.push(retryArg);
     return args;
   }
 
-  function shouldRetryFailureItems(task, retryArg, failureCount = 0) {
-    return Boolean(retryArg && !isInterruptedTask(task) && !hasDeferredDocuments(task) && Number(failureCount) > 0);
+  function shouldRetryFailureItems(task, retryArg, failureCount = 0, provider = {}) {
+    return Boolean(
+      retryArg
+      && !isInterruptedTask(task)
+      && !hasDeferredDocuments(task)
+      && !isCursorContinuation(task, provider)
+      && Number(failureCount) > 0
+    );
   }
 
   function providerCheckpointFile(provider, values = {}) {
@@ -41,6 +60,7 @@
     buildResumeArgs,
     hasDeferredDocuments,
     isInterruptedTask,
+    isCursorContinuation,
     providerCheckpointArgs,
     providerCheckpointFile,
     shouldRetryFailureItems


### PR DESCRIPTION
## 修复内容

- Group 导出因超时或异常中断后，“继续任务”保留 `--resume`：先恢复未完成条目，再按已保存游标继续后续页面；不再自动缩窄为“只重试失败项”。
- Group 列表请求遇到临时 DevTools 超时，执行有界冷却重试；仍失败时保留断点供继续任务恢复。
- 图片或附件下载失败只作为资源警告和资源记录，不再将已写入的 Markdown 文档标记成失败项。
- 修复任务报告中同一资源失败重复展示，以及已有资源细节仍提示“没有逐项原因”的问题。
- 知识星球插件升级至 1.0.7。

## 根因

异常退出的历史任务被通用恢复逻辑附加了 `--retry-failed`。知识星球 Group 使用游标型 checkpoint，因此该参数会让后端仅处理失败集合并停止后续分页；资源超时又会把已导出的文档写入失败集合，进一步放大该问题。

## 验证

- `python scripts/quality_check.py`
- 覆盖游标型失败任务继续、临时目录请求超时重试、资源失败不变成重试文档、报告错误去重。