### PR TITLE
fix(onenote): restore 1.3.7 checkpoint compatibility

### DIFF
--- a/plugins/onenote/backend/export_onenote.py
+++ b/plugins/onenote/backend/export_onenote.py
@@ -937,7 +937,10 @@ def export_onenote(args: argparse.Namespace, nodes: list[TocNode], pages: list[T
     output.mkdir(parents=True, exist_ok=True)
     # OneNote can take several minutes to recover its COM server.  Each page
     # still renews the lease, while the longer lease protects one slow call.
-    checkpoint = open_checkpoint_from_args(args, "onenote", "export", lease_seconds=15 * 60)
+    checkpoint = open_checkpoint_from_args(args, "onenote", "export")
+    if checkpoint:
+        checkpoint.lease_seconds = 15 * 60
+
     pages_by_id = {page.id: page for page in pages}
     planner = PathPlanner(output, pages_by_id, child_page_ids(pages))
     selected = selected_pages(args, pages)

--- a/plugins/onenote/plugin.json
+++ b/plugins/onenote/plugin.json
@@ -4,7 +4,7 @@
   "id": "onenote",
   "name": "OneNote",
   "description": "Windows 桌面版 OneNote 本地 Markdown 导出。",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "Wandao Official",
   "homepage": "https://www.onenote.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_onenote_checkpoint_contract.py
+++ b/tests/test_onenote_checkpoint_contract.py
@@ -52,10 +52,13 @@ class OneNoteCheckpointContractTests(unittest.TestCase):
                 "--doc-id", page.id,
                 "--resume",
             ])
-            with mock.patch.object(onenote, "open_checkpoint_from_args", return_value=checkpoint):
+            with mock.patch.object(onenote, "open_checkpoint_from_args", return_value=checkpoint) as open_checkpoint:
                 report = onenote.export_onenote(args, [page], [page])
 
         self.assertEqual(report["exported"], 0)
+        open_checkpoint.assert_called_once_with(args, "onenote", "export")
+        # Keep slow COM recovery safe without requiring the newer core API.
+        self.assertEqual(checkpoint.lease_seconds, 15 * 60)
         self.assertEqual(report["skipped"], 1)
         self.assertTrue(checkpoint.closed)
         self.assertEqual(len(checkpoint.upserts), 1)


### PR DESCRIPTION
## 修复\n\n- OneNote 插件 1.0.5 不再向 Wandao 1.3.7 不支持的 open_checkpoint_from_args 参数传递 lease_seconds。\n- 在创建 checkpoint 后直接延长对象租约至 15 分钟，保留 COM 恢复期间的任务保护。\n- 补充旧版 checkpoint API 的兼容性回归测试。\n\n## 验证\n\n- python -m unittest tests.test_onenote_checkpoint_contract tests.test_onenote_publish_recovery tests.test_wandao_checkpoint\n- python scripts/quality_check.py\n\n发布后仅更新 OneNote 插件，无需重新打桌面安装包。