### PR TITLE
fix(zsxq): preserve column rate-limit pauses

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -311,10 +311,23 @@ def wait_eval(
 
 
 def wait_with_stop(args: argparse.Namespace | None, seconds: float) -> None:
-    deadline = time.time() + max(0, seconds)
-    while time.time() < deadline:
+    """Sleep responsively and keep a claimed checkpoint alive during long pauses."""
+    deadline = time.monotonic() + max(0, seconds)
+    heartbeat = getattr(args, "_checkpoint_heartbeat", None) if args else None
+    heartbeat_interval = max(
+        5.0,
+        float(getattr(args, "_checkpoint_heartbeat_interval", 30.0) or 30.0),
+    ) if args else 30.0
+    next_heartbeat = time.monotonic() + heartbeat_interval
+    while time.monotonic() < deadline:
         check_stopped(args)
-        time.sleep(min(1.0, deadline - time.time()))
+        now = time.monotonic()
+        if callable(heartbeat) and now >= next_heartbeat:
+            # Let a real lease-loss error propagate. Continuing after another
+            # run takes over a checkpoint would corrupt resume state.
+            heartbeat()
+            next_heartbeat = now + heartbeat_interval
+        time.sleep(min(1.0, deadline - now))
 
 
 def format_duration(seconds: float | int | None) -> str:
@@ -2026,7 +2039,7 @@ def resolve_toc_item(cdp: CDPClient, source: dict[str, Any], args: argparse.Name
     if source.get("topicId") or source.get("topicUid"):
         try:
             return resolve_toc_item_api(cdp, source, args)
-        except (ExportStopped, SkipDocument):
+        except (ExportStopped, SkipDocument, RateLimitPaused):
             raise
         except Exception as exc:
             if str(source.get("key") or "").startswith("group:"):
@@ -2705,7 +2718,7 @@ def resolve_toc_item_api(cdp: CDPClient, source: dict[str, Any], args: argparse.
             article_content["contentCompleteness"] = "full"
             article_content["previewArticleUrl"] = article_url
             return article_content
-        except (ExportStopped, SkipDocument):
+        except (ExportStopped, SkipDocument, RateLimitPaused):
             raise
         except Exception as exc:
             emit(args, f"知识星球文章页读取失败，保留主题摘要：{source.get('title') or topic_id} ({exc})", event="log.message", level="warn")
@@ -2832,7 +2845,7 @@ def resolve_link(cdp: CDPClient, link: dict[str, str], args: argparse.Namespace 
                 content["topicUrl"] = content.get("topicUrl") or topic_url
                 content["sourceText"] = link.get("text") or href
                 return content
-            except (ExportStopped, SkipDocument):
+            except (ExportStopped, SkipDocument, RateLimitPaused):
                 raise
             except Exception as exc:
                 emit(
@@ -3480,6 +3493,10 @@ def export_entry(args: argparse.Namespace) -> dict[str, Any]:
                     "resumeKey": zsxq_group_resume_key(task_group_id, task_group_scope, output),
                 })
         checkpoint.start_task(task_metadata)
+        # 429/1059 backoff can intentionally exceed the five-minute task lease.
+        # Heartbeat from wait_with_stop keeps the existing claim valid without
+        # issuing any additional requests to Knowledge Planet.
+        args._checkpoint_heartbeat = checkpoint.heartbeat
     cdp: CDPClient | None = None
     chrome_proc: subprocess.Popen[Any] | None = None
     try:
@@ -4813,6 +4830,8 @@ def export_entry(args: argparse.Namespace) -> dict[str, Any]:
             finish_checkpoint_task_safely(checkpoint, status="failed", error=str(exc))
         raise
     finally:
+        if hasattr(args, "_checkpoint_heartbeat"):
+            delattr(args, "_checkpoint_heartbeat")
         if checkpoint:
             checkpoint.close()
         if cdp:

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_zsxq_group_export.py
+++ b/tests/test_zsxq_group_export.py
@@ -495,6 +495,86 @@ class ZsxqGroupExportTests(unittest.TestCase):
         warning = finish_checkpoint_task_safely(checkpoint, status="completed", report={"exportedDocs": 1})
         self.assertEqual(warning, "lease lost")
 
+    def test_toc_rate_limit_pause_does_not_fall_back_to_page_click(self) -> None:
+        source = {
+            "key": "column:1:123",
+            "title": "专栏条目",
+            "topicId": "123",
+            "entryUrl": "https://wx.zsxq.com/columns/123",
+        }
+        cdp = mock.Mock()
+        with mock.patch.object(
+            export_zsxq,
+            "resolve_toc_item_api",
+            side_effect=RateLimitPaused("连续 4 次 429，安全暂停"),
+        ):
+            with self.assertRaises(RateLimitPaused):
+                export_zsxq.resolve_toc_item(cdp, source, argparse.Namespace())
+
+        cdp.evaluate.assert_not_called()
+
+    def test_article_rate_limit_pause_does_not_degrade_to_preview(self) -> None:
+        source = {
+            "key": "column:1:123",
+            "title": "专栏文章",
+            "topicId": "123",
+            "rawTopic": {
+                "talk": {
+                    "text": "摘要",
+                    "article": {"article_url": "https://articles.zsxq.com/example"},
+                }
+            },
+        }
+        with mock.patch.object(
+            export_zsxq,
+            "collect_article_content",
+            side_effect=RateLimitPaused("连续 4 次 429，安全暂停"),
+        ):
+            with self.assertRaises(RateLimitPaused):
+                export_zsxq.resolve_toc_item_api(mock.Mock(), source, argparse.Namespace())
+
+    def test_link_rate_limit_pause_does_not_fall_back_to_page_export(self) -> None:
+        link = {"href": "https://t.zsxq.com/CsGBs", "text": "专栏正文链接"}
+        cdp = mock.Mock()
+        cdp.evaluate.return_value = "https://wx.zsxq.com/topic/82811424545181252"
+        with (
+            mock.patch.object(export_zsxq, "navigate_with_retry") as navigate,
+            mock.patch.object(
+                export_zsxq,
+                "find_article_url_on_topic",
+                return_value={"href": "https://wx.zsxq.com/topic/82811424545181252", "article": ""},
+            ),
+            mock.patch.object(export_zsxq, "detect_rate_limited_page", return_value={"limited": False}),
+            mock.patch.object(
+                export_zsxq,
+                "resolve_toc_item_api",
+                side_effect=RateLimitPaused("连续 4 次 429，安全暂停"),
+            ),
+        ):
+            with self.assertRaises(RateLimitPaused):
+                export_zsxq.resolve_link(cdp, link, argparse.Namespace(rate_limit_retries=0))
+
+        navigate.assert_called_once_with(cdp, link["href"], mock.ANY)
+
+    def test_long_wait_heartbeats_checkpoint_without_network_requests(self) -> None:
+        args = argparse.Namespace(
+            _checkpoint_heartbeat=mock.Mock(),
+            _checkpoint_heartbeat_interval=5,
+        )
+        clock = [0.0]
+
+        def advance(seconds: float) -> None:
+            clock[0] += seconds
+
+        with (
+            mock.patch.object(export_zsxq.time, "monotonic", side_effect=lambda: clock[0]),
+            mock.patch.object(export_zsxq.time, "sleep", side_effect=advance),
+        ):
+            export_zsxq.wait_with_stop(args, 16)
+
+        self.assertEqual(args._checkpoint_heartbeat.call_count, 3)
+
+
     def test_full_comment_api_uses_smaller_safe_batch(self) -> None:
         self.assertEqual(export_zsxq.DEFAULT_COMMENT_BATCH_SIZE, 30)
         source = inspect.getsource(export_zsxq.fetch_topic_comments_api)


### PR DESCRIPTION
## 问题\n知识星球专栏在 429/1059 风控后，部分 API 优先导出路径会把可恢复的 RateLimitPaused 当成普通错误，错误走到页面兜底或摘要降级。长休眠还可能超过 checkpoint 租约，最终显示为失败。\n\n## 修复\n- 专栏目录、普通链接和文章正文三条路径均原样传播 RateLimitPaused，不再追加页面兜底请求。\n- 长休眠期间每 30 秒刷新 SQLite checkpoint 租约，不发送额外知识星球请求。\n- 知识星球插件版本升级至 1.0.8。\n\n## 验证\n- python -m unittest tests.test_zsxq_group_export（45 项通过）\n- python scripts/quality_check.py（通过）\n- 使用已授权会话对用户给出的专栏 URL 低频实测：目录 9 组 / 88 篇；首个章节、内链正文与 2 张图片成功导出。\n- 对实测中出现过 429 的短链接单独低频验证，成功导出且未递归额外请求。\n\n不包含桌面安装包构建；合并后仅触发知识星球插件热更新。