### PR TITLE
fix(zsxq): preserve login URL on legacy desktop

### DIFF
--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/plugins/zsxq/providers/zsxq-column/provider.json
+++ b/plugins/zsxq/providers/zsxq-column/provider.json
@@ -11,6 +11,8 @@
   "trustLevel": "official",
   "status": "stable",
   "templateId": "template-zsxq-column",
+  "urlParam": "--entry-url",
+  "noUrl": false,
   "defaults": { "output": "exports/zsxq-column" },
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": true, "images": true, "attachments": true, "tree": true, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "items", "resourceTracking": true },

--- a/plugins/zsxq/providers/zsxq-group/provider.json
+++ b/plugins/zsxq/providers/zsxq-group/provider.json
@@ -11,6 +11,8 @@
   "trustLevel": "official",
   "status": "stable",
   "templateId": "template-zsxq-group",
+  "urlParam": "--entry-url",
+  "noUrl": false,
   "defaults": { "output": "exports/zsxq-group" },
   "capabilities": { "export": true, "import": false, "guide": false, "login": true, "scanToc": false, "images": true, "attachments": true, "tree": false, "batch": true, "retryFailures": true },
   "checkpoint": { "supported": true, "strategy": "cursor", "resourceTracking": true },

--- a/tests_js/provider_legacy_compat.test.js
+++ b/tests_js/provider_legacy_compat.test.js
@@ -55,6 +55,20 @@ test('every bundled provider with an old HTML template resolves legacy parameter
   }
 });
 
+test('knowledge-star legacy templates explicitly declare their required entry URL', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  for (const providerId of ['zsxq-column', 'zsxq-group']) {
+    const manifestPath = path.join(repoRoot, 'plugins', 'zsxq', 'providers', providerId, 'provider.json');
+    const provider = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    assert.equal(provider.urlParam, '--entry-url', `${providerId} must be compatible with desktop releases that infer template URL fields`);
+    assert.equal(provider.noUrl, false, `${providerId} login must require an entry URL`);
+    assert.deepEqual(resolveLegacyTemplateConfig(provider), {
+      urlParam: '--entry-url',
+      outputParam: '--output',
+      noUrl: false
+    });
+  }
+});
 test('main process applies compatibility after validating Provider v1 fields', () => {
   const mainSource = fs.readFileSync(path.resolve(__dirname, '..', 'wandao_electron', 'main.js'), 'utf8');
   assert.match(mainSource, /Object\.assign\(provider, resolveLegacyTemplateConfig\(raw\)\)/);


### PR DESCRIPTION
## 问题

知识星球插件 1.0.9 新增 `follow_link_scope` 后，Wandao 1.3.7 的旧模板兼容层会把它和 `entry_url` 同时识别为 URL 候选，进而误判 Provider 无需 URL。登录命令最终只传入 `--login`，后端在打开浏览器前报 `--entry-url is required`。

## 修复

- 两个知识星球 Provider 显式声明 `urlParam: --entry-url` 和 `noUrl: false`，不再依赖旧桌面端的字段名推断。
- 插件版本升级为 1.0.10。
- 增加回归测试，确保这两个旧 HTML 模板始终声明必需的入口 URL。

## 验证

- `python scripts/quality_check.py`（通过）
- 本地构建 zsxq 1.0.10 插件包并检查包内两个 Provider 清单（通过）
- 用 Wandao 1.3.7 的旧 URL 推断逻辑模拟，两个登录命令均包含 `--entry-url <url> --login`（通过）
