### PR TITLE
release: Wandao 1.3.8 diagnostics and package size reduction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandao"
-version = "1.3.7"
+version = "1.3.8"
 description = "万能导：多平台知识库 Markdown 导出与互转工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests_js/release_diagnostics_and_size.test.js
+++ b/tests_js/release_diagnostics_and_size.test.js
@@ -1,0 +1,32 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+test('developer reports identify the desktop and active plugin versions', () => {
+  const appSource = read('wandao_electron/renderer/app.js');
+  const mainSource = read('wandao_electron/main.js');
+
+  assert.match(mainSource, /appVersion:\s*PROJECT_INFO\.version/);
+  assert.match(appSource, /Wandao 版本：\$\{paths\.appVersion/);
+  assert.match(appSource, /当前插件：\$\{activePluginVersionLabel\(\)\}/);
+  assert.match(appSource, /插件版本：\$\{plugins\.join/);
+});
+
+test('release configuration keeps only the supported Electron locales', () => {
+  const manifest = JSON.parse(read('wandao_electron/package.json'));
+  assert.deepEqual(manifest.build.electronLanguages, ['zh-CN', 'zh-TW', 'en-US']);
+});
+
+test('portable Python preparation removes build-only package tooling after install', () => {
+  const source = read('wandao_electron/scripts/prepare_python_runtime.py');
+
+  assert.match(source, /def remove_build_only_runtime_files/);
+  assert.match(source, /"pip", "setuptools", "pkg_resources"/);
+  assert.match(source, /"Lib\/ensurepip"/);
+  assert.match(source, /remove_build_only_runtime_files\(output_dir\)/);
+  assert.match(source, /verify_runtime_is_release_only\(output_dir\)/);
+});

--- a/wandao_electron/main.js
+++ b/wandao_electron/main.js
@@ -2025,6 +2025,7 @@ ipcMain.handle('get-app-path', async () => {
   const userData = app.getPath('userData');
   return {
     appPath: app.getAppPath(),
+    appVersion: PROJECT_INFO.version,
     userData,
     dataRoot: userData,
     projectRoot: pythonLibraryDir()

--- a/wandao_electron/package-lock.json
+++ b/wandao_electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wandao",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wandao",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "electron": "^39.8.5",

--- a/wandao_electron/package.json
+++ b/wandao_electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wandao",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Wandao multi-platform document conversion tool",
   "main": "main.js",
   "scripts": {
@@ -43,6 +43,11 @@
     "appId": "com.wandao.app",
     "productName": "Wandao",
     "electronDist": "node_modules/electron/dist",
+    "electronLanguages": [
+      "zh-CN",
+      "zh-TW",
+      "en-US"
+    ],
     "publish": [
       {
         "provider": "github",

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -750,6 +750,14 @@ function activeToolLabel() {
   return active?.textContent?.trim() || TOOLS[currentTool]?.title || currentTool || '未知功能';
 }
 
+function activePluginVersionLabel() {
+  const provider = TOOLS[currentTool];
+  if (!provider?.pluginId) return '主程序内置功能';
+  return provider.pluginVersion
+    ? `${provider.pluginId} v${provider.pluginVersion}`
+    : `${provider.pluginId}（版本未知）`;
+}
+
 async function copyDeveloperReport() {
   let paths = appPaths || {};
   if (!paths.userData && window.electronAPI.getAppPath) {
@@ -768,8 +776,10 @@ async function copyDeveloperReport() {
     `生成时间：${formatUserDateTime(new Date())}`,
     `当前功能：${activeToolLabel()}`,
     `当前工具 ID：${currentTool || '-'}`,
+    `Wandao 版本：${paths.appVersion || '未知'}`,
     `系统平台：${navigator.platform || '-'}`,
     `浏览器内核：${navigator.userAgent || '-'}`,
+    `当前插件：${activePluginVersionLabel()}`,
     paths.userData ? `应用数据目录：${paths.userData}` : '',
     paths.projectRoot ? `项目目录：${paths.projectRoot}` : '',
     '',
@@ -1826,7 +1836,16 @@ async function loadProviderManifests() {
   }
   PROVIDER_REGISTRY.replaceExternal(manifests);
   refreshProviderTools();
-  appendDetailedLog('provider', 'info', `已加载 ${manifests.length} 个外部 Provider。`);
+  const plugins = [...new Map(manifests
+    .filter((provider) => provider?.pluginId)
+    .map((provider) => [provider.pluginId, provider.pluginVersion || '未知']))
+    .entries()]
+    .map(([id, version]) => `${id} v${version}`);
+  appendDetailedLog(
+    'provider',
+    'info',
+    `已加载 ${manifests.length} 个外部 Provider。插件版本：${plugins.join('，') || '无'}`
+  );
 }
 
 function renderProviderSafetyNotice(provider) {
@@ -3938,7 +3957,7 @@ function renderAppPathsInitializationState() {
 function announceStartupOnce() {
   if (startupAnnounced) return;
   startupAnnounced = true;
-  log('万能导已启动', 'success');
+  log(`万能导已启动（Wandao v${appPaths?.appVersion || '未知'}）`, 'success');
   window.setTimeout(() => checkForUpdates(true), 1000);
 }
 

--- a/wandao_electron/scripts/prepare_python_runtime.py
+++ b/wandao_electron/scripts/prepare_python_runtime.py
@@ -152,15 +152,60 @@ def remove_previous_output(output_dir: pathlib.Path) -> None:
 
 
 def cleanup_runtime(output_dir: pathlib.Path) -> None:
-    for folder_name in ("__pycache__", "test", "tests"):
+    for folder_name in ("__pycache__", ".pytest_cache", "test", "tests"):
         for folder in output_dir.rglob(folder_name):
             if folder.is_dir():
                 shutil.rmtree(folder, ignore_errors=True)
-    for pyc in output_dir.rglob("*.pyc"):
-        try:
-            pyc.unlink()
-        except OSError:
-            pass
+    for pattern in ("*.pyc", "*.pyo"):
+        for compiled_file in output_dir.rglob(pattern):
+            try:
+                compiled_file.unlink()
+            except OSError:
+                pass
+
+def remove_build_only_runtime_files(output_dir: pathlib.Path) -> None:
+    """Remove installation tooling after dependencies have been installed and verified.
+
+    The bundled interpreter never installs packages on an end user's machine.
+    Keeping pip, setuptools and ensurepip in a release only increases the
+    installer size and exposes unnecessary package-management entry points.
+    """
+    for relative_dir in ("Lib/ensurepip", "lib/python3.11/ensurepip"):
+        shutil.rmtree(output_dir / relative_dir, ignore_errors=True)
+
+    for site_packages in output_dir.rglob("site-packages"):
+        if not site_packages.is_dir():
+            continue
+        for name in ("pip", "setuptools", "pkg_resources"):
+            shutil.rmtree(site_packages / name, ignore_errors=True)
+        for pattern in ("pip-*.dist-info", "setuptools-*.dist-info"):
+            for metadata in site_packages.glob(pattern):
+                shutil.rmtree(metadata, ignore_errors=True)
+
+    for scripts_dir in (output_dir / "Scripts", output_dir / "bin"):
+        if not scripts_dir.is_dir():
+            continue
+        for pattern in ("pip*", "easy_install*"):
+            for script in scripts_dir.glob(pattern):
+                if script.is_file() or script.is_symlink():
+                    script.unlink(missing_ok=True)
+
+
+def verify_runtime_is_release_only(output_dir: pathlib.Path) -> None:
+    forbidden = []
+    for relative_dir in ("Lib/ensurepip", "lib/python3.11/ensurepip"):
+        candidate = output_dir / relative_dir
+        if candidate.exists():
+            forbidden.append(str(candidate.relative_to(output_dir)))
+    for site_packages in output_dir.rglob("site-packages"):
+        for name in ("pip", "setuptools", "pkg_resources"):
+            if (site_packages / name).exists():
+                forbidden.append(str((site_packages / name).relative_to(output_dir)))
+        for pattern in ("pip-*.dist-info", "setuptools-*.dist-info"):
+            forbidden.extend(str(path.relative_to(output_dir)) for path in site_packages.glob(pattern))
+    if forbidden:
+        raise SystemExit(f"运行时仍包含仅构建期工具：{', '.join(sorted(forbidden))}")
+
 
 
 def python_executable(output_dir: pathlib.Path, target: str) -> pathlib.Path:
@@ -226,6 +271,8 @@ def prepare_runtime(target: str, output_dir: pathlib.Path, cache_dir: pathlib.Pa
     install_requirements(py, PROJECT_DIR / "requirements.txt")
     cleanup_runtime(output_dir)
     verify_runtime(py)
+    remove_build_only_runtime_files(output_dir)
+    verify_runtime_is_release_only(output_dir)
     write_build_info(output_dir, target, asset_name)
     print(f"Prepared bundled Python runtime: {output_dir}")
 


### PR DESCRIPTION
## 内容\n- 错误报告新增 Wandao 版本与当前插件版本；Provider 加载日志记录完整插件版本列表。\n- Electron 发行包只保留 zh-CN、zh-TW、en-US 三种 locale。\n- Python 运行时在依赖安装与验证后移除 pip、setuptools、pkg_resources、ensurepip、测试缓存和编译缓存，并验证不残留。\n- 桌面端与 Python 项目版本统一升级到 1.3.8。\n\n## 本地验证\n- python scripts/quality_check.py 通过（514 Python tests，105 JS tests）。\n- Windows 解包构建通过；scripts/package_smoke.py 验证 14 个插件、20 个 Provider、19 个可执行后端。\n- 解包产物 locales 仅包含 en-US、zh-CN、zh-TW。\n- 解包运行时确认不存在 pip、setuptools、pkg_resources、ensurepip。