### PR TITLE
ci: keep desktop releases to Windows and macOS installers

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -181,11 +181,7 @@ jobs:
           name: Wandao ${{ github.ref_name }}
           generate_release_notes: true
           make_latest: true
-          # Checksums and the SBOM must travel with the release assets so users
-          # can verify downloads without first locating a CI run. Provenance is
-          # additionally published through GitHub artifact attestation above.
+          # Keep the public release focused on the two supported desktop installers.
           files: |
             release-artifacts/*.exe
             release-artifacts/*.zip
-            release-artifacts/SHA256SUMS
-            release-artifacts/wandao.spdx.json

--- a/tests/test_electron_health.py
+++ b/tests/test_electron_health.py
@@ -232,8 +232,11 @@ class ElectronHealthTests(unittest.TestCase):
         self.assertNotIn("CSC_LINK:", workflow)
         self.assertIn("actions/attest-build-provenance", workflow)
         self.assertIn("Generate release SBOM", workflow)
-        self.assertIn("release-artifacts/SHA256SUMS", workflow)
-        self.assertIn("release-artifacts/wandao.spdx.json", workflow)
+        release_files = workflow.split("files: |", 1)[1]
+        self.assertIn("release-artifacts/*.exe", release_files)
+        self.assertIn("release-artifacts/*.zip", release_files)
+        self.assertNotIn("release-artifacts/SHA256SUMS", release_files)
+        self.assertNotIn("release-artifacts/wandao.spdx.json", release_files)
 
     def test_bootstrap_node_runtime_is_pinned_and_verified(self) -> None:
         powershell = read_text("start-wandao.ps1")


### PR DESCRIPTION
## 内容\n桌面端 GitHub Release 只上传受支持的安装包：Windows .exe 与 macOS .zip。\n\n不再把 SHA256SUMS、SBOM 文件和相关构建产物作为 Release 附件上传，避免发行版出现非安装文件。