### PR TITLE
fix(zsxq): preserve code blocks and recover from rate-limit bursts

### DIFF
--- a/plugins/zsxq/backend/export_zsxq.py
+++ b/plugins/zsxq/backend/export_zsxq.py
@@ -83,6 +83,8 @@ DEFAULT_COMMENT_BATCH_SIZE = 30
 DEFAULT_COMMENT_REQUEST_DELAY = 3.0
 DEFAULT_COMMENT_REQUEST_JITTER = 2.0
 MAX_FULL_COMMENT_PAGES = 200
+RATE_LIMIT_WINDOW_SECONDS = 20 * 60
+RATE_LIMIT_EXTENDED_BACKOFF_SECONDS = 5 * 60
 GROUP_CURSOR_NAME = "zsxq-group"
 EXPORT_SEQUENCE_RE = re.compile(r"^(?P<sequence>\d+)-")
 MAX_GROUP_NEWEST_REFRESH_PAGES = 250
@@ -473,34 +475,73 @@ def rate_limit_pause_seconds(args: argparse.Namespace | None, event_index: int) 
 
 def pause_for_rate_limit(args: argparse.Namespace | None, label: str, attempt: int, retries: int) -> None:
     events = 0
+    window_events = 0
     max_events = 1
     if args:
         events = int(getattr(args, "_rate_limit_events", 0) or 0) + 1
         args._rate_limit_events = events
         args._rate_limit_total_events = int(getattr(args, "_rate_limit_total_events", 0) or 0) + 1
         max_events = max(1, int(getattr(args, "rate_limit_max_events", 4) or 4))
+        now = time.monotonic()
+        recent_events = [
+            float(timestamp)
+            for timestamp in (getattr(args, "_rate_limit_recent_events", []) or [])
+            if now - float(timestamp) < RATE_LIMIT_WINDOW_SECONDS
+        ]
+        recent_events.append(now)
+        args._rate_limit_recent_events = recent_events
+        window_events = len(recent_events)
     # Both HTTP 429 and ZSXQ error 1059 reach this function.  Retry only after
     # a progressively longer cool-down; the next event beyond the configured
-    # budget becomes a resumable checkpoint pause rather than endless traffic.
+    # budget triggers an extended cooling-off period instead of repeatedly
+    # changing topic IDs while the account is still being rate limited.
+    # A successful request resets only the consecutive streak.  It must not
+    # erase a burst of intermittent limits across different topic IDs.
     if events >= max_events:
         raise RateLimitPaused(
             f"知识星球连续触发 {events} 次 429/1059 风控，已安全暂停并保存断点：{label}"
         )
+    if window_events >= max_events:
+        pause = RATE_LIMIT_EXTENDED_BACKOFF_SECONDS
+        emit(
+            args,
+            f"知识星球近 {RATE_LIMIT_WINDOW_SECONDS // 60} 分钟已触发 {window_events} 次 429/1059 风控，"
+            f"执行长休眠 {format_duration(pause)} 后自动继续：{label}",
+            event="task.paused",
+            level="warn",
+            stats={
+                "rateLimitEvents": events,
+                "rateLimitWindowEvents": window_events,
+                "rateLimitExtendedBackoffSeconds": round(pause, 1),
+            },
+        )
+        wait_with_stop(args, pause)
+        # A long recovery starts a new burst window. Without this reset, a
+        # later single 429 would immediately trigger another long sleep based
+        # on stale pre-cooldown events.
+        args._rate_limit_events = 0
+        args._rate_limit_recent_events = []
+        return
     if attempt >= retries:
         raise RateLimitPaused(f"429/1059 风控重试次数已用尽，已安全暂停并保存断点：{label}")
     pause = rate_limit_pause_seconds(args, events)
     emit(
         args,
-        f"触发 429/1059 风控第 {events} 次，长休眠 {format_duration(pause)} 后重试：{label}",
+        f"触发 429/1059 风控：连续第 {events} 次，近 {RATE_LIMIT_WINDOW_SECONDS // 60} 分钟第 {window_events} 次，"
+        f"长休眠 {format_duration(pause)} 后重试：{label}",
         event="task.paused",
         level="warn",
-        stats={"rateLimitEvents": events, "rateLimitBackoffSeconds": round(pause, 1)},
+        stats={
+            "rateLimitEvents": events,
+            "rateLimitWindowEvents": window_events,
+            "rateLimitBackoffSeconds": round(pause, 1),
+        },
     )
     wait_with_stop(args, pause)
 
 
 def clear_rate_limit_streak(args: argparse.Namespace | None) -> None:
-    """A successful protected request starts a later 429/1059 at stage one."""
+    """Reset only the consecutive streak after a successful protected request."""
     if args:
         args._rate_limit_events = 0
 
@@ -604,6 +645,19 @@ ZSXQ_CONVERTER_JS = r"""
     const text = candidates.sort((a, b) => b.length - a.length)[0] || el.innerText || el.textContent || "";
     return stripCodeToolbarText(text);
   }
+  function isCodeBlock(el) {
+    if (!el || el.nodeType !== 1) return false;
+    if (el.tagName.toLowerCase() === "pre") return true;
+    const className = String(el.className || "");
+    return /(?:^|[\s_-])(?:ql-)?code(?:[\s_-]|$)|codeblock|code-block|syntaxhighlighter|highlight|codemirror|monaco/i.test(className);
+  }
+  function fencedCodeBlock(el) {
+    const code = codeBlockText(el);
+    const backtickRuns = code.match(/`+/g) || [];
+    const fenceLength = Math.max(3, ...backtickRuns.map(run => run.length + 1));
+    const fence = "`".repeat(fenceLength);
+    return `${fence}\n${code}\n${fence}`;
+  }
   function inline(node) {
     if (!node) return "";
     if (node.nodeType === 3) return node.nodeValue.replace(/[\u200b\u200c\u200d\ufeff]/g, "");
@@ -664,7 +718,7 @@ ZSXQ_CONVERTER_JS = r"""
     if (el.classList && (el.classList.contains("comment-container") || el.classList.contains("comment-item"))) return "";
     if (/^h[1-6]$/.test(tag)) return "#".repeat(+tag[1] + 1) + " " + clean(inline(el));
     if (tag === "p") return clean(inline(el));
-    if (tag === "pre") return "```\n" + codeBlockText(el) + "\n```";
+    if (isCodeBlock(el)) return fencedCodeBlock(el);
     if (tag === "blockquote") return clean(el.innerText).split("\n").map(x => "> " + x).join("\n");
     if (tag === "ul" || tag === "ol") {
       const items = [...el.children].flatMap(child => {
@@ -703,7 +757,9 @@ ZSXQ_CONVERTER_JS = r"""
     || fallbackTitle
     || document.title.replace(/-知识星球$/, "")
   );
-  const markdown = [...root.children].map(block).filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+  // Normal blocks already use clean(). Do not globally collapse blank lines
+  // here, because that would alter whitespace inside fenced code blocks.
+  const markdown = [...root.children].map(block).filter(Boolean).join("\n\n").trim();
   const uniqueLinks = [];
   const seen = new Set();
   for (const link of links) {
@@ -5105,6 +5161,8 @@ def export_entry(args: argparse.Namespace) -> dict[str, Any]:
             "attachmentRequestCount": int(getattr(args, "_resource_attachment_request_count", 0) or 0),
             "rateLimitEvents": int(getattr(args, "_rate_limit_total_events", 0) or 0),
             "rateLimitCurrentStreak": int(getattr(args, "_rate_limit_events", 0) or 0),
+            "rateLimitWindowEvents": len(getattr(args, "_rate_limit_recent_events", []) or []),
+            "rateLimitWindowSeconds": RATE_LIMIT_WINDOW_SECONDS,
             "requestDelaySeconds": float(getattr(args, "request_delay", 0) or 0),
             "requestJitterSeconds": float(getattr(args, "request_jitter", 0) or 0),
             "resourceRequestDelaySeconds": float(getattr(args, "resource_request_delay", 0) or 0),

--- a/plugins/zsxq/plugin.json
+++ b/plugins/zsxq/plugin.json
@@ -4,7 +4,7 @@
   "id": "zsxq",
   "name": "知识星球",
   "description": "知识星球 Group、专栏、帖子与文章 Markdown 导出。",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "publisher": "Wandao Official",
   "homepage": "https://wx.zsxq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_zsxq_group_export.py
+++ b/tests/test_zsxq_group_export.py
@@ -430,12 +430,36 @@ class ZsxqGroupExportTests(unittest.TestCase):
         self.assertLessEqual(third, 15 * 60)
 
     def test_successful_protected_request_resets_only_the_rate_limit_streak(self) -> None:
-        args = argparse.Namespace(_rate_limit_events=2, _rate_limit_total_events=5)
+        args = argparse.Namespace(_rate_limit_events=2, _rate_limit_total_events=5, _rate_limit_recent_events=[1.0, 2.0])
 
         clear_rate_limit_streak(args)
 
         self.assertEqual(args._rate_limit_events, 0)
         self.assertEqual(args._rate_limit_total_events, 5)
+        self.assertEqual(args._rate_limit_recent_events, [1.0, 2.0])
+
+    def test_intermittent_rate_limits_use_one_extended_cooldown_within_the_global_window(self) -> None:
+        args = argparse.Namespace(
+            _rate_limit_events=0,
+            _rate_limit_total_events=0,
+            rate_limit_max_events=3,
+            rate_limit_retries=5,
+            rate_limit_pause=60,
+        )
+        with mock.patch.object(export_zsxq.time, "monotonic", side_effect=[0.0, 60.0, 120.0]), mock.patch.object(
+            export_zsxq, "wait_with_stop"
+        ) as wait:
+            pause_for_rate_limit(args, attempt=0, retries=5, label="topic one")
+            clear_rate_limit_streak(args)
+            pause_for_rate_limit(args, attempt=0, retries=5, label="topic two")
+            clear_rate_limit_streak(args)
+            pause_for_rate_limit(args, attempt=0, retries=5, label="topic three")
+
+        self.assertEqual(wait.call_count, 3)
+        self.assertEqual(wait.call_args_list[-1].args[1], export_zsxq.RATE_LIMIT_EXTENDED_BACKOFF_SECONDS)
+        self.assertEqual(args._rate_limit_events, 0)
+        self.assertEqual(args._rate_limit_total_events, 3)
+        self.assertEqual(args._rate_limit_recent_events, [])
 
     def test_group_api_stops_after_second_429_without_more_requests(self) -> None:
         args = argparse.Namespace(
@@ -776,6 +800,15 @@ class ZsxqGroupExportTests(unittest.TestCase):
         self.assertIn("评论图片 1", content["markdown"])
         self.assertIn("https://example.com/comment.png", content["images"])
         self.assertEqual(content["commentExportMode"], "full")
+
+    def test_converter_keeps_classed_code_blocks_and_their_blank_lines(self) -> None:
+        source = export_zsxq.ZSXQ_CONVERTER_JS
+
+        self.assertIn("function isCodeBlock(el)", source)
+        self.assertIn("codeblock|code-block", source)
+        self.assertIn("function fencedCodeBlock(el)", source)
+        self.assertIn("if (isCodeBlock(el)) return fencedCodeBlock(el);", source)
+        self.assertNotIn('join("\\n\\n").replace(/\\n{3,}/g, "\\n\\n")', source)
 
     def test_localize_images_strips_full_width_rich_text_suffix_before_download(self) -> None:
         bad_url = "https://article-images.zsxq.com/FlvsDpWcaJl9FuFC4X_nnUfuoE1H\uff1asleep"


### PR DESCRIPTION
## 修复内容\n- 知识星球在 20 分钟内累计达到 4 次非连续 429/1059 时，自动固定长休眠 5 分钟后继续，不需要用户手动继续任务。\n- 长休眠期间通过 checkpoint 心跳保持任务租约；日志与报告显示连续次数和窗口次数。\n- 修复 Issue #74：识别知识星球 Quill/code-block 等类名代码容器，输出 Markdown 围栏代码块；不再全局压缩代码块内空行与换行。\n- 知识星球插件升级为 1.0.13。\n\n## 验证\n- python scripts/quality_check.py 通过：Python 521 项、Node 105 项。\n- 已授权专栏真实测试 15 分钟：16 篇完成，出现 2 次非连续 429/1059，均在退避后恢复；没有并发或无限重试。\n- 增加间歇风控固定 5 分钟自动休眠、代码容器识别及代码空行保留回归测试。\n\nCloses #74