### PR TITLE
test: respect plugin platforms in package smoke

### DIFF
--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -52,20 +52,35 @@ RUNTIME_TARGETS = {
 }
 
 
-def expected_providers() -> set[str]:
+def plugin_supports_platform(manifest: dict[str, object], target_platform: str) -> bool:
+    platforms = manifest.get("platforms")
+    if platforms is None:
+        return True
+    if not isinstance(platforms, list):
+        raise RuntimeError("plugin.json platforms 必须是数组")
+    return not platforms or target_platform in platforms
+
+
+def expected_providers(target_platform: str | None = None) -> set[str]:
+    target_platform = target_platform or sys.platform
     provider_ids: set[str] = set()
     for manifest_path in (REPO_ROOT / "plugins").glob("*/plugin.json"):
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not plugin_supports_platform(manifest, target_platform):
+            continue
         for relative_path in manifest.get("entrypoints", {}).get("providers", []):
             provider = json.loads((manifest_path.parent / relative_path).read_text(encoding="utf-8"))
             provider_ids.add(str(provider["id"]))
     return provider_ids
 
 
-def executable_provider_ids() -> set[str]:
+def executable_provider_ids(target_platform: str | None = None) -> set[str]:
+    target_platform = target_platform or sys.platform
     provider_ids: set[str] = set()
     for manifest_path in (REPO_ROOT / "plugins").glob("*/plugin.json"):
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not plugin_supports_platform(manifest, target_platform):
+            continue
         for relative_path in manifest.get("entrypoints", {}).get("providers", []):
             provider_path = manifest_path.parent / relative_path
             provider = json.loads(provider_path.read_text(encoding="utf-8"))

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -601,8 +601,28 @@ class PackagedSmokeContractTests(unittest.TestCase):
             if path.is_dir() and (path / "plugin.json").is_file()
         }
         self.assertEqual(len(expected_plugins), 14)
-        self.assertEqual(len(package_smoke.expected_providers()), 20)
-        self.assertEqual(len(package_smoke.executable_provider_ids()), 19)
+        expected_counts = {
+            "win32": (20, 19),
+            "darwin": (19, 18),
+            "linux": (18, 17),
+        }
+        for target_platform, (provider_count, executable_count) in expected_counts.items():
+            with self.subTest(platform=target_platform):
+                self.assertEqual(
+                    len(package_smoke.expected_providers(target_platform)),
+                    provider_count,
+                )
+                self.assertEqual(
+                    len(package_smoke.executable_provider_ids(target_platform)),
+                    executable_count,
+                )
+
+    def test_platform_specific_providers_are_excluded_from_smoke_expectations(self) -> None:
+        self.assertIn("onenote", package_smoke.expected_providers("win32"))
+        self.assertNotIn("onenote", package_smoke.expected_providers("darwin"))
+        self.assertNotIn("onenote", package_smoke.expected_providers("linux"))
+        self.assertIn("dingtalk-export", package_smoke.expected_providers("darwin"))
+        self.assertNotIn("dingtalk-export", package_smoke.expected_providers("linux"))
 
     def test_every_ci_package_smoke_passes_an_actual_application_path(self) -> None:
         workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- filter expected packaged providers by each plugin's supported platforms
- align executable provider counts with runtime discovery on Windows, macOS, and Linux
- add regression coverage for OneNote and DingTalk platform exclusions

## Validation
- package smoke tests: 27/27
- full quality gate: pass

This fixes the macOS v1.4.0 tag smoke failure; the application bundle itself built successfully.