### PR TITLE
fix: 修复息流导入断点续跑重复导入

### DIFF
--- a/plugins/xiliu/backend/import_flowus.py
+++ b/plugins/xiliu/backend/import_flowus.py
@@ -68,6 +68,7 @@ COS_REGION = "beijing"
 # Markdown image patterns
 MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^\n)]+)\)")
 MARKDOWN_DOC_EXTENSIONS = {".md", ".markdown", ".mdown"}
+RUNTIME_JOB_ID_RE = re.compile(r"^\d{10,}-[a-z0-9]+$", re.I)
 
 
 class ImportTaskTerminalFailure(FlowUsError):
@@ -757,7 +758,7 @@ def page_exists(client: FlowUsClient, page_id: str) -> bool:
         if not isinstance(blocks, dict):
             raise FlowUsError("确认页面是否存在失败：响应中缺少 blocks")
         return page_id in blocks
-    if str(code) == "404":
+    if str(code) in ("404", "3005"):
         return False
     raise FlowUsError(f"确认页面是否存在失败：{_api_error_msg(data)}")
 
@@ -1259,6 +1260,49 @@ def _persist_import_item(
     )
 
 
+def _seed_checkpoint_from_latest_scope(checkpoint: Any) -> None:
+    """Adopt items from the latest same-scope run when old UI used per-run job IDs."""
+    if not checkpoint or not hasattr(checkpoint, "conn"):
+        return
+    row = checkpoint.conn.execute(
+        "SELECT resume_key FROM tasks WHERE task_id = ?",
+        (checkpoint.task_id,),
+    ).fetchone()
+    resume_key = str(row["resume_key"] or "") if row else ""
+    if not resume_key:
+        return
+    existing = checkpoint.conn.execute(
+        "SELECT 1 FROM items WHERE task_id = ? LIMIT 1",
+        (checkpoint.task_id,),
+    ).fetchone()
+    if existing:
+        return
+    source = checkpoint.conn.execute(
+        """
+        SELECT task_id FROM tasks
+        WHERE provider_id = ? AND action = ? AND resume_key = ? AND task_id != ?
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """,
+        (checkpoint.provider_id, checkpoint.action, resume_key, checkpoint.task_id),
+    ).fetchone()
+    if not source:
+        return
+    checkpoint.conn.execute(
+        """
+        INSERT OR IGNORE INTO items (
+            task_id, item_key, source_id, parent_key, title, status, stage, attempts,
+            target_id, last_error, metadata_json, created_at, updated_at, completed_at
+        )
+        SELECT ?, item_key, source_id, parent_key, title, status, stage, attempts,
+            target_id, last_error, metadata_json, created_at, updated_at, completed_at
+        FROM items WHERE task_id = ?
+        """,
+        (checkpoint.task_id, str(source["task_id"])),
+    )
+    checkpoint.conn.commit()
+
+
 def _ensure_parent_pages(
     client: FlowUsClient,
     checkpoint: Any,
@@ -1387,6 +1431,7 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
             "resume": bool(getattr(args, "resume", False)),
             "retryFailed": bool(getattr(args, "retry_failed", False)),
         })
+        _seed_checkpoint_from_latest_scope(checkpoint)
 
     checkpoint_metadata = _checkpoint_metadata(checkpoint)
     for doc in docs:
@@ -1600,6 +1645,9 @@ def _import_flowus_impl(args: argparse.Namespace, checkpoint: Any) -> dict[str, 
 
 
 def import_flowus(args: argparse.Namespace) -> dict[str, Any]:
+    checkpoint_task_id = str(getattr(args, "checkpoint_task_id", "") or "")
+    if not checkpoint_task_id or RUNTIME_JOB_ID_RE.match(checkpoint_task_id):
+        args.checkpoint_task_id = "xiliu-import"
     checkpoint = open_checkpoint_from_args(args, "xiliu", "import")
     try:
         return _import_flowus_impl(args, checkpoint)

--- a/plugins/xiliu/plugin.json
+++ b/plugins/xiliu/plugin.json
@@ -3,7 +3,7 @@
   "id": "xiliu",
   "name": "息流",
   "description": "导出/导入 FlowUs (息流) 文档，保留目录结构。",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "tllovesxs",
   "core": { "minVersion": "1.3.2" },
   "entrypoints": {

--- a/plugins/xiliu/providers/xiliu-import/provider.json
+++ b/plugins/xiliu/providers/xiliu-import/provider.json
@@ -92,6 +92,15 @@
       "min": 30,
       "advanced": true,
       "actions": ["import"]
+    },
+    {
+      "name": "retry_failed",
+      "label": "只重试上次失败项",
+      "type": "checkbox",
+      "arg": "--retry-failed",
+      "default": false,
+      "advanced": true,
+      "actions": ["import"]
     }
   ],
   "actions": [
@@ -137,7 +146,7 @@
       "kind": "import",
       "label": "开始导入",
       "script": "../../backend/import_flowus.py",
-      "args": ["--progress-every", "1"],
+      "args": ["--progress-every", "1", "--checkpoint-task-id", "xiliu-import"],
       "progressTitle": "息流导入",
       "progressDetail": "正在导入文档..."
     }


### PR DESCRIPTION
## 变更说明

本次修复息流（FlowUs）导入在停止后重新点击“开始导入”时，已完成文档仍会被重复导入的问题。

主要调整：

- 固定息流导入的 checkpoint task id 为 `xiliu-import`，避免每次运行使用新的 jobId 导致 checkpoint 状态分散。
- 兼容旧版本已经生成的 jobId checkpoint：首次使用稳定 task id 时，会从相同 source/target 的最近一次任务继承 item 状态。
- 将 FlowUs `code=3005` 识别为页面不存在，允许断点恢复时重新创建未完成页面。
- 在息流导入高级参数中增加“只重试上次失败项”，对应后端已有的 `--retry-failed` 能力。

## 验证

- `python -m py_compile plugins\xiliu\backend\import_flowus.py`
- 使用 Node 解析 `plugins\xiliu\providers\xiliu-import\provider.json` 成功
- 手动验证：导入过程中停止后再次点击“开始导入”，应跳过已完成项并继续剩余文档