### PR TITLE
fix(ima): 保留笔记 Markdown 并本地化图片

### DIFF
--- a/plugins/ima/backend/ima_knowledge.py
+++ b/plugins/ima/backend/ima_knowledge.py
@@ -17,11 +17,15 @@ import getpass
 import hashlib
 import hmac
 import html
+import http.client
+import ipaddress
 import json
 import mimetypes
 import os
 import random
 import re
+import socket
+import string
 import sys
 import time
 import urllib.error
@@ -133,6 +137,25 @@ MARKDOWN_REFERENCE_RE = re.compile(
     r"!\[[^\]]*\]\(([^)]+)\)|\[[^\]]+\]\(([^)]+)\)|<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']",
     re.IGNORECASE,
 )
+MARKDOWN_FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<rest>[^\r\n]*)")
+MARKDOWN_LIST_MARKER_RE = re.compile(r"(?P<marker>[-+*]|\d{1,9}[.)])(?P<spacing>[ \t]+)")
+MARKDOWN_BACKSLASH_ESCAPE_RE = re.compile(r"\\([" + re.escape(string.punctuation) + r"])")
+MARKDOWN_REFERENCE_DEFINITION_RE = re.compile(
+    r"^ {0,3}\[(?P<label>(?:\\.|[^\]\\\r\n])+)\]:[ \t]*"
+)
+HTML_IMAGE_SOURCE_RE = re.compile(
+    r"(?i)(?<![A-Za-z0-9_:.-])src[ \t]*=[ \t]*"
+    r'(?:"(?P<double>[^"]*)"|\'(?P<single>[^\']*)\'|(?P<bare>[^\s"\'=<>`]+))'
+)
+NOTE_IMAGE_CONTENT_EXTENSIONS = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/avif": ".avif",
+}
+NOTE_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif"}
+MAX_NOTE_IMAGE_BYTES = 20 * 1024 * 1024
 
 
 @dataclass
@@ -155,6 +178,10 @@ class KnowledgeEntry:
     @property
     def export_id(self) -> str:
         return f"{self.kb_id}{DOC_ID_SEPARATOR}{self.media_id}"
+
+    @property
+    def path(self) -> str:
+        return "/".join([self.kb_name, *self.relative_parts, self.title])
 
 
 def emit(message: str, *, event: str = "log.message", level: str = "info", **fields: Any) -> None:
@@ -506,6 +533,694 @@ def extract_content_text(data: dict[str, Any]) -> str:
     return ""
 
 
+def get_note_export_text(client: ImaClient, note_id: str, title: str) -> tuple[str, bool]:
+    data = client.note("get_doc_content", {"note_id": note_id, "target_content_format": 1})
+    markdown = extract_content_text(data)
+    if not markdown:
+        raise ImaError(f"ima 笔记 Markdown 正文为空：{title}")
+    return markdown, False
+
+
+def resolve_public_image_addresses(hostname: str, port: int) -> list[str]:
+    try:
+        results = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise ImaError(f"图片域名解析失败：{exc}") from exc
+    addresses: list[str] = []
+    for item in results:
+        address = item[4][0]
+        if address not in addresses:
+            addresses.append(address)
+    if not addresses:
+        raise ImaError("图片域名没有解析到可用地址")
+    for address in addresses:
+        if not ipaddress.ip_address(address).is_global:
+            raise ImaError("图片地址指向非公网网络")
+    return addresses
+
+
+def validate_remote_image_url(url: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    except ValueError as exc:
+        raise ImaError("图片地址格式无效") from exc
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ImaError("图片地址不是安全的 HTTP/HTTPS URL")
+    resolve_public_image_addresses(parsed.hostname, port)
+    return url
+
+
+def connect_to_public_image_address(connection: http.client.HTTPConnection) -> None:
+    last_error: OSError | None = None
+    for address in resolve_public_image_addresses(connection.host, connection.port):
+        try:
+            connection.sock = connection._create_connection(
+                (address, connection.port),
+                connection.timeout,
+                connection.source_address,
+            )
+            return
+        except OSError as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise ImaError("图片域名没有可连接的公网地址")
+
+
+class PinnedHTTPConnection(http.client.HTTPConnection):
+    def connect(self) -> None:
+        connect_to_public_image_address(self)
+
+
+class PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def connect(self) -> None:
+        connect_to_public_image_address(self)
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
+class PinnedHTTPHandler(urllib.request.HTTPHandler):
+    def http_open(self, request):
+        return self.do_open(PinnedHTTPConnection, request)
+
+
+class PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def https_open(self, request):
+        return self.do_open(PinnedHTTPSConnection, request)
+
+
+class SafeImageRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        validate_remote_image_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def read_note_image_response(response: Any, max_bytes: int = MAX_NOTE_IMAGE_BYTES) -> bytes:
+    try:
+        declared_size = int(str(response.headers.get("Content-Length") or "0") or "0")
+    except ValueError:
+        declared_size = 0
+    if declared_size > max_bytes:
+        raise ImaError(f"图片超过大小限制（{max_bytes // 1024 // 1024} MB）")
+    body = response.read(max_bytes + 1)
+    if len(body) > max_bytes:
+        raise ImaError(f"图片超过大小限制（{max_bytes // 1024 // 1024} MB）")
+    return body
+
+
+def download_note_image(url: str, timeout: int = 120) -> tuple[bytes, str, str]:
+    validate_remote_image_url(url)
+    request = urllib.request.Request(url, headers={"User-Agent": "Wandao/ima-export"})
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        SafeImageRedirectHandler(),
+        PinnedHTTPHandler(),
+        PinnedHTTPSHandler(),
+    )
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            final_url = str(response.geturl() or url)
+            content_type = str(response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+            if not content_type.startswith("image/"):
+                raise ImaError(f"图片响应不是图片类型：{content_type or 'unknown'}")
+            body = read_note_image_response(response)
+    except ImaError:
+        raise
+    except urllib.error.HTTPError as exc:
+        raise ImaError(f"图片下载 HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise ImaError(f"图片下载失败：{exc}") from exc
+    if not body:
+        raise ImaError("图片响应为空")
+    return body, content_type, final_url
+
+
+def note_image_extension(content_type: str, final_url: str) -> str:
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    if normalized in NOTE_IMAGE_CONTENT_EXTENSIONS:
+        return NOTE_IMAGE_CONTENT_EXTENSIONS[normalized]
+    suffix = Path(urllib.parse.urlsplit(final_url).path).suffix.lower()
+    if suffix in NOTE_IMAGE_SUFFIXES:
+        return ".jpg" if suffix == ".jpeg" else suffix
+    raise ImaError(f"不支持的图片类型：{normalized or 'unknown'}")
+
+
+def safe_note_image_url(url: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        return "[invalid image URL]"
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    try:
+        if parsed.port:
+            hostname = f"{hostname}:{parsed.port}"
+    except ValueError:
+        pass
+    return urllib.parse.urlunsplit((parsed.scheme, hostname, parsed.path, "", ""))
+
+
+def markdown_blockquote_prefix(line: str) -> tuple[int, int]:
+    depth = 0
+    index = 0
+    while index < len(line):
+        candidate = index
+        spaces = 0
+        while candidate < len(line) and line[candidate] == " " and spaces < 3:
+            candidate += 1
+            spaces += 1
+        if candidate >= len(line) or line[candidate] != ">":
+            break
+        depth += 1
+        index = candidate + 1
+        if index < len(line) and line[index] in " \t":
+            index += 1
+    return depth, index
+
+
+def markdown_fenced_code_ranges(markdown: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    opening: tuple[str, int, int, int] | None = None
+    offset = 0
+    for line in markdown.splitlines(keepends=True):
+        quote_depth, content_index = markdown_blockquote_prefix(line)
+        if (
+            opening is not None
+            and quote_depth < opening[3]
+            and line[content_index:].strip()
+        ):
+            ranges.append((opening[2], offset))
+            opening = None
+        match = MARKDOWN_FENCE_RE.match(line[content_index:])
+        if match:
+            marker = match.group("marker")
+            rest = match.group("rest")
+            if opening is None:
+                opening = (marker[0], len(marker), offset, quote_depth)
+            elif (
+                marker[0] == opening[0]
+                and len(marker) >= opening[1]
+                and quote_depth == opening[3]
+                and not rest.strip()
+            ):
+                ranges.append((opening[2], offset + len(line)))
+                opening = None
+        offset += len(line)
+    if opening is not None:
+        ranges.append((opening[2], len(markdown)))
+    return ranges
+
+
+def merge_markdown_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(ranges):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def markdown_leading_indent(line: str) -> tuple[int, int]:
+    columns = 0
+    index = 0
+    while index < len(line) and line[index] in " \t":
+        if line[index] == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+        index += 1
+    return columns, index
+
+
+def markdown_list_content_indent(line: str, indent: int, content_index: int, base: int) -> int | None:
+    if indent - base > 3:
+        return None
+    match = MARKDOWN_LIST_MARKER_RE.match(line, content_index)
+    if not match:
+        return None
+    marker_width = len(match.group("marker"))
+    column = indent + marker_width
+    spacing_columns = 0
+    for char in match.group("spacing"):
+        width = 4 - (column % 4) if char == "\t" else 1
+        spacing_columns += width
+        column += width
+    padding = spacing_columns if 1 <= spacing_columns <= 4 else 1
+    return indent + marker_width + padding
+
+
+def markdown_indented_code_ranges(
+    markdown: str,
+    fenced_ranges: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    list_indents: list[int] = []
+    active_quote_depth = 0
+    fence_index = 0
+    offset = 0
+    for line in markdown.splitlines(keepends=True):
+        while fence_index < len(fenced_ranges) and offset >= fenced_ranges[fence_index][1]:
+            fence_index += 1
+        if fence_index < len(fenced_ranges) and offset >= fenced_ranges[fence_index][0]:
+            offset += len(line)
+            continue
+        quote_depth, quote_content_index = markdown_blockquote_prefix(line)
+        content = line[quote_content_index:]
+        if not content.strip():
+            offset += len(line)
+            continue
+        if quote_depth != active_quote_depth:
+            list_indents.clear()
+            active_quote_depth = quote_depth
+        indent, relative_content_index = markdown_leading_indent(content)
+        content_index = quote_content_index + relative_content_index
+        while list_indents and indent < list_indents[-1]:
+            list_indents.pop()
+        base = list_indents[-1] if list_indents else 0
+        list_content_indent = markdown_list_content_indent(line, indent, content_index, base)
+        if list_content_indent is not None:
+            list_indents.append(list_content_indent)
+        elif indent - base >= 4:
+            ranges.append((offset, offset + len(line)))
+        offset += len(line)
+    return ranges
+
+
+def is_markdown_character_escaped(markdown: str, index: int) -> bool:
+    backslashes = 0
+    index -= 1
+    while index >= 0 and markdown[index] == "\\":
+        backslashes += 1
+        index -= 1
+    return bool(backslashes % 2)
+
+
+def markdown_inline_code_end(markdown: str, cursor: int, limit: int | None = None) -> int | None:
+    if markdown[cursor] != "`" or is_markdown_character_escaped(markdown, cursor):
+        return None
+    run_end = cursor + 1
+    while run_end < len(markdown) and markdown[run_end] == "`":
+        run_end += 1
+    marker = markdown[cursor:run_end]
+    search_end = len(markdown) if limit is None else limit
+    closing = markdown.find(marker, run_end, search_end)
+    while closing >= 0 and (
+        (closing > 0 and markdown[closing - 1] == "`")
+        or (closing + len(marker) < len(markdown) and markdown[closing + len(marker)] == "`")
+    ):
+        closing = markdown.find(marker, closing + len(marker), search_end)
+    return closing + len(marker) if closing >= 0 else None
+
+
+def markdown_html_comment_ranges(
+    markdown: str,
+    blocked_ranges: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    blocked_index = 0
+    cursor = 0
+    while cursor < len(markdown):
+        while blocked_index < len(blocked_ranges) and cursor >= blocked_ranges[blocked_index][1]:
+            blocked_index += 1
+        if blocked_index < len(blocked_ranges) and cursor >= blocked_ranges[blocked_index][0]:
+            cursor = blocked_ranges[blocked_index][1]
+            continue
+        limit = blocked_ranges[blocked_index][0] if blocked_index < len(blocked_ranges) else len(markdown)
+        code_end = markdown_inline_code_end(markdown, cursor, limit)
+        if code_end is not None:
+            cursor = code_end
+            continue
+        if markdown.startswith("<!--", cursor):
+            closing = markdown.find("-->", cursor + 4)
+            end = len(markdown) if closing < 0 else closing + 3
+            ranges.append((cursor, end))
+            cursor = end
+            continue
+        cursor += 1
+    return ranges
+
+
+def markdown_ignored_ranges(markdown: str) -> list[tuple[int, int]]:
+    fenced_ranges = markdown_fenced_code_ranges(markdown)
+    block_ranges = merge_markdown_ranges(
+        fenced_ranges + markdown_indented_code_ranges(markdown, fenced_ranges)
+    )
+    return merge_markdown_ranges(
+        block_ranges + markdown_html_comment_ranges(markdown, block_ranges)
+    )
+
+
+def markdown_link_closing_paren(markdown: str, cursor: int) -> int | None:
+    while cursor < len(markdown) and markdown[cursor] in " \t":
+        cursor += 1
+    if cursor >= len(markdown) or markdown[cursor] in "\r\n":
+        return None
+    if markdown[cursor] == ")":
+        return cursor
+    opener = markdown[cursor]
+    closer = {"\"": "\"", "'": "'", "(": ")"}.get(opener)
+    if closer is None:
+        return None
+    cursor += 1
+    escaped = False
+    while cursor < len(markdown):
+        char = markdown[cursor]
+        if char in "\r\n":
+            return None
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == closer:
+            cursor += 1
+            while cursor < len(markdown) and markdown[cursor] in " \t":
+                cursor += 1
+            return cursor if cursor < len(markdown) and markdown[cursor] == ")" else None
+        cursor += 1
+    return None
+
+
+def normalize_markdown_reference_label(label: str) -> str:
+    unescaped = MARKDOWN_BACKSLASH_ESCAPE_RE.sub(r"\1", label)
+    return " ".join(unescaped.split()).casefold()
+
+
+def markdown_reference_definition_targets(
+    markdown: str,
+    reference_labels: set[str],
+    ignored_ranges: list[tuple[int, int]],
+) -> list[tuple[int, int, str]]:
+    if not reference_labels:
+        return []
+    targets: list[tuple[int, int, str]] = []
+    seen_labels: set[str] = set()
+    ignored_index = 0
+    offset = 0
+    for line in markdown.splitlines(keepends=True):
+        while ignored_index < len(ignored_ranges) and offset >= ignored_ranges[ignored_index][1]:
+            ignored_index += 1
+        if ignored_index < len(ignored_ranges) and offset >= ignored_ranges[ignored_index][0]:
+            offset += len(line)
+            continue
+        match = MARKDOWN_REFERENCE_DEFINITION_RE.match(line)
+        if not match:
+            offset += len(line)
+            continue
+        label = normalize_markdown_reference_label(match.group("label"))
+        if label not in reference_labels or label in seen_labels:
+            offset += len(line)
+            continue
+        seen_labels.add(label)
+        cursor = match.end()
+        if cursor >= len(line) or line[cursor] in "\r\n":
+            offset += len(line)
+            continue
+        if line[cursor] == "<":
+            url_start = cursor + 1
+            url_end = url_start
+            escaped = False
+            while url_end < len(line):
+                char = line[url_end]
+                if char in "\r\n":
+                    break
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == ">":
+                    break
+                url_end += 1
+            if url_end >= len(line) or line[url_end] != ">":
+                offset += len(line)
+                continue
+        else:
+            url_start = cursor
+            url_end = cursor
+            escaped = False
+            while url_end < len(line):
+                char = line[url_end]
+                if char in "\r\n" or (char in " \t" and not escaped):
+                    break
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                url_end += 1
+        source_url = MARKDOWN_BACKSLASH_ESCAPE_RE.sub(
+            r"\1",
+            html.unescape(line[url_start:url_end]),
+        )
+        if source_url.lower().startswith(("http://", "https://")):
+            targets.append((offset + url_start, offset + url_end, source_url))
+        offset += len(line)
+    return targets
+
+
+def markdown_html_image_targets(
+    markdown: str,
+    ignored_ranges: list[tuple[int, int]],
+) -> list[tuple[int, int, str]]:
+    targets: list[tuple[int, int, str]] = []
+    ignored_index = 0
+    cursor = 0
+    while cursor < len(markdown):
+        while ignored_index < len(ignored_ranges) and cursor >= ignored_ranges[ignored_index][1]:
+            ignored_index += 1
+        if ignored_index < len(ignored_ranges) and cursor >= ignored_ranges[ignored_index][0]:
+            cursor = ignored_ranges[ignored_index][1]
+            continue
+        limit = ignored_ranges[ignored_index][0] if ignored_index < len(ignored_ranges) else None
+        code_end = markdown_inline_code_end(markdown, cursor, limit)
+        if code_end is not None:
+            cursor = code_end
+            continue
+        if markdown[cursor:cursor + 4].lower() != "<img" or (
+            cursor + 4 < len(markdown)
+            and markdown[cursor + 4] not in " \t\r\n/>"
+        ):
+            cursor += 1
+            continue
+        tag_end = cursor + 4
+        quote = ""
+        while tag_end < len(markdown):
+            char = markdown[tag_end]
+            if quote:
+                if char == quote:
+                    quote = ""
+            elif char in "\"'":
+                quote = char
+            elif char == ">":
+                break
+            tag_end += 1
+        if tag_end >= len(markdown) or markdown[tag_end] != ">":
+            cursor += 4
+            continue
+        tag = markdown[cursor:tag_end + 1]
+        source_match = HTML_IMAGE_SOURCE_RE.search(tag)
+        if source_match:
+            group_name = next(
+                name for name in ("double", "single", "bare")
+                if source_match.group(name) is not None
+            )
+            relative_start, relative_end = source_match.span(group_name)
+            source_url = html.unescape(source_match.group(group_name))
+            if source_url.lower().startswith(("http://", "https://")):
+                targets.append(
+                    (cursor + relative_start, cursor + relative_end, source_url)
+                )
+        cursor = tag_end + 1
+    return targets
+
+
+def iter_markdown_remote_image_targets(markdown: str) -> list[tuple[int, int, str]]:
+    targets: list[tuple[int, int, str]] = []
+    reference_labels: set[str] = set()
+    ignored_ranges = markdown_ignored_ranges(markdown)
+    ignored_index = 0
+    cursor = 0
+    while cursor < len(markdown):
+        while ignored_index < len(ignored_ranges) and cursor >= ignored_ranges[ignored_index][1]:
+            ignored_index += 1
+        if ignored_index < len(ignored_ranges) and cursor >= ignored_ranges[ignored_index][0]:
+            cursor = ignored_ranges[ignored_index][1]
+            continue
+        code_end = markdown_inline_code_end(
+            markdown,
+            cursor,
+            ignored_ranges[ignored_index][0] if ignored_index < len(ignored_ranges) else None,
+        )
+        if code_end is not None:
+            cursor = code_end
+            continue
+        if not markdown.startswith("![", cursor):
+            cursor += 1
+            continue
+        if is_markdown_character_escaped(markdown, cursor):
+            cursor += 2
+            continue
+        label_cursor = cursor + 2
+        label_depth = 1
+        escaped = False
+        while label_cursor < len(markdown) and label_depth:
+            char = markdown[label_cursor]
+            if char in "\r\n":
+                break
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == "[":
+                label_depth += 1
+            elif char == "]":
+                label_depth -= 1
+            label_cursor += 1
+        if label_depth or label_cursor > len(markdown):
+            cursor += 2
+            continue
+        label = markdown[cursor + 2:label_cursor - 1]
+        if label_cursor >= len(markdown) or markdown[label_cursor] != "(":
+            reference_label = label
+            reference_end = label_cursor
+            if label_cursor < len(markdown) and markdown[label_cursor] == "[":
+                closing = markdown.find("]", label_cursor + 1)
+                if closing < 0 or "\n" in markdown[label_cursor:closing] or "\r" in markdown[label_cursor:closing]:
+                    cursor += 2
+                    continue
+                explicit_label = markdown[label_cursor + 1:closing]
+                reference_label = explicit_label or label
+                reference_end = closing + 1
+            normalized_label = normalize_markdown_reference_label(reference_label)
+            if normalized_label:
+                reference_labels.add(normalized_label)
+            cursor = reference_end
+            continue
+        target_cursor = label_cursor + 1
+        while target_cursor < len(markdown) and markdown[target_cursor] in " \t":
+            target_cursor += 1
+        if target_cursor >= len(markdown) or markdown[target_cursor] in "\r\n":
+            cursor += 2
+            continue
+        if markdown[target_cursor] == "<":
+            url_start = target_cursor + 1
+            url_end = url_start
+            escaped = False
+            while url_end < len(markdown):
+                char = markdown[url_end]
+                if char in "\r\n":
+                    break
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == ">":
+                    break
+                url_end += 1
+            if url_end >= len(markdown) or markdown[url_end] != ">":
+                cursor += 2
+                continue
+            link_end = markdown_link_closing_paren(markdown, url_end + 1)
+        else:
+            url_start = target_cursor
+            url_end = target_cursor
+            depth = 0
+            escaped = False
+            link_end = None
+            while url_end < len(markdown):
+                char = markdown[url_end]
+                if char in "\r\n":
+                    break
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == "(":
+                    depth += 1
+                elif char == ")":
+                    if depth == 0:
+                        link_end = url_end
+                        break
+                    depth -= 1
+                elif char in " \t" and depth == 0:
+                    link_end = markdown_link_closing_paren(markdown, url_end)
+                    break
+                url_end += 1
+        if link_end is None or url_end <= url_start:
+            cursor += 2
+            continue
+        source_url = MARKDOWN_BACKSLASH_ESCAPE_RE.sub(
+            r"\1",
+            html.unescape(markdown[url_start:url_end]),
+        )
+        if source_url.lower().startswith(("http://", "https://")):
+            targets.append((url_start, url_end, source_url))
+        cursor = link_end + 1
+    targets.extend(
+        markdown_reference_definition_targets(
+            markdown,
+            reference_labels,
+            ignored_ranges,
+        )
+    )
+    targets.extend(markdown_html_image_targets(markdown, ignored_ranges))
+    return sorted({target for target in targets}, key=lambda target: target[0])
+
+
+def localize_note_images(markdown: str, md_path: Path) -> tuple[str, int, list[dict[str, str]]]:
+    assets_dir = md_path.with_name(f"{md_path.stem}_assets")
+    localized: dict[str, str | None] = {}
+    failures: list[dict[str, str]] = []
+    saved = 0
+    next_index = 1
+
+    def localize(source_url: str) -> str | None:
+        nonlocal saved, next_index
+        if source_url not in localized:
+            index = next_index
+            next_index += 1
+            try:
+                body, content_type, final_url = download_note_image(source_url)
+                extension = note_image_extension(content_type, final_url)
+                assets_dir.mkdir(parents=True, exist_ok=True)
+                target = assets_dir / f"image-{index:03d}{extension}"
+                target.write_bytes(body)
+                relative = urllib.parse.quote(f"{assets_dir.name}/{target.name}", safe="/")
+                localized[source_url] = relative
+                saved += 1
+            except ImaStopped:
+                raise
+            except Exception as exc:
+                localized[source_url] = None
+                failures.append(
+                    {
+                        "kind": "image",
+                        "url": safe_note_image_url(source_url),
+                        "error": str(exc),
+                        "index": str(index),
+                    }
+                )
+        return localized[source_url]
+
+    parts: list[str] = []
+    previous = 0
+    for url_start, url_end, source_url in iter_markdown_remote_image_targets(markdown):
+        relative = localize(source_url)
+        if not relative:
+            continue
+        parts.append(markdown[previous:url_start])
+        parts.append(relative)
+        previous = url_end
+    parts.append(markdown[previous:])
+    rewritten = "".join(parts)
+    return rewritten, saved, failures
+
+
 def extension_for_download(title: str, media_type: int | None, content_type: str) -> str:
     suffix = Path(title).suffix
     if suffix:
@@ -531,24 +1246,35 @@ def download_url(url: str, headers: dict[str, str] | None = None) -> tuple[bytes
         raise ImaError(f"下载原文失败：{exc}") from exc
 
 
-def save_note_entry(client: ImaClient, entry: KnowledgeEntry, target_dir: Path) -> Path:
+def save_note_entry(
+    client: ImaClient,
+    entry: KnowledgeEntry,
+    target_dir: Path,
+    existing_path: Path | None = None,
+) -> tuple[Path, list[dict[str, str]]]:
     media_info = client.wiki("get_media_info", {"media_id": entry.media_id})
     note_id = str((media_info.get("notebook_ext_info") or {}).get("notebook_id") or "")
     if not note_id:
         raise ImaError("笔记类型没有返回 notebook_id")
-    note_data = client.note("get_doc_content", {"note_id": note_id, "target_content_format": 0})
-    text = extract_content_text(note_data).strip()
-    if not text:
-        text = f"# {entry.title}\n\n> ima 笔记接口未返回可导出的正文。"
-    elif not text.lstrip().startswith("#"):
-        text = f"# {entry.title}\n\n{text}\n"
+    text, _ = get_note_export_text(client, note_id, entry.title)
     target_dir.mkdir(parents=True, exist_ok=True)
     target = unique_path(target_dir / f"{sanitize_filename(entry.title)}.md")
+    if existing_path is not None:
+        candidate = existing_path.expanduser().resolve()
+        if candidate.suffix.lower() == ".md" and candidate.parent == target_dir.resolve():
+            target = candidate
+    text, _, resource_failures = localize_note_images(text, target)
     target.write_text(text, "utf-8")
-    return target
+    return target, resource_failures
 
 
-def save_media_entry(client: ImaClient, entry: KnowledgeEntry, output_root: Path) -> tuple[str, Path | None, str]:
+def save_media_entry(
+    client: ImaClient,
+    entry: KnowledgeEntry,
+    output_root: Path,
+    *,
+    existing_note_path: Path | None = None,
+) -> tuple[str, Path | None, str, list[dict[str, str]]]:
     target_dir = output_root / sanitize_filename(entry.kb_name, "knowledge-base")
     for part in entry.relative_parts:
         target_dir /= sanitize_filename(part, "folder")
@@ -557,14 +1283,19 @@ def save_media_entry(client: ImaClient, entry: KnowledgeEntry, output_root: Path
     media_info = client.wiki("get_media_info", {"media_id": entry.media_id})
     media_type = int(media_info.get("media_type") or entry.media_type or 0)
     if media_type == 11:
-        path = save_note_entry(client, entry, target_dir)
-        return "exported_note", path, ""
+        path, resource_failures = save_note_entry(
+            client,
+            entry,
+            target_dir,
+            existing_path=existing_note_path,
+        )
+        return "exported_note", path, "", resource_failures
 
     url_info = media_info.get("url_info") or {}
     url = str(url_info.get("url") or "")
     headers = url_info.get("headers") if isinstance(url_info.get("headers"), dict) else {}
     if not url:
-        return "skipped", None, "ima 未返回可下载原文链接"
+        return "skipped", None, "ima 未返回可下载原文链接", []
 
     content, content_type = download_url(url, {str(k): str(v) for k, v in headers.items()})
     ext = extension_for_download(entry.title, media_type, content_type)
@@ -573,7 +1304,7 @@ def save_media_entry(client: ImaClient, entry: KnowledgeEntry, output_root: Path
         name += ext
     target = unique_path(target_dir / name)
     target.write_bytes(content)
-    return "exported", target, ""
+    return "exported", target, "", []
 
 
 def selected_entries(entries: list[KnowledgeEntry], doc_ids: list[str]) -> list[KnowledgeEntry]:
@@ -596,6 +1327,7 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
     checkpoint = open_checkpoint_from_args(args, "ima", "export")
     kbs, entries = scan_remote_tree(client, args)
     docs = selected_entries(entries, args.doc_id or [])
+    failed_checkpoint_items: dict[str, dict[str, Any]] = {}
     if checkpoint:
         checkpoint.start_task(
             {
@@ -612,15 +1344,20 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
                 title=entry.title,
                 source_url=entry.path,
                 source_id=entry.export_id,
-                parent_key=entry.parent_id,
-                metadata={"exportId": entry.export_id, "mediaId": entry.media_id, "knowledgeBaseId": entry.knowledge_base_id},
+                parent_key=entry.parent_node_id,
+                metadata={"exportId": entry.export_id, "mediaId": entry.media_id, "knowledgeBaseId": entry.kb_id},
             )
+        failed_checkpoint_items = {
+            str(item.get("item_key") or ""): item
+            for item in checkpoint.failed_items()
+        }
         if getattr(args, "retry_failed", False):
             docs = [entry for entry in docs if checkpoint.item_status(f"ima:entry:{entry.export_id}") == "failed"]
     total = len(docs)
     exported = 0
     skipped = 0
     failures: list[dict[str, str]] = []
+    resource_failures: list[dict[str, str]] = []
     started = time.time()
     emit(
         f"开始导出 ima 知识库内容：共 {total} 个文件。",
@@ -642,16 +1379,60 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
                 event="document.export.started",
                 doc={"id": entry.export_id, "title": entry.title, "index": index},
             )
-            status, path, reason = save_media_entry(client, entry, output)
+            previous_item = failed_checkpoint_items.get(item_key) or {}
+            previous_path = str(previous_item.get("local_path") or "").strip()
+            status, path, reason, entry_resource_failures = save_media_entry(
+                client,
+                entry,
+                output,
+                existing_note_path=Path(previous_path) if previous_path else None,
+            )
             if status.startswith("exported"):
                 exported += 1
+                reported_entry_failures = [
+                    {**failure, "document": entry.title}
+                    for failure in entry_resource_failures
+                ]
+                resource_failures.extend(reported_entry_failures)
                 if checkpoint:
-                    checkpoint.complete_item(item_key, local_path=str(path or ""), metadata={"exportId": entry.export_id})
+                    item_metadata = {
+                        "exportId": entry.export_id,
+                        "resourceFailures": reported_entry_failures,
+                    }
+                    if reported_entry_failures:
+                        checkpoint.complete_item(
+                            item_key,
+                            local_path=str(path or ""),
+                            metadata=item_metadata,
+                        )
+                        checkpoint.fail_item(
+                            item_key,
+                            f"{len(reported_entry_failures)} 个资源下载失败",
+                        )
+                    else:
+                        checkpoint.complete_item(
+                            item_key,
+                            local_path=str(path or ""),
+                            metadata=item_metadata,
+                        )
                 emit(
                     f"ima 文件导出完成：{entry.title}",
                     event="document.export.completed",
                     doc={"id": entry.export_id, "title": entry.title, "index": index, "path": str(path)},
                 )
+                for failure in entry_resource_failures:
+                    emit(
+                        f"ima 图片下载失败，已保留远程链接：{entry.title}：{failure.get('error', '')}",
+                        event="resource.download.failed",
+                        level="warn",
+                        doc={"id": entry.export_id, "title": entry.title, "index": index, "path": str(path)},
+                        resource={
+                            "type": failure.get("kind", "image"),
+                            "url": failure.get("url", ""),
+                            "index": failure.get("index", ""),
+                        },
+                        error={"message": failure.get("error", "")},
+                    )
             else:
                 skipped += 1
                 if reason:
@@ -684,7 +1465,12 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
                 f"progress {index}/{total} exported={exported} skipped={skipped} failures={len(failures)}",
                 event="task.progress",
                 progress={"current": index, "total": total},
-                stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
+                stats={
+                    "exportedDocs": exported,
+                    "skippedDocs": skipped,
+                    "failureCount": len(failures),
+                    "resourceFailureCount": len(resource_failures),
+                },
             )
     report = {
         "provider": "ima",
@@ -695,6 +1481,8 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
         "skippedDocs": skipped,
         "failureCount": len(failures),
         "failures": failures[:20],
+        "resourceFailureCount": len(resource_failures),
+        "resourceFailures": resource_failures,
         "output": str(output),
         "elapsedSeconds": round(time.time() - started, 1),
         "requestCount": int(getattr(args, "_request_count", 0) or 0),
@@ -703,16 +1491,29 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
         report["checkpoint"] = checkpoint.stats()
     report = finalize_report(report, provider="ima", mode="export", output=output)
     if checkpoint:
-        if failures:
-            checkpoint.fail_task(f"{len(failures)} 个文档失败", status="failed")
+        if failures or resource_failures:
+            checkpoint.fail_task(
+                f"{len(failures)} 个文档失败，{len(resource_failures)} 个资源失败",
+                status="failed",
+            )
         else:
             checkpoint.complete_task(report)
         checkpoint.close()
+    warning_parts = []
+    if failures:
+        warning_parts.append(f"{len(failures)} 个文档失败")
+    if resource_failures:
+        warning_parts.append(f"{len(resource_failures)} 个资源下载失败")
     emit(
-        "ima 导出完成" if not failures else f"ima 导出完成，但有 {len(failures)} 个失败项",
+        "ima 导出完成" if not warning_parts else f"ima 导出完成，但有{'，'.join(warning_parts)}",
         event="task.completed",
-        level="success" if not failures else "warn",
-        stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
+        level="success" if not warning_parts else "warn",
+        stats={
+            "exportedDocs": exported,
+            "skippedDocs": skipped,
+            "failureCount": len(failures),
+            "resourceFailureCount": len(resource_failures),
+        },
     )
     return report
 

--- a/plugins/ima/plugin.json
+++ b/plugins/ima/plugin.json
@@ -4,7 +4,7 @@
   "id": "ima",
   "name": "ima 知识库",
   "description": "ima 知识库 OpenAPI 导出与本地文件批量导入。",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "Wandao Official",
   "homepage": "https://ima.qq.com/",
   "license": "AGPL-3.0-only",

--- a/tests/test_ima_note_export.py
+++ b/tests/test_ima_note_export.py
@@ -1,0 +1,663 @@
+import argparse
+import json
+import sqlite3
+import tempfile
+import unittest
+from contextlib import closing
+from pathlib import Path
+from unittest import mock
+
+from plugins.ima.backend import ima_knowledge as ima
+from wandao_core.checkpoint import WandaoCheckpoint
+
+
+class FakeClient:
+    def __init__(self, note_responses):
+        self.note_responses = iter(note_responses)
+        self.note_calls = []
+        self.args = None
+
+    def note(self, action, payload):
+        self.note_calls.append((action, payload))
+        response = next(self.note_responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class FakeImageResponse:
+    def __init__(
+        self,
+        body,
+        content_type,
+        url="https://cdn.example.test/a.png",
+        content_length="",
+    ):
+        self.body = body
+        self.headers = {"Content-Type": content_type}
+        if content_length:
+            self.headers["Content-Length"] = content_length
+        self.url = url
+
+    def read(self, size=-1):
+        return self.body if size < 0 else self.body[:size]
+
+    def geturl(self):
+        return self.url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class ImaNoteExportTests(unittest.TestCase):
+    def export_args(self, output):
+        return argparse.Namespace(
+            output=str(output),
+            checkpoint_file="",
+            doc_id=[],
+            knowledge_base_id="",
+            resume=False,
+            retry_failed=False,
+            progress_every=1,
+        )
+
+    def test_get_note_export_text_requests_markdown_first(self):
+        markdown = "# Note\n\n**bold**\n\n![image](https://cdn.example.test/a.png)"
+        client = FakeClient([{"content": markdown}])
+
+        text, downgraded = ima.get_note_export_text(client, "note-id", "Note")
+
+        self.assertEqual(text, markdown)
+        self.assertFalse(downgraded)
+        self.assertEqual(
+            client.note_calls,
+            [("get_doc_content", {"note_id": "note-id", "target_content_format": 1})],
+        )
+
+    def test_get_note_export_text_preserves_markdown_verbatim_without_synthesized_title(self):
+        markdown = "    indented code\n\nparagraph with trailing spaces  \n"
+        client = FakeClient([{"content": markdown}])
+
+        text, downgraded = ima.get_note_export_text(client, "note-id", "Note")
+
+        self.assertEqual(text, markdown)
+        self.assertFalse(downgraded)
+
+    def test_get_note_export_text_propagates_markdown_failure_without_plain_text_retry(self):
+        client = FakeClient([ima.ImaError("markdown failed"), {"content": "plain body"}])
+
+        with self.assertRaisesRegex(ima.ImaError, "markdown failed"):
+            ima.get_note_export_text(client, "note-id", "Note")
+
+        self.assertEqual(len(client.note_calls), 1)
+        self.assertEqual(client.note_calls[0][1]["target_content_format"], 1)
+
+    def test_localize_note_images_writes_assets_and_rewrites_links(self):
+        markdown = (
+            "# Note\n\n![first](https://cdn.example.test/a)\n\n"
+            "![second](https://cdn.example.test/b.jpg)\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            responses = [
+                (b"png", "image/png", "https://cdn.example.test/a"),
+                (b"jpg", "image/jpeg", "https://cdn.example.test/b.jpg"),
+            ]
+            with mock.patch.object(ima, "download_note_image", side_effect=responses):
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            self.assertEqual(saved, 2)
+            self.assertEqual(failures, [])
+            self.assertIn("![first](Note_assets/image-001.png)", rewritten)
+            self.assertIn("![second](Note_assets/image-002.jpg)", rewritten)
+            self.assertEqual((Path(directory) / "Note_assets" / "image-001.png").read_bytes(), b"png")
+
+    def test_localize_note_images_without_images_does_not_create_assets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+
+            rewritten, saved, failures = ima.localize_note_images("# Note\n\nBody", md_path)
+
+            self.assertEqual(rewritten, "# Note\n\nBody")
+            self.assertEqual(saved, 0)
+            self.assertEqual(failures, [])
+            self.assertFalse((Path(directory) / "Note_assets").exists())
+
+    def test_localize_note_images_deduplicates_urls(self):
+        markdown = "![one](https://cdn.example.test/a.png) ![two](https://cdn.example.test/a.png)"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", "https://cdn.example.test/a.png"),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            self.assertEqual(download.call_count, 1)
+            self.assertEqual(saved, 1)
+            self.assertEqual(rewritten.count("Note_assets/image-001.png"), 2)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_rewrites_reference_style_image_definition(self):
+        url = "https://cdn.example.test/reference.png?key=one&signature=two"
+        markdown = f"![diagram][Asset ID]\n\n[asset id]: <{url}> \"caption\"\n"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", url),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(url)
+            self.assertIn("![diagram][Asset ID]", rewritten)
+            self.assertIn('[asset id]: <Note_assets/image-001.png> "caption"', rewritten)
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_rewrites_html_img_src(self):
+        markdown_url = "https://cdn.example.test/image.webp?key=one&amp;signature=two"
+        download_url = "https://cdn.example.test/image.webp?key=one&signature=two"
+        markdown = f'<figure><img alt="diagram" src="{markdown_url}"></figure>'
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"webp", "image/webp", download_url),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(download_url)
+            self.assertEqual(
+                rewritten,
+                '<figure><img alt="diagram" src="Note_assets/image-001.webp"></figure>',
+            )
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_resumes_after_unclosed_blockquote_fence(self):
+        code_url = "https://cdn.example.test/code.png"
+        image_url = "https://cdn.example.test/outside.png"
+        markdown = (
+            f"> ```md\n> ![code]({code_url})\n\n"
+            f"![outside]({image_url})\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", image_url),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(image_url)
+            self.assertIn(f"![code]({code_url})", rewritten)
+            self.assertIn("![outside](Note_assets/image-001.png)", rewritten)
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_unescapes_ima_signed_url_query(self):
+        markdown = "![one](https://cdn.example.test/a.webp?key=one\\&signature=two)"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(
+                    b"webp",
+                    "image/webp",
+                    "https://cdn.example.test/a.webp?key=one&signature=two",
+                ),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(
+                "https://cdn.example.test/a.webp?key=one&signature=two"
+            )
+            self.assertEqual(rewritten, "![one](Note_assets/image-001.webp)")
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_supports_balanced_parentheses_in_url(self):
+        url = "https://cdn.example.test/a_(b).png"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", url),
+            ):
+                rewritten, saved, failures = ima.localize_note_images(
+                    f"before ![one]({url}) after", md_path
+                )
+
+            self.assertEqual(rewritten, "before ![one](Note_assets/image-001.png) after")
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_ignores_code_and_escaped_images(self):
+        real_url = "https://cdn.example.test/real.png"
+        markdown = (
+            "\\![escaped](https://cdn.example.test/escaped.png)\n"
+            "`![inline](https://cdn.example.test/inline.png)`\n"
+            "```markdown\n![fenced](https://cdn.example.test/fenced.png)\n```\n"
+            f"![real]({real_url})\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", real_url),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(real_url)
+            self.assertIn("\\![escaped](https://cdn.example.test/escaped.png)", rewritten)
+            self.assertIn("`![inline](https://cdn.example.test/inline.png)`", rewritten)
+            self.assertIn("![fenced](https://cdn.example.test/fenced.png)", rewritten)
+            self.assertIn("![real](Note_assets/image-001.png)", rewritten)
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_ignores_indented_code_and_html_comments(self):
+        real_markdown_url = "https://cdn.example.test/a_\\(b\\).png"
+        real_download_url = "https://cdn.example.test/a_(b).png"
+        markdown = (
+            "    ![indented](https://cdn.example.test/indented.png)\n"
+            ">     ![quoted-code](https://cdn.example.test/quoted-code.png)\n"
+            "<!-- ![comment](https://cdn.example.test/comment.png) -->\n"
+            f"\\`literal ![real]({real_markdown_url}) backtick\\`\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", real_download_url),
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            download.assert_called_once_with(real_download_url)
+            self.assertIn("![indented](https://cdn.example.test/indented.png)", rewritten)
+            self.assertIn(
+                "![quoted-code](https://cdn.example.test/quoted-code.png)",
+                rewritten,
+            )
+            self.assertIn("![comment](https://cdn.example.test/comment.png)", rewritten)
+            self.assertIn("![real](Note_assets/image-001.png)", rewritten)
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_respects_list_and_block_context(self):
+        list_url = "https://cdn.example.test/list.png"
+        after_fence_url = "https://cdn.example.test/after.png"
+        markdown = (
+            "- item\n\n"
+            f"    ![list]({list_url})\n\n"
+            "```markdown\n<!-- unclosed inside code\n```\n"
+            f"![after]({after_fence_url})\n"
+            "    ![code](https://cdn.example.test/code.png)\n"
+            " \t![mixed](https://cdn.example.test/mixed.png)\n"
+        )
+
+        def image_response(url):
+            return b"png", "image/png", url
+
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                side_effect=image_response,
+            ) as download:
+                rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            self.assertEqual(
+                [call.args[0] for call in download.call_args_list],
+                [list_url, after_fence_url],
+            )
+            self.assertIn("![list](Note_assets/image-001.png)", rewritten)
+            self.assertIn("![after](Note_assets/image-002.png)", rewritten)
+            self.assertIn("![code](https://cdn.example.test/code.png)", rewritten)
+            self.assertIn("![mixed](https://cdn.example.test/mixed.png)", rewritten)
+            self.assertEqual(saved, 2)
+            self.assertEqual(failures, [])
+
+    def test_localize_note_images_keeps_remote_url_on_failure(self):
+        url = "https://cdn.example.test/a.png"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(ima, "download_note_image", side_effect=ima.ImaError("HTTP 500")):
+                rewritten, saved, failures = ima.localize_note_images(f"![one]({url})", md_path)
+
+            self.assertEqual(rewritten, f"![one]({url})")
+            self.assertEqual(saved, 0)
+            self.assertEqual(len(failures), 1)
+            self.assertEqual(failures[0]["kind"], "image")
+            self.assertFalse((Path(directory) / "Note_assets").exists())
+
+    def test_localize_note_images_records_malformed_url_as_resource_failure(self):
+        markdown = "![one](https://[bad.example/a.png)"
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+
+            rewritten, saved, failures = ima.localize_note_images(markdown, md_path)
+
+            self.assertEqual(rewritten, markdown)
+            self.assertEqual(saved, 0)
+            self.assertEqual(len(failures), 1)
+            self.assertEqual(failures[0]["url"], "[invalid image URL]")
+            self.assertFalse((Path(directory) / "Note_assets").exists())
+
+    def test_localize_note_images_does_not_swallow_stop_signal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                side_effect=ima.ImaStopped("stopped"),
+            ):
+                with self.assertRaisesRegex(ima.ImaStopped, "stopped"):
+                    ima.localize_note_images("![one](https://cdn.example.test/a.png)", md_path)
+
+    def test_localize_note_images_uses_final_markdown_stem(self):
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "Note_2.md"
+            with mock.patch.object(
+                ima,
+                "download_note_image",
+                return_value=(b"png", "image/png", "https://cdn.example.test/a.png"),
+            ):
+                rewritten, saved, failures = ima.localize_note_images(
+                    "![one](https://cdn.example.test/a.png)", md_path
+                )
+
+            self.assertEqual(saved, 1)
+            self.assertEqual(failures, [])
+            self.assertEqual(rewritten, "![one](Note_2_assets/image-001.png)")
+            self.assertTrue((Path(directory) / "Note_2_assets" / "image-001.png").is_file())
+
+    def test_validate_remote_image_url_rejects_private_destinations(self):
+        urls = (
+            "http://127.0.0.1/a.png",
+            "http://[::1]/a.png",
+            "http://user:pass@example.com/a.png",
+        )
+        for url in urls:
+            with self.subTest(url=url), self.assertRaises(ima.ImaError):
+                ima.validate_remote_image_url(url)
+
+    def test_validate_remote_image_url_rejects_non_global_destination(self):
+        resolution = [
+            (ima.socket.AF_INET, ima.socket.SOCK_STREAM, 6, "", ("100.64.0.1", 443))
+        ]
+        with mock.patch.object(ima.socket, "getaddrinfo", return_value=resolution):
+            with self.assertRaisesRegex(ima.ImaError, "公网"):
+                ima.validate_remote_image_url("https://cdn.example.test/a.png")
+
+    def test_pinned_http_connection_connects_to_validated_ip(self):
+        resolution = [
+            (ima.socket.AF_INET, ima.socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))
+        ]
+        connection = ima.PinnedHTTPConnection("cdn.example.test", 80, timeout=5)
+        fake_socket = mock.Mock()
+        connection._create_connection = mock.Mock(return_value=fake_socket)
+
+        with mock.patch.object(ima.socket, "getaddrinfo", return_value=resolution):
+            connection.connect()
+
+        connection._create_connection.assert_called_once_with(
+            ("8.8.8.8", 80), 5, None
+        )
+
+    def test_pinned_https_connection_preserves_hostname_for_tls(self):
+        connection = ima.PinnedHTTPSConnection("cdn.example.test", 443, timeout=5)
+        raw_socket = mock.Mock()
+        wrapped_socket = mock.Mock()
+        connection._context = mock.Mock()
+        connection._context.wrap_socket.return_value = wrapped_socket
+
+        def connect_pinned(target):
+            target.sock = raw_socket
+
+        with mock.patch.object(
+            ima,
+            "connect_to_public_image_address",
+            side_effect=connect_pinned,
+        ):
+            connection.connect()
+
+        connection._context.wrap_socket.assert_called_once_with(
+            raw_socket,
+            server_hostname="cdn.example.test",
+        )
+        self.assertIs(connection.sock, wrapped_socket)
+
+    def test_read_note_image_response_enforces_size_limit(self):
+        response = FakeImageResponse(b"12345", "image/png")
+
+        with self.assertRaisesRegex(ima.ImaError, "大小限制"):
+            ima.read_note_image_response(response, max_bytes=4)
+
+    def test_download_note_image_rejects_non_image_response(self):
+        opener = mock.Mock()
+        opener.open.return_value = FakeImageResponse(b"<html>error</html>", "text/html")
+        with (
+            mock.patch.object(ima, "validate_remote_image_url", side_effect=lambda url: url),
+            mock.patch.object(ima.urllib.request, "build_opener", return_value=opener),
+        ):
+            with self.assertRaisesRegex(ima.ImaError, "不是图片"):
+                ima.download_note_image("https://cdn.example.test/a.png")
+
+    def test_download_note_image_does_not_resolve_again_after_pinned_response(self):
+        opener = mock.Mock()
+        opener.open.return_value = FakeImageResponse(b"png", "image/png")
+        with (
+            mock.patch.object(ima, "validate_remote_image_url") as validate,
+            mock.patch.object(ima.urllib.request, "build_opener", return_value=opener),
+        ):
+            body, content_type, final_url = ima.download_note_image(
+                "https://cdn.example.test/a.png"
+            )
+
+        validate.assert_called_once_with("https://cdn.example.test/a.png")
+        self.assertEqual((body, content_type, final_url), (
+            b"png",
+            "image/png",
+            "https://cdn.example.test/a.png",
+        ))
+
+    def test_safe_note_image_url_removes_credentials_and_query(self):
+        sanitized = ima.safe_note_image_url(
+            "https://user:secret@example.com/image.png?token=private#fragment"
+        )
+
+        self.assertEqual(sanitized, "https://example.com/image.png")
+
+    def test_save_media_entry_keeps_non_note_export_contract(self):
+        client = mock.Mock()
+        client.wiki.return_value = {
+            "media_type": 7,
+            "url_info": {"url": "https://cdn.example.test/note.md"},
+        }
+        entry = ima.KnowledgeEntry("kb", "KB", "media", "Doc.md", "", [], False, 7)
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.object(
+                ima,
+                "download_url",
+                return_value=(b"# Doc", "text/markdown"),
+            ):
+                status, path, reason, resource_failures = ima.save_media_entry(
+                    client,
+                    entry,
+                    Path(directory),
+                )
+
+            self.assertEqual(status, "exported")
+            self.assertEqual(path.read_bytes(), b"# Doc")
+            self.assertEqual(reason, "")
+            self.assertEqual(resource_failures, [])
+
+    def test_save_note_entry_reuses_checkpoint_path(self):
+        client = mock.Mock()
+        client.wiki.return_value = {"notebook_ext_info": {"notebook_id": "note-id"}}
+        entry = ima.KnowledgeEntry("kb", "KB", "note", "Note", "", [], False, 11)
+        with tempfile.TemporaryDirectory() as directory:
+            target_dir = Path(directory) / "KB"
+            target_dir.mkdir()
+            existing_path = target_dir / "Note.md"
+            existing_path.write_text("old", encoding="utf-8")
+            with (
+                mock.patch.object(
+                    ima,
+                    "get_note_export_text",
+                    return_value=("# Note\n\nnew", False),
+                ),
+                mock.patch.object(
+                    ima,
+                    "localize_note_images",
+                    return_value=("# Note\n\nnew", 0, []),
+                ) as localize,
+            ):
+                path, resource_failures = ima.save_note_entry(
+                    client,
+                    entry,
+                    target_dir,
+                    existing_path=existing_path,
+                )
+
+            self.assertEqual(path, existing_path)
+            self.assertEqual(path.read_text("utf-8"), "# Note\n\nnew")
+            localize.assert_called_once_with("# Note\n\nnew", existing_path)
+            self.assertEqual(resource_failures, [])
+            self.assertFalse((target_dir / "Note_2.md").exists())
+
+    def test_export_selected_reports_note_image_failures_as_partial(self):
+        kb = ima.KnowledgeBase("kb", "KB")
+        entry = ima.KnowledgeEntry("kb", "KB", "note", "Note", "", [], False, 11)
+        failure = {"kind": "image", "url": "https://cdn.example.test/a.png", "error": "HTTP 500", "index": "1"}
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "KB" / "Note.md"
+            with (
+                mock.patch.object(ima, "scan_remote_tree", return_value=([kb], [entry])),
+                mock.patch.object(
+                    ima,
+                    "save_media_entry",
+                    return_value=("exported_note", path, "", [failure]),
+                ),
+                mock.patch.object(ima, "emit"),
+            ):
+                report = ima.export_selected(object(), self.export_args(directory))
+
+        self.assertEqual(report["exportedDocs"], 1)
+        self.assertEqual(report["failureCount"], 0)
+        self.assertEqual(report["resourceFailureCount"], 1)
+        self.assertEqual(report["resourceFailures"][0]["document"], "Note")
+        self.assertEqual(report["outcome"], "partial")
+
+    def test_export_selected_reports_clean_resource_outcome(self):
+        kb = ima.KnowledgeBase("kb", "KB")
+        entry = ima.KnowledgeEntry("kb", "KB", "note", "Note", "", [], False, 11)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "KB" / "Note.md"
+            with (
+                mock.patch.object(ima, "scan_remote_tree", return_value=([kb], [entry])),
+                mock.patch.object(
+                    ima,
+                    "save_media_entry",
+                    return_value=("exported_note", path, "", []),
+                ),
+                mock.patch.object(ima, "emit"),
+            ):
+                report = ima.export_selected(object(), self.export_args(directory))
+
+        self.assertEqual(report["resourceFailureCount"], 0)
+        self.assertEqual(report["resourceFailures"], [])
+        self.assertEqual(report["outcome"], "completed")
+
+    def test_export_selected_marks_resource_failure_item_retryable(self):
+        kb = ima.KnowledgeBase("kb", "KB")
+        entry = ima.KnowledgeEntry("kb", "KB", "note", "Note", "", [], False, 11)
+        failure = {
+            "kind": "image",
+            "url": "https://cdn.example.test/a.png",
+            "error": "HTTP 500",
+            "index": "1",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "KB" / "Note.md"
+            path.parent.mkdir(parents=True)
+            path.write_text("![remote](https://cdn.example.test/a.png)", encoding="utf-8")
+            checkpoint_file = Path(directory) / "checkpoint.sqlite"
+            args = self.export_args(directory)
+            args.checkpoint_file = str(checkpoint_file)
+            args.checkpoint_task_id = "ima-resource-retry"
+            save_entry = mock.Mock(
+                return_value=("exported_note", path, "", [failure])
+            )
+
+            original_fail_item = WandaoCheckpoint.fail_item
+
+            def legacy_fail_item(checkpoint, item_key, error, retryable=True):
+                return original_fail_item(checkpoint, item_key, error, retryable)
+
+            with (
+                mock.patch.object(ima, "scan_remote_tree", return_value=([kb], [entry])),
+                mock.patch.object(ima, "save_media_entry", save_entry),
+                mock.patch.object(ima, "emit"),
+                mock.patch.object(WandaoCheckpoint, "fail_item", legacy_fail_item),
+            ):
+                ima.export_selected(object(), args)
+
+            with closing(sqlite3.connect(checkpoint_file)) as connection:
+                failed_row = connection.execute(
+                    "SELECT status, local_path, metadata_json "
+                    "FROM items WHERE item_key = ?",
+                    (f"ima:entry:{entry.export_id}",),
+                ).fetchone()
+
+            def retry_save(_client, _entry, _output, *, existing_note_path=None):
+                self.assertEqual(existing_note_path, path)
+                path.write_text("![local](Note_assets/image-001.png)", encoding="utf-8")
+                return "exported_note", path, "", []
+
+            args.retry_failed = True
+            save_entry.side_effect = retry_save
+            with (
+                mock.patch.object(ima, "scan_remote_tree", return_value=([kb], [entry])),
+                mock.patch.object(ima, "save_media_entry", save_entry),
+                mock.patch.object(ima, "emit"),
+            ):
+                retry_report = ima.export_selected(object(), args)
+
+            with closing(sqlite3.connect(checkpoint_file)) as connection:
+                completed_row = connection.execute(
+                    "SELECT status, local_path FROM items WHERE item_key = ?",
+                    (f"ima:entry:{entry.export_id}",),
+                ).fetchone()
+
+            self.assertEqual(failed_row[0], "failed")
+            self.assertEqual(failed_row[1], str(path))
+            metadata = json.loads(failed_row[2])
+            self.assertEqual(len(metadata["resourceFailures"]), 1)
+            self.assertEqual(retry_report["outcome"], "completed")
+            self.assertEqual(completed_row, ("completed", str(path)))
+            self.assertFalse((path.parent / "Note_2.md").exists())
+
+    def test_ima_plugin_version_is_1_0_4(self):
+        manifest = Path(ima.__file__).resolve().parents[1] / "plugin.json"
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["version"], "1.0.4")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

- Closes #122

## 改动内容

- IMA 笔记正文改为请求并原样保存 Markdown，不再在 Markdown 请求失败时静默降级为纯文本。
- 将 Markdown 行内图片、引用式图片和 HTML `<img>` 的远程资源下载到同名 `_assets` 目录，并改写为相对路径。
- 图片下载增加地址校验、重定向校验、响应类型和大小限制；单张图片失败时保留原链接并进入资源失败报告。
- IMA 插件版本由 `1.0.3` 提升到 `1.0.4`，新增 IMA 导出专项回归测试。

## 为什么需要这个改动

- 现有 IMA 笔记导出可能丢失 Markdown 格式，正文中的图片也不会随文档落盘。
- 用户离线查看或迁移导出结果时，需要保留标题、列表、引用、代码块等 Markdown 结构及可访问的本地图片。

## 共创流程确认

- [x] 我已经搜索过已有 Issue 和 PR，没有重复实现同一个功能或 Bug。
- [x] 已关联并按 Issue #122 的单一范围实现。
- [x] 这个 PR 只修改 IMA 插件及其专项测试，没有通用底层或其他平台改动。
- [x] 没有提交 Cookie、账号密码、App Secret、Token、API Key 或私人知识库内容。

## 测试方式

- [x] 已运行 `python scripts/quality_check.py`
- [x] 已通过 `node scripts/validate_plugins.js` 和 `node --test tests_js/plugin_manager.test.js`（由完整质量检查覆盖）
- [x] 已通过 Python 编译和完整 Python 测试
- [x] 已通过桌面前端 JS 语法检查
- [x] 已通过 Rust 1.88.0 的 fmt、check、test 和 Clippy（完整质量检查覆盖，Rust 源码未改）
- [x] 已在桌面端手动测试 IMA 导出
- [x] 已测试图片处理与资源失败报告
- [x] 已测试代码块、引用、列表等 Markdown 边界
- [x] 已确认 `git diff --check` 无空白错误

具体过程：

```text
python scripts\quality_check.py
python -m unittest tests.test_ima_note_export

git diff --check
```

结果：完整质量检查退出码为 0；IMA 专项测试 32 项通过。桌面端使用 10 项脱敏样例验证，导出 10/10，文件失败 0，资源失败 0。

## 涉及范围

- [x] ima 知识库
- [ ] 其他平台导出或导入
- [ ] Provider 架构
- [ ] 桌面端界面
- [ ] Tauri 2 / Rust 主进程

## 新增或修改在线插件检查

- [x] 业务改动仅位于 `plugins/ima`，测试仅新增 IMA 专项文件
- [x] 已提升 `plugin.json.version` 到 `1.0.4`，`core.minVersion` 未改变
- [x] 权限声明未扩大
- [x] 没有导入其他平台的业务脚本
- [x] 已通过插件验证和 plugin-manager 测试

## 稳定发布申请（可选）

本 PR 不申请调整插件发布等级。

## 插件验收证据（新增或修改 `plugins/` 时必填）

### 界面与导入导出效果

- 桌面端：10 项脱敏样例全部完成导出，文件失败 0，资源失败 0。
- Markdown：专项测试验证正文逐字保留，不合成标题、不去除首尾空白；Markdown 请求失败会明确报错。
- 图片：专项测试验证行内图片、引用式图片、HTML `<img>`、重复 URL、转义查询参数及括号 URL 的本地化。
- 特殊格式：代码围栏、缩进代码、行内代码、引用中的代码、HTML 注释内伪图片均不会被误下载。
- 失败路径：专项测试验证非法地址、私网地址、非图片响应、超限响应及单图失败报告。
- 截图未随 PR 提交，避免暴露私人知识库内容；验收依据为脱敏自动化 fixture 与上述脱敏桌面结果摘要。

### 自测与可靠性

- [x] 图片保存到最终 Markdown 文件同名的 `_assets` 目录，重复 URL 只下载一次
- [x] 图片失败保留远程链接，并记录为可重试资源失败项
- [x] checkpoint 已有路径会被复用，不改变非笔记媒体的导出契约
- [x] 停止信号不会被图片失败处理吞掉
- [x] 下载逐跳校验目标地址，并限制内容类型与最大响应大小
- [ ] 附件处理：不适用，本 PR 只处理 IMA 笔记内图片
- [ ] 导入效果：不适用，本 PR 只修改导出
- [ ] 并发与 429 退避：不适用，本 PR 未引入并发或修改请求节流

## Provider v1 兼容检查

不适用：本 PR 不修改旧 `providers/` 兼容目录或 Provider v1 声明。

## 用户影响

不需要重新登录或重新配置。更新 IMA 插件后重新导出笔记即可获得 Markdown 正文和本地图片目录。非笔记媒体及其他平台行为不变。

## 已知限制

- 仅本地化 HTTP/HTTPS 图片；data URI、相对路径和其他协议保持原样。
- 单张图片下载失败不会中止整篇笔记，原远程链接会保留，并在资源失败报告中记录脱敏后的地址和错误。
- IMA 未返回 Markdown 正文或 Markdown 接口失败时，该笔记会明确失败，不再导出伪装成 Markdown 的纯文本。

## 截图或效果

为避免提交私人知识库内容，本 PR 不附真实平台截图。自动化测试使用 `example.test`、合成 ID 和临时目录，桌面验收仅提供脱敏汇总数字。

## 敏感信息检查

- [x] PR 中不包含 Cookie、账号密码、App Secret、Token、API Key 等敏感信息
- [x] 未提交原始日志、真实知识库名称、笔记标题、平台 ID 或用户本地路径
- [x] 测试文件仅使用合成内容、保留测试域名和临时目录

## 补充说明

本 PR 为一个提交、三个文件；`wandao_core` 与其他平台插件相对 `main` 均无改动。