### PR TITLE
fix(ima): preserve Markdown images on import and export

### DIFF
--- a/plugins/ima/backend/ima_knowledge.py
+++ b/plugins/ima/backend/ima_knowledge.py
@@ -13,6 +13,7 @@ download APIs.
 from __future__ import annotations
 
 import argparse
+import base64
 import getpass
 import hashlib
 import hmac
@@ -22,6 +23,8 @@ import mimetypes
 import os
 import random
 import re
+import shutil
+import socket
 import sys
 import time
 import urllib.error
@@ -133,6 +136,31 @@ MARKDOWN_REFERENCE_RE = re.compile(
     r"!\[[^\]]*\]\(([^)]+)\)|\[[^\]]+\]\(([^)]+)\)|<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']",
     re.IGNORECASE,
 )
+MARKDOWN_IMAGE_RE = re.compile(
+    r"!\[[^\]]*\]\(\s*(?:<(?P<bracket>https?://[^>\s]+)>|(?P<plain>https?://[^)\s]+))",
+    re.IGNORECASE,
+)
+HTML_IMAGE_RE = re.compile(r"<img\b[^>]*\bsrc\s*=\s*[\"'](?P<src>[^\"']+)[\"']", re.IGNORECASE)
+REMOTE_URL_RE = re.compile(r"https?://[^\s<>\"')]+", re.IGNORECASE)
+DATA_IMAGE_RE = re.compile(r"data:image/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+", re.IGNORECASE)
+IMAGE_URL_SUFFIXES = {".avif", ".bmp", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
+READ_RETRY_ACTIONS = {
+    "check_repeated_names",
+    "get_addable_knowledge_base_list",
+    "get_doc_content",
+    "get_knowledge_list",
+    "get_media_info",
+    "search_knowledge_base",
+}
+BARE_IMAGE_LINE_RE = re.compile(
+    r"(?m)^(?P<indent>\s*)(?P<url>https?://[^\s<>\"')]+)(?P<trailing>\s*)$",
+    re.IGNORECASE,
+)
+MARKDOWN_IMAGE_REFERENCE_RE = re.compile(
+    r"!\[[^\]]*\]\(\s*(?P<value><[^>\n]+>|[^)\n]+)\)",
+    re.IGNORECASE,
+)
+HTML_IMAGE_REFERENCE_RE = re.compile(r"<img\b[^>]*\bsrc\s*=\s*[\"'](?P<src>[^\"']+)[\"']", re.IGNORECASE)
 
 
 @dataclass
@@ -266,6 +294,15 @@ def throttle(args: argparse.Namespace | None) -> None:
     args._request_count = int(getattr(args, "_request_count", 0) or 0) + 1
 
 
+def is_timeout_exception(exc: BaseException) -> bool:
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return True
+    if isinstance(exc, urllib.error.URLError):
+        reason = exc.reason
+        return isinstance(reason, (TimeoutError, socket.timeout)) or "timed out" in str(reason).lower()
+    return "timed out" in str(exc).lower()
+
+
 class ImaClient:
     def __init__(self, client_id: str, api_key: str, args: argparse.Namespace | None = None) -> None:
         self.client_id = client_id
@@ -273,28 +310,46 @@ class ImaClient:
         self.args = args
 
     def post(self, base_path: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:
-        check_stopped(self.args)
-        throttle(self.args)
         url = f"{BASE_URL}/{base_path}/{action}"
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        request = urllib.request.Request(
-            url,
-            data=body,
-            headers={
-                "Content-Type": "application/json",
-                "ima-openapi-clientid": self.client_id,
-                "ima-openapi-apikey": self.api_key,
-            },
-            method="POST",
-        )
-        try:
-            with urllib.request.urlopen(request, timeout=60) as response:
-                raw = response.read().decode("utf-8", errors="replace")
-        except urllib.error.HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")
-            raise ImaError(f"ima API HTTP {exc.code}：{detail}") from exc
-        except urllib.error.URLError as exc:
-            raise ImaError(f"ima API 请求失败：{exc}") from exc
+        attempts = 3 if action in READ_RETRY_ACTIONS else 1
+        raw = ""
+        for attempt in range(attempts):
+            check_stopped(self.args)
+            if attempt:
+                wait_with_stop(self.args, min(1.5 * attempt, 4.0))
+            throttle(self.args)
+            request = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "ima-openapi-clientid": self.client_id,
+                    "ima-openapi-apikey": self.api_key,
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=120) as response:
+                    raw = response.read().decode("utf-8", errors="replace")
+                break
+            except urllib.error.HTTPError as exc:
+                detail = exc.read().decode("utf-8", errors="replace")
+                raise ImaError(f"ima API HTTP {exc.code}：{detail}") from exc
+            except (TimeoutError, socket.timeout, urllib.error.URLError) as exc:
+                if is_timeout_exception(exc) and attempt + 1 < attempts:
+                    emit(
+                        f"ima API {action} 读取超时，正在重试（{attempt + 1}/{attempts - 1}）",
+                        event="request.retry",
+                        level="warn",
+                        action=action,
+                    )
+                    continue
+                if is_timeout_exception(exc):
+                    raise ImaError(f"ima API {action} 读取超时：{exc}") from exc
+                raise ImaError(f"ima API 请求失败：{exc}") from exc
+        if not raw:
+            raise ImaError(f"ima API {action} 未返回内容")
         try:
             data = json.loads(raw)
         except json.JSONDecodeError as exc:
@@ -520,30 +575,287 @@ def extension_for_download(title: str, media_type: int | None, content_type: str
 
 
 def download_url(url: str, headers: dict[str, str] | None = None) -> tuple[bytes, str]:
-    request = urllib.request.Request(url, headers=headers or {})
-    try:
-        with urllib.request.urlopen(request, timeout=120) as response:
-            return response.read(), response.headers.get("Content-Type", "")
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise ImaError(f"下载原文 HTTP {exc.code}：{detail}") from exc
-    except urllib.error.URLError as exc:
-        raise ImaError(f"下载原文失败：{exc}") from exc
+    for attempt in range(3):
+        request = urllib.request.Request(url, headers=headers or {})
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                return response.read(), response.headers.get("Content-Type", "")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise ImaError(f"下载原文 HTTP {exc.code}：{detail}") from exc
+        except (TimeoutError, socket.timeout, urllib.error.URLError) as exc:
+            if is_timeout_exception(exc) and attempt < 2:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            if is_timeout_exception(exc):
+                raise ImaError(f"下载原文读取超时：{exc}") from exc
+            raise ImaError(f"下载原文失败：{exc}") from exc
+    raise ImaError("下载原文失败：重试次数已用尽")
 
 
-def save_note_entry(client: ImaClient, entry: KnowledgeEntry, target_dir: Path) -> Path:
+def _clean_remote_url(value: str) -> str:
+    return html.unescape(str(value or "").strip()).strip("<>").rstrip(".,;，。；")
+
+
+def _is_remote_image_url(url: str, *, allow_unknown_suffix: bool = False) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        return False
+    suffix = Path(urllib.parse.unquote(parsed.path)).suffix.lower()
+    return allow_unknown_suffix or suffix in IMAGE_URL_SUFFIXES
+
+
+def remote_image_urls(markdown: str) -> list[str]:
+    """Return remote image URLs without attempting to fetch arbitrary links."""
+
+    result: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str, *, allow_unknown_suffix: bool = False) -> None:
+        url = _clean_remote_url(raw)
+        if url and url not in seen and _is_remote_image_url(url, allow_unknown_suffix=allow_unknown_suffix):
+            seen.add(url)
+            result.append(url)
+
+    for match in MARKDOWN_IMAGE_RE.finditer(markdown):
+        add(match.group("bracket") or match.group("plain"), allow_unknown_suffix=True)
+    for match in HTML_IMAGE_RE.finditer(markdown):
+        add(match.group("src"), allow_unknown_suffix=True)
+    for match in REMOTE_URL_RE.finditer(markdown):
+        add(match.group(0))
+    return result
+
+
+def data_image_urls(markdown: str) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for match in DATA_IMAGE_RE.finditer(markdown):
+        value = match.group(0)
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _resource_failure(resource_failures: list[dict[str, str]], url: str, exc: Exception) -> None:
+    host = urllib.parse.urlparse(url).netloc or "unknown-host"
+    resource_failures.append({"type": "image", "host": host, "error": str(exc)})
+
+
+def localize_markdown_images(
+    markdown: str,
+    assets_dir: Path,
+    resource_failures: list[dict[str, str]] | None = None,
+) -> tuple[str, int]:
+    """Download remote Markdown images and rewrite them to sibling local assets."""
+
+    failures = resource_failures if resource_failures is not None else []
+    urls = [*remote_image_urls(markdown), *data_image_urls(markdown)]
+    if not urls:
+        return markdown, 0
+
+    replacements: dict[str, str] = {}
+    downloaded = 0
+    for index, url in enumerate(urls, 1):
+        try:
+            if url.startswith("data:"):
+                header, encoded = url.split(",", 1)
+                content = base64.b64decode(encoded, validate=True)
+                content_type = header[5:].split(";", 1)[0]
+            else:
+                content, content_type = download_url(url)
+            if not content:
+                raise ImaError("图片响应为空")
+            source_name = "" if url.startswith("data:") else Path(urllib.parse.unquote(urllib.parse.urlparse(url).path)).name
+            suffix = extension_for_download(source_name, None, content_type)
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            target = unique_path(assets_dir / f"image-{index:03d}{suffix}")
+            target.write_bytes(content)
+            replacements[url] = f"{assets_dir.name}/{target.name}".replace("\\", "/")
+            downloaded += 1
+        except Exception as exc:
+            _resource_failure(failures, url, exc)
+
+    localized = markdown
+    for remote_url, local_url in replacements.items():
+        localized = localized.replace(remote_url, local_url)
+
+    def replace_bare_image_line(match: re.Match[str]) -> str:
+        url = _clean_remote_url(match.group("url"))
+        local_url = replacements.get(url)
+        if not local_url:
+            return match.group(0)
+        return f"{match.group('indent')}![]({local_url}){match.group('trailing')}"
+
+    localized = BARE_IMAGE_LINE_RE.sub(replace_bare_image_line, localized)
+    return localized, downloaded
+
+
+def _local_image_references(markdown: str) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for match in MARKDOWN_IMAGE_REFERENCE_RE.finditer(markdown):
+        value = match.group("value").strip()
+        if value.startswith("<") and value.endswith(">"):
+            value = value[1:-1].strip()
+        else:
+            value = re.sub(r"\s+(?:\"[^\"]*\"|'[^']*')\s*$", "", value).strip()
+        value = _clean_remote_url(value)
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    for match in HTML_IMAGE_REFERENCE_RE.finditer(markdown):
+        value = _clean_remote_url(match.group("src"))
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def embed_local_markdown_images(
+    markdown: str,
+    source_path: Path,
+    source_root: Path,
+    resource_failures: list[dict[str, str]] | None = None,
+) -> tuple[str, int]:
+    """Embed local Markdown images so an IMA note remains self-contained."""
+
+    failures = resource_failures if resource_failures is not None else []
+    replacements: dict[str, str] = {}
+    embedded = 0
+    source_path = source_path.resolve()
+    source_root = source_root.resolve()
+    for raw_reference in _local_image_references(markdown):
+        parsed = urllib.parse.urlparse(raw_reference)
+        if parsed.scheme or parsed.netloc or raw_reference.startswith(("/", "\\", "data:")):
+            continue
+        reference = urllib.parse.unquote(raw_reference.split("#", 1)[0].split("?", 1)[0])
+        candidate = (source_path.parent / reference).resolve()
+        try:
+            candidate.relative_to(source_root)
+        except ValueError:
+            failures.append({"type": "image", "reference": raw_reference, "error": "引用路径超出导入目录"})
+            continue
+        if not candidate.is_file() or candidate.suffix.lower() not in IMAGE_URL_SUFFIXES:
+            failures.append({"type": "image", "reference": raw_reference, "error": "本地图片不存在或格式不支持"})
+            continue
+        try:
+            content_type = mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
+            encoded = base64.b64encode(candidate.read_bytes()).decode("ascii")
+            replacements[raw_reference] = f"data:{content_type};base64,{encoded}"
+            embedded += 1
+        except OSError as exc:
+            failures.append({"type": "image", "reference": raw_reference, "error": str(exc)})
+
+    localized = markdown
+    for raw_reference, data_url in replacements.items():
+        localized = localized.replace(raw_reference, data_url)
+    return localized, embedded
+
+
+def repair_exported_local_image_references(output_root: Path) -> tuple[int, list[dict[str, str]]]:
+    """Restore local Markdown image paths after ima flattens imported files."""
+
+    output_root = output_root.resolve()
+    image_paths = [
+        path
+        for path in iter_regular_files_under_root(output_root)
+        if path.suffix.lower() in IMAGE_URL_SUFFIXES
+    ]
+    by_name: dict[str, list[Path]] = {}
+    for path in image_paths:
+        by_name.setdefault(path.name, []).append(path)
+
+    repaired = 0
+    failures: list[dict[str, str]] = []
+    for markdown_path in iter_regular_files_under_root(output_root, suffixes={".md", ".markdown"}):
+        try:
+            text = markdown_path.read_text("utf-8", errors="ignore")
+        except OSError as exc:
+            failures.append({"title": markdown_path.name, "reference": "", "reason": str(exc)})
+            continue
+        for raw_reference in _local_image_references(text):
+            parsed = urllib.parse.urlparse(raw_reference)
+            if parsed.scheme or parsed.netloc or raw_reference.startswith(("/", "\\", "data:")):
+                continue
+            reference = urllib.parse.unquote(raw_reference.split("#", 1)[0].split("?", 1)[0])
+            if not reference:
+                continue
+            target = (markdown_path.parent / reference).resolve()
+            try:
+                target.relative_to(output_root)
+            except ValueError:
+                failures.append({"title": markdown_path.name, "reference": raw_reference, "reason": "引用路径超出导出目录"})
+                continue
+            if target.is_file():
+                continue
+            candidates = [candidate for candidate in by_name.get(Path(reference).name, []) if candidate.is_file()]
+            if len(candidates) != 1:
+                reason = "找不到同名图片" if not candidates else "同名图片不唯一"
+                failures.append({"title": markdown_path.name, "reference": raw_reference, "reason": reason})
+                continue
+            source = candidates[0]
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(source), str(target))
+                by_name[Path(reference).name] = [candidate for candidate in candidates if candidate != source]
+                repaired += 1
+            except OSError as exc:
+                failures.append({"title": markdown_path.name, "reference": raw_reference, "reason": str(exc)})
+    return repaired, failures
+
+
+def _note_id_from_media_info(media_info: dict[str, Any]) -> str:
+    for key in ("note_id", "notebook_id", "doc_id", "content_id"):
+        value = media_info.get(key)
+        if value:
+            return str(value).strip()
+    for key in ("notebook_ext_info", "note_info", "ext_info"):
+        nested = media_info.get(key)
+        if isinstance(nested, dict):
+            note_id = _note_id_from_media_info(nested)
+            if note_id:
+                return note_id
+    return ""
+
+
+def _resource_warning(resource_failures: list[dict[str, str]]) -> str:
+    if not resource_failures:
+        return ""
+    hosts = sorted({item.get("host", "unknown-host") for item in resource_failures})
+    return f"{len(resource_failures)} 张图片下载失败（{', '.join(hosts[:3])}）"
+
+
+def save_note_entry(
+    client: ImaClient,
+    entry: KnowledgeEntry,
+    target_dir: Path,
+    resource_failures: list[dict[str, str]] | None = None,
+) -> Path:
     media_info = client.wiki("get_media_info", {"media_id": entry.media_id})
-    note_id = str((media_info.get("notebook_ext_info") or {}).get("notebook_id") or "")
+    note_id = _note_id_from_media_info(media_info)
     if not note_id:
         raise ImaError("笔记类型没有返回 notebook_id")
-    note_data = client.note("get_doc_content", {"note_id": note_id, "target_content_format": 0})
+    try:
+        note_data = client.note("get_doc_content", {"note_id": note_id, "target_content_format": 1})
+    except ImaError:
+        note_data = client.note("get_doc_content", {"note_id": note_id, "target_content_format": 0})
     text = extract_content_text(note_data).strip()
     if not text:
         text = f"# {entry.title}\n\n> ima 笔记接口未返回可导出的正文。"
     elif not text.lstrip().startswith("#"):
         text = f"# {entry.title}\n\n{text}\n"
     target_dir.mkdir(parents=True, exist_ok=True)
-    target = unique_path(target_dir / f"{sanitize_filename(entry.title)}.md")
+    name = sanitize_filename(entry.title)
+    if Path(name).suffix.lower() not in {".md", ".markdown"}:
+        name += ".md"
+    target = unique_path(target_dir / name)
+    failures = resource_failures if resource_failures is not None else []
+    text, _ = localize_markdown_images(
+        text,
+        target_dir / f"{target.stem}_assets",
+        failures,
+    )
     target.write_text(text, "utf-8")
     return target
 
@@ -556,9 +868,10 @@ def save_media_entry(client: ImaClient, entry: KnowledgeEntry, output_root: Path
 
     media_info = client.wiki("get_media_info", {"media_id": entry.media_id})
     media_type = int(media_info.get("media_type") or entry.media_type or 0)
+    resource_failures: list[dict[str, str]] = []
     if media_type == 11:
-        path = save_note_entry(client, entry, target_dir)
-        return "exported_note", path, ""
+        path = save_note_entry(client, entry, target_dir, resource_failures)
+        return "exported_note", path, _resource_warning(resource_failures)
 
     url_info = media_info.get("url_info") or {}
     url = str(url_info.get("url") or "")
@@ -572,8 +885,21 @@ def save_media_entry(client: ImaClient, entry: KnowledgeEntry, output_root: Path
     if not Path(name).suffix:
         name += ext
     target = unique_path(target_dir / name)
-    target.write_bytes(content)
-    return "exported", target, ""
+    if media_type == 7 or target.suffix.lower() in {".md", ".markdown"}:
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            target.write_bytes(content)
+            return "exported", target, ""
+        text, _ = localize_markdown_images(
+            text,
+            target_dir / f"{target.stem}_assets",
+            resource_failures,
+        )
+        target.write_text(text, "utf-8")
+    else:
+        target.write_bytes(content)
+    return "exported", target, _resource_warning(resource_failures)
 
 
 def selected_entries(entries: list[KnowledgeEntry], doc_ids: list[str]) -> list[KnowledgeEntry]:
@@ -610,10 +936,16 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
             checkpoint.upsert_item(
                 f"ima:entry:{entry.export_id}",
                 title=entry.title,
-                source_url=entry.path,
+                source_url="/".join(
+                    [
+                        sanitize_filename(entry.kb_name, "knowledge-base"),
+                        *(sanitize_filename(part, "folder") for part in entry.relative_parts),
+                        sanitize_filename(entry.title),
+                    ]
+                ),
                 source_id=entry.export_id,
-                parent_key=entry.parent_id,
-                metadata={"exportId": entry.export_id, "mediaId": entry.media_id, "knowledgeBaseId": entry.knowledge_base_id},
+                parent_key=entry.parent_node_id,
+                metadata={"exportId": entry.export_id, "mediaId": entry.media_id, "knowledgeBaseId": entry.kb_id},
             )
         if getattr(args, "retry_failed", False):
             docs = [entry for entry in docs if checkpoint.item_status(f"ima:entry:{entry.export_id}") == "failed"]
@@ -621,6 +953,9 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
     exported = 0
     skipped = 0
     failures: list[dict[str, str]] = []
+    resource_failures: list[dict[str, str]] = []
+    local_reference_repairs = 0
+    local_reference_failures: list[dict[str, str]] = []
     started = time.time()
     emit(
         f"开始导出 ima 知识库内容：共 {total} 个文件。",
@@ -645,12 +980,19 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
             status, path, reason = save_media_entry(client, entry, output)
             if status.startswith("exported"):
                 exported += 1
+                if reason:
+                    resource_failures.append({"title": entry.title, "reason": reason})
                 if checkpoint:
-                    checkpoint.complete_item(item_key, local_path=str(path or ""), metadata={"exportId": entry.export_id})
+                    checkpoint.complete_item(
+                        item_key,
+                        local_path=str(path or ""),
+                        metadata={"exportId": entry.export_id, "resourceWarning": reason},
+                    )
                 emit(
                     f"ima 文件导出完成：{entry.title}",
                     event="document.export.completed",
                     doc={"id": entry.export_id, "title": entry.title, "index": index, "path": str(path)},
+                    warning=reason,
                 )
             else:
                 skipped += 1
@@ -684,8 +1026,28 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
                 f"progress {index}/{total} exported={exported} skipped={skipped} failures={len(failures)}",
                 event="task.progress",
                 progress={"current": index, "total": total},
-                stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
+                stats={
+                    "exportedDocs": exported,
+                    "skippedDocs": skipped,
+                    "failureCount": len(failures),
+                    "resourceFailureCount": len(resource_failures),
+                },
             )
+    local_reference_repairs, local_reference_failures = repair_exported_local_image_references(output)
+    for item in local_reference_failures:
+        resource_failures.append(
+            {
+                "title": item.get("title", ""),
+                "reason": f"本地图片引用未修复：{item.get('reference', '')}（{item.get('reason', '未知原因')}）",
+            }
+        )
+    if local_reference_repairs or local_reference_failures:
+        emit(
+            f"ima 本地图片引用修复完成：修复 {local_reference_repairs} 个，失败 {len(local_reference_failures)} 个",
+            event="document.export.resources_repaired",
+            level="warn" if local_reference_failures else "info",
+            stats={"repaired": local_reference_repairs, "failures": len(local_reference_failures)},
+        )
     report = {
         "provider": "ima",
         "mode": "export",
@@ -695,6 +1057,10 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
         "skippedDocs": skipped,
         "failureCount": len(failures),
         "failures": failures[:20],
+        "resourceFailureCount": len(resource_failures),
+        "resourceFailures": resource_failures[:20],
+        "localImageReferenceRepairs": local_reference_repairs,
+        "localImageReferenceFailures": local_reference_failures[:20],
         "output": str(output),
         "elapsedSeconds": round(time.time() - started, 1),
         "requestCount": int(getattr(args, "_request_count", 0) or 0),
@@ -712,7 +1078,14 @@ def export_selected(client: ImaClient, args: argparse.Namespace) -> dict[str, An
         "ima 导出完成" if not failures else f"ima 导出完成，但有 {len(failures)} 个失败项",
         event="task.completed",
         level="success" if not failures else "warn",
-        stats={"exportedDocs": exported, "skippedDocs": skipped, "failureCount": len(failures)},
+        stats={
+            "exportedDocs": exported,
+            "skippedDocs": skipped,
+            "failureCount": len(failures),
+            "resourceFailureCount": len(resource_failures),
+            "localImageReferenceRepairs": local_reference_repairs,
+            "localImageReferenceFailures": len(local_reference_failures),
+        },
     )
     return report
 
@@ -935,6 +1308,52 @@ def upload_to_cos(path: Path, credential: dict[str, Any], content_type: str) -> 
         raise ImaError(f"COS 上传失败：{exc}") from exc
 
 
+def upload_markdown_note(
+    client: ImaClient,
+    args: argparse.Namespace,
+    path: Path,
+    source_root: Path,
+    resource_failures: list[dict[str, str]],
+) -> str:
+    kb_id = args.knowledge_base_id
+    if not kb_id:
+        raise ImaError("导入需要填写目标知识库 ID")
+    file_name = path.name
+    if args.skip_existing and is_repeated(client, kb_id, args.folder_id or "", file_name, 11):
+        return "skipped_existing"
+    try:
+        content = path.read_text("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ImaError(f"Markdown 不是有效 UTF-8：{path.name}") from exc
+    content, embedded = embed_local_markdown_images(content, path, source_root, resource_failures)
+    created = client.note(
+        "import_doc",
+        {
+            "title": file_name,
+            "content": content,
+            "content_format": 1,
+        },
+    )
+    note_id = _note_id_from_media_info(created)
+    if not note_id:
+        raise ImaError("import_doc 未返回 note_id")
+    add_payload: dict[str, Any] = {
+        "media_type": 11,
+        "title": file_name,
+        "knowledge_base_id": kb_id,
+        "note_info": {"content_id": note_id},
+    }
+    if args.folder_id:
+        add_payload["folder_id"] = args.folder_id
+    client.wiki("add_knowledge", add_payload)
+    emit(
+        f"Markdown 笔记已导入：{file_name}（内嵌图片 {embedded} 张）",
+        event="document.import.resources_embedded",
+        stats={"embeddedImages": embedded},
+    )
+    return note_id
+
+
 def upload_file(client: ImaClient, args: argparse.Namespace, path: Path) -> str:
     kb_id = args.knowledge_base_id
     if not kb_id:
@@ -998,6 +1417,7 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
     imported = 0
     skipped = 0
     failures: list[dict[str, str]] = []
+    resource_failures: list[dict[str, str]] = []
     started = time.time()
     total = len(files)
     emit(
@@ -1016,7 +1436,13 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
                 event="document.import.started",
                 doc={"path": relative_path, "index": index},
             )
-            result = upload_file(client, args, path)
+            file_resources: list[dict[str, str]] = []
+            if path.suffix.lower() in {".md", ".markdown"}:
+                result = upload_markdown_note(client, args, path, source_dir, file_resources)
+            else:
+                result = upload_file(client, args, path)
+            for item in file_resources:
+                resource_failures.append({"relativePath": relative_path, **item})
             if result == "skipped_existing":
                 skipped += 1
             else:
@@ -1041,7 +1467,12 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
                 f"progress {index}/{total} imported={imported} skipped={skipped} failures={len(failures)}",
                 event="task.progress",
                 progress={"current": index, "total": total},
-                stats={"importedDocs": imported, "skippedDocs": skipped, "failureCount": len(failures)},
+                stats={
+                    "importedDocs": imported,
+                    "skippedDocs": skipped,
+                    "failureCount": len(failures),
+                    "resourceFailureCount": len(resource_failures),
+                },
             )
     report = {
         "provider": "ima",
@@ -1054,6 +1485,8 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
         "skippedFiles": skipped,
         "failureCount": len(failures),
         "failures": failures[:20],
+        "resourceFailureCount": len(resource_failures),
+        "resourceFailures": resource_failures[:20],
         "elapsedSeconds": round(time.time() - started, 1),
         "requestCount": int(getattr(args, "_request_count", 0) or 0),
     }
@@ -1062,7 +1495,12 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
         "ima 导入完成" if not failures else f"ima 导入完成，但有 {len(failures)} 个失败项",
         event="task.completed",
         level="success" if not failures else "warn",
-        stats={"importedDocs": imported, "skippedDocs": skipped, "failureCount": len(failures)},
+        stats={
+            "importedDocs": imported,
+            "skippedDocs": skipped,
+            "failureCount": len(failures),
+            "resourceFailureCount": len(resource_failures),
+        },
     )
     return report
 
@@ -1095,7 +1533,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--source-dir", help="本地待导入目录")
     parser.add_argument("--source-file", help="单篇测试文件")
     parser.add_argument("--scan-source", action="store_true", help="扫描本地可导入文件")
-    parser.add_argument("--include-referenced-assets", action="store_true", help="将 Markdown 引用的本地图片/附件也作为独立文件上传")
+    parser.add_argument(
+        "--include-referenced-assets",
+        dest="include_referenced_assets",
+        action="store_true",
+        default=False,
+        help="将 Markdown 引用的本地图片/附件也作为独立文件上传（默认关闭；图片会内嵌到 Markdown 笔记）",
+    )
+    parser.add_argument(
+        "--exclude-referenced-assets",
+        dest="include_referenced_assets",
+        action="store_false",
+        help="不单独上传 Markdown 引用的本地图片/附件",
+    )
     parser.add_argument("--import-one", action="store_true", help="导入第一篇或 source-file")
     parser.add_argument("--import-all", action="store_true", help="批量导入")
     parser.add_argument("--skip-existing", action="store_true", default=True, help="目标已有同名文件时跳过")

--- a/plugins/ima/plugin.json
+++ b/plugins/ima/plugin.json
@@ -4,7 +4,7 @@
   "id": "ima",
   "name": "ima 知识库",
   "description": "ima 知识库 OpenAPI 导出与本地文件批量导入。",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "Wandao Official",
   "homepage": "https://ima.qq.com/",
   "license": "AGPL-3.0-only",

--- a/plugins/ima/providers/ima-import/provider.json
+++ b/plugins/ima/providers/ima-import/provider.json
@@ -18,7 +18,7 @@
     { "name": "knowledge_base_id", "label": "目标知识库 ID", "type": "text", "arg": "--knowledge-base-id", "required": true, "actions": ["plan", "importOne", "import"] },
     { "name": "folder_id", "label": "目标文件夹 ID（可选）", "type": "text", "arg": "--folder-id", "advanced": true, "actions": ["importOne", "import"] },
     { "name": "source_dir", "label": "本地待导入目录", "type": "directory", "arg": "--source-dir", "required": true, "history": "path", "actions": ["plan", "importOne", "import"] },
-    { "name": "include_referenced_assets", "label": "同时上传 Markdown 引用资源", "type": "checkbox", "arg": "--include-referenced-assets", "default": false, "advanced": true, "actions": ["importOne", "import"] },
+    { "name": "include_referenced_assets", "label": "额外上传 Markdown 引用资源（默认图片已内嵌）", "type": "checkbox", "arg": "--include-referenced-assets", "default": false, "advanced": true, "actions": ["importOne", "import"] },
     { "name": "max_import", "label": "最多导入数量（0 为全部）", "type": "number", "arg": "--max-import", "default": 0, "min": 0, "advanced": true, "actions": ["import"] }
   ],
   "actions": [

--- a/tests/test_ima_export.py
+++ b/tests/test_ima_export.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from plugins.ima.backend import ima_knowledge as module
+
+
+class FakeImaClient:
+    def __init__(self, media_info: dict, note_data: dict | None = None) -> None:
+        self.media_info = media_info
+        self.note_data = note_data or {}
+
+    def wiki(self, action: str, payload: dict) -> dict:
+        if action == "get_media_info":
+            return self.media_info
+        raise AssertionError(action)
+
+    def note(self, action: str, payload: dict) -> dict:
+        if action == "get_doc_content":
+            return self.note_data
+        raise AssertionError(action)
+
+
+class FakeImaImportClient:
+    def __init__(self) -> None:
+        self.note_payload: dict = {}
+        self.add_payload: dict = {}
+
+    def wiki(self, action: str, payload: dict) -> dict:
+        if action == "check_repeated_names":
+            return {"results": [{"name": payload["params"][0]["name"], "is_repeated": False}]}
+        if action == "add_knowledge":
+            self.add_payload = payload
+            return {}
+        raise AssertionError(action)
+
+    def note(self, action: str, payload: dict) -> dict:
+        if action == "import_doc":
+            self.note_payload = payload
+            return {"note_id": "note-test"}
+        raise AssertionError(action)
+
+
+class ImaExportTests(unittest.TestCase):
+    def test_remote_image_urls_ignore_normal_links(self) -> None:
+        text = (
+            "[普通链接](https://example.com/page)\n"
+            "![Markdown](https://cdn.example.com/a.png?x=1)\n"
+            '<img src="https://cdn.example.com/b" alt="HTML">\n'
+            "https://cdn.example.com/c.webp\n"
+        )
+        self.assertEqual(
+            module.remote_image_urls(text),
+            [
+                "https://cdn.example.com/a.png?x=1",
+                "https://cdn.example.com/b",
+                "https://cdn.example.com/c.webp",
+            ],
+        )
+
+    def test_note_export_localizes_images(self) -> None:
+        client = FakeImaClient(
+            {"media_type": 11, "notebook_ext_info": {"notebook_id": "note-1"}},
+            {"content": "正文\n\n![图](https://cdn.example.com/a.png)"},
+        )
+        with tempfile.TemporaryDirectory() as temporary, patch.object(
+            module, "download_url", return_value=(b"png", "image/png")
+        ):
+            path = module.save_note_entry(
+                client,
+                module.KnowledgeEntry("kb", "知识库", "media", "测试笔记", "", [], False, 11),
+                Path(temporary),
+            )
+            self.assertIn("![图](测试笔记_assets/image-001.png)", path.read_text(encoding="utf-8"))
+            self.assertEqual((Path(temporary) / "测试笔记_assets" / "image-001.png").read_bytes(), b"png")
+
+    def test_markdown_file_export_localizes_images(self) -> None:
+        client = FakeImaClient(
+            {
+                "media_type": 7,
+                "url_info": {"url": "https://ima.example.com/source.md"},
+            }
+        )
+        responses = [
+            ("# 标题\n\n![图](https://cdn.example.com/a.png)\n".encode("utf-8"), "text/markdown"),
+            (b"png", "image/png"),
+        ]
+        with tempfile.TemporaryDirectory() as temporary, patch.object(
+            module, "download_url", side_effect=responses
+        ):
+            status, path, warning = module.save_media_entry(
+                client,
+                module.KnowledgeEntry("kb", "知识库", "media", "原文.md", "", [], False, 7),
+                Path(temporary),
+            )
+            self.assertEqual(status, "exported")
+            self.assertEqual(warning, "")
+            assert path is not None
+            self.assertIn("原文_assets/image-001.png", path.read_text(encoding="utf-8"))
+            self.assertTrue((path.parent / "原文_assets" / "image-001.png").is_file())
+
+    def test_ima_import_includes_referenced_assets_by_default(self) -> None:
+        args = module.parse_args(["--scan-source"])
+        self.assertFalse(args.include_referenced_assets)
+
+    def test_local_markdown_images_are_embedded_for_ima_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            image_dir = root / "文档.assets"
+            image_dir.mkdir()
+            image = image_dir / "image.png"
+            image.write_bytes(b"png")
+            markdown = "![图](文档.assets/image.png)\n"
+
+            embedded, count = module.embed_local_markdown_images(markdown, root / "文档.md", root)
+
+            self.assertEqual(count, 1)
+            self.assertIn("data:image/png;base64,cG5n", embedded)
+
+    def test_markdown_import_uses_one_note_with_embedded_images(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            image_dir = root / "文档.assets"
+            image_dir.mkdir()
+            (image_dir / "image.png").write_bytes(b"png")
+            markdown = root / "文档.md"
+            markdown.write_text("![图](文档.assets/image.png)\n", encoding="utf-8")
+            client = FakeImaImportClient()
+            args = module.parse_args(
+                [
+                    "--knowledge-base-id",
+                    "kb-test",
+                    "--source-dir",
+                    str(root),
+                    "--yes",
+                ]
+            )
+
+            result = module.upload_markdown_note(client, args, markdown, root, [])
+
+            self.assertEqual(result, "note-test")
+            self.assertEqual(client.add_payload["media_type"], 11)
+            self.assertEqual(client.add_payload["note_info"]["content_id"], "note-test")
+            self.assertIn("data:image/png;base64,cG5n", client.note_payload["content"])
+
+    def test_export_repairs_flattened_local_image_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            markdown_dir = root / "测试"
+            markdown_dir.mkdir()
+            markdown = markdown_dir / "文档 带空格.md"
+            markdown.write_text("![图](文档 带空格.assets/image.png)\n", encoding="utf-8")
+            source_image = markdown_dir / "image.png"
+            source_image.write_bytes(b"png")
+
+            repaired, failures = module.repair_exported_local_image_references(root)
+
+            self.assertEqual(repaired, 1)
+            self.assertEqual(failures, [])
+            self.assertTrue((markdown_dir / "文档 带空格.assets" / "image.png").is_file())
+            self.assertFalse(source_image.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 发布 ima 插件 `1.0.4`，不升级 Wandao 主程序版本。
- 修复 Markdown 导入时本地图片被作为独立知识条目上传、正文图片无法显示的问题。
- 修复 ima 导出中的外链、内嵌图片、本地相对路径图片和带空格路径。
- 为 ima 读取类 API 与图片下载增加有限重试，降低偶发读取超时导致整批失败的概率。

## Root cause

IMA 的 Markdown 笔记应通过 `note/import_doc` 创建后再关联到知识库；此前导入流程把 Markdown 和引用图片分别作为普通文件上传，IMA 不会自动建立相对路径关联。导出时，IMA 又可能把图片条目扁平化到知识库根目录，导致本地 Markdown 引用失效。

## Validation

- `node scripts/validate_plugins.js`
- `node scripts/check_plugin_versions.js origin/main`
- `node --test tests_js/plugin_manager.test.js tests_js/plugin_release_policy.test.js`
- `python -m unittest tests.test_ima_export -v`
- `python scripts/quality_check.py --skip-node`
- 使用真实 ima 测试知识库完成导入、导出和失败文档重试验证。

Refs #122