### PR TITLE
chore: 热路径小优化（预编译正则 / 减少子进程）

### DIFF
--- a/plugins/csdn/backend/export_csdn.py
+++ b/plugins/csdn/backend/export_csdn.py
@@ -65,6 +65,12 @@ IMAGE_CONTENT_TYPES = {
     "image/webp": ".webp",
     "image/avif": ".avif",
 }
+# Regexes used while walking every HTML node — precompiled to avoid per-node cache churn.
+_WHITESPACE_RE = re.compile(r"\s+")
+_TRAILING_WS_BEFORE_NEWLINE_RE = re.compile(r"[ \t]+\n")
+_LEADING_WS_AFTER_NEWLINE_RE = re.compile(r"\n[ \t]+")
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
+_CODE_LANG_RE = re.compile(r"(?:language|lang)-([A-Za-z0-9_+-]+)")
 
 
 @dataclass(frozen=True)
@@ -330,12 +336,12 @@ class CsdnMarkdownRenderer:
 
     @staticmethod
     def _inline_text(value: str) -> str:
-        return re.sub(r"\s+", " ", html.unescape(str(value or "")).replace("\xa0", " "))
+        return _WHITESPACE_RE.sub(" ", html.unescape(str(value or "")).replace("\xa0", " "))
 
     def _inline(self, value: str) -> str:
-        text = re.sub(r"[ \t]+\n", "\n", value)
-        text = re.sub(r"\n[ \t]+", "\n", text)
-        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = _TRAILING_WS_BEFORE_NEWLINE_RE.sub("\n", value)
+        text = _LEADING_WS_AFTER_NEWLINE_RE.sub("\n", text)
+        text = _EXCESS_NEWLINES_RE.sub("\n\n", text)
         return text
 
     def _text(self, node: HtmlNode) -> str:
@@ -353,13 +359,13 @@ class CsdnMarkdownRenderer:
     def _code_language(node: HtmlNode) -> str:
         classes = node.attrs.get("class", "").split()
         for value in classes:
-            match = re.search(r"(?:language|lang)-([A-Za-z0-9_+-]+)", value)
+            match = _CODE_LANG_RE.search(value)
             if match:
                 return match.group(1).lower()
         for child in node.children:
             if isinstance(child, HtmlNode):
                 for value in child.attrs.get("class", "").split():
-                    match = re.search(r"(?:language|lang)-([A-Za-z0-9_+-]+)", value)
+                    match = _CODE_LANG_RE.search(value)
                     if match:
                         return match.group(1).lower()
         return ""
@@ -367,8 +373,8 @@ class CsdnMarkdownRenderer:
     @staticmethod
     def _normalize(value: str) -> str:
         text = value.replace("\r\n", "\n").replace("\r", "\n")
-        text = re.sub(r"[ \t]+\n", "\n", text)
-        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = _TRAILING_WS_BEFORE_NEWLINE_RE.sub("\n", text)
+        text = _EXCESS_NEWLINES_RE.sub("\n\n", text)
         return text.strip() + "\n" if text.strip() else ""
 
 

--- a/scripts/quality_check.py
+++ b/scripts/quality_check.py
@@ -77,9 +77,10 @@ def iter_python_files() -> list[Path]:
 
 
 def run_py_compile() -> None:
-    for path in iter_python_files():
+    python_files = iter_python_files()
+    for path in python_files:
         py_compile.compile(str(path), doraise=True)
-    print(f"Python compile passed ({len(iter_python_files())} files).")
+    print(f"Python compile passed ({len(python_files)} files).")
 
 
 def run_unittest() -> None:

--- a/wandao_core/logging.py
+++ b/wandao_core/logging.py
@@ -30,6 +30,7 @@ SENSITIVE_ASSIGNMENT_RE = re.compile(
     r"\b(cookie|token|secret|password|authorization|signature|access[_-]?key|api[_-]?key)\s*([:=])\s*[^\s,&;)]+",
     re.I,
 )
+BEARER_TOKEN_RE = re.compile(r"(Bearer\s+)[A-Za-z0-9._~+/=-]+", re.I)
 
 
 def structured_logs_enabled() -> bool:
@@ -65,7 +66,7 @@ def mask_sensitive(value: Any) -> Any:
         return [mask_sensitive(item) for item in value]
     if isinstance(value, str):
         text = SIGNATURE_QUERY_RE.sub(r"\1***", value)
-        text = re.sub(r"(Bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1***", text, flags=re.I)
+        text = BEARER_TOKEN_RE.sub(r"\1***", text)
         text = SENSITIVE_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}***", text)
         return text
     return value
@@ -171,7 +172,3 @@ def emit_legacy(
 
 def print_text(message: str) -> None:
     print(message, flush=True)
-    try:
-        sys.stdout.flush()
-    except Exception:
-        pass


### PR DESCRIPTION
## 改动概要

三处行为不变、零风险的微优化：

### 1. `wandao_core/logging.py`（结构化日志热路径，每条日志都经过）
- Bearer token 脱敏正则从 `re.sub(r..., ..., flags=re.I)`（每次调用重新编译）改为模块级预编译 `BEARER_TOKEN_RE`，与同文件已有的 `SIGNATURE_QUERY_RE`、`SENSITIVE_ASSIGNMENT_RE` 风格一致。
- `print_text()` 里 `print(..., flush=True)` 之后多余的 `sys.stdout.flush()` 删除——`flush=True` 已刷新 stdout。

### 2. `plugins/csdn/backend/export_csdn.py`（逐节点 HTML 解析热路径）
- 把 `_inline_text` / `_inline` / `_normalize` / `_code_language` 中逐节点调用的 5 个字面量正则提升为模块级预编译常量：`_WHITESPACE_RE`、`_TRAILING_WS_BEFORE_NEWLINE_RE`、`_LEADING_WS_AFTER_NEWLINE_RE`、`_EXCESS_NEWLINES_RE`、`_CODE_LANG_RE`。递归遍历每个 HTML 节点时省下 re 缓存查找/模式构造开销。

### 3. `scripts/quality_check.py`
- `run_py_compile()` 原本调用两次 `iter_python_files()`，每次都会 spawn 一次 `git ls-files` 子进程。改为复用同一结果，少跑一次子进程。

## 测试

```
pytest tests/test_csdn_export.py tests/test_logging_encoding.py tests/test_package_smoke.py
-> 49 passed, 16 subtests passed
```

所有改动均为行为保持（behavior-preserving），不影响日志输出、脱敏结果、CSDN Markdown 渲染产物或质量门禁结果。