### PR TITLE
fix: 修复发行版更新清单工作流

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -402,6 +402,9 @@ jobs:
       attestations: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Release job 增加仓库检出步骤，确保可以找到 scripts/build_updater_manifest.py 并生成 latest.json，避免下次发行版构建在生成更新清单阶段失败。