### PR TITLE
fix(feishu): export long native docs completely by scrolling to the bottom (#129)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-feishu-export-scroll-incomplete.md
+++ b/docs/superpowers/plans/2026-08-23-feishu-export-scroll-incomplete.md
@@ -1,0 +1,383 @@
+# Feishu Export Scroll Completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Feishu native-doc Markdown export collect the full lazily-mounted document body by hardening scroll-container detection and bottom-stability logic in `FEISHU_CONVERTER_JS` (issue #129).
+
+**Architecture:** Keep the existing DOM → Markdown converter. Extract scroll-container resolution and the scroll/collect loop into named JS helpers inside `FEISHU_CONVERTER_JS`, then drive those helpers from a Node test that builds a synthetic nested-scroller DOM (same pattern as `tests_js/yuque_converter.test.js`). Remove the unused `materialize_doc_dom` helper so only one scroll path remains.
+
+**Tech Stack:** Python exporter string embedding JS (`plugins/feishu/backend/export_feishu.py`), Node `node:test` + `linkedom` via `wandao_electron` deps, existing unittest suite for Feishu session/Markdown paths.
+
+## Global Constraints
+
+- Scope is native docs only (`obj_type=22` / `FEISHU_CONVERTER_JS`); do not change Markdown-file download / preview-fallback behavior.
+- Do not add a new user-facing `incomplete` warning contract in this change.
+- Do not require live Feishu credentials or a real browser for automated tests.
+- Bottom stability requires **4** consecutive rounds with no new blocks and no `scrollHeight` growth.
+- Hard ceiling is about **120** scroll iterations.
+- Remove the extra `stable += 1` when already at `maxY`.
+- Follow the approved design: `docs/superpowers/specs/2026-08-23-feishu-export-scroll-incomplete-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `plugins/feishu/backend/export_feishu.py` | Own `FEISHU_CONVERTER_JS` helpers + remove unused `materialize_doc_dom` |
+| `tests_js/feishu_converter_scroll.test.js` | Synthetic DOM tests for scroller choice and lazy height growth |
+| `tests/test_feishu_session_and_markdown.py` | Existing regression guard; only touch if a call-site rename forces it |
+| `plugins/feishu/plugin.json` | Patch version bump when shipping the fix |
+
+---
+
+### Task 1: Failing scroll-collector tests
+
+**Files:**
+- Create: `tests_js/feishu_converter_scroll.test.js`
+- Modify: `plugins/feishu/backend/export_feishu.py` (only enough to expose named helpers the test can call; keep old loop behavior until Task 2)
+- Test: `tests_js/feishu_converter_scroll.test.js`
+
+**Interfaces:**
+- Consumes: `FEISHU_CONVERTER_JS` source text from `plugins/feishu/backend/export_feishu.py`
+- Produces:
+  - `resolveFeishuDocScroller(root, document)` → Element
+  - `collectFeishuDocBlocks({ root, scroller, document, sleep, renderBlock, currentBlocks, maxIterations })` → `{ rendered: string[], blockCount: number, scrollIterations: number }`
+  - Test harness loads converter helpers the same way `tests_js/yuque_converter.test.js` loads `YUQUE_CONVERTER_JS`
+
+- [ ] **Step 1: Add named helper stubs inside `FEISHU_CONVERTER_JS` without changing behavior yet**
+
+In `plugins/feishu/backend/export_feishu.py`, inside `FEISHU_CONVERTER_JS`, wrap the existing scroller/collection logic behind named functions that the outer async IIFE still calls. Keep today’s termination semantics (`stable >= 2`, extra `stable += 1` at bottom, 80 iterations) so production behavior is unchanged until Task 2.
+
+Shape to expose (exact names required by later tasks/tests):
+
+```javascript
+function resolveFeishuDocScroller(root, doc) {
+  // current findScroller behavior for now
+}
+
+async function collectFeishuDocBlocks(options) {
+  // current scroll/collect loop for now
+  // options: { root, scroller, document, sleep, setScroll, currentBlocks, renderBlock, maxIterations }
+  // return { rendered, blockCount, scrollIterations }
+}
+```
+
+Also attach them for tests without breaking CDP evaluate:
+
+```javascript
+const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
+if (typeof globalThis !== "undefined") globalThis.__feishuConverterScrollApi = api;
+```
+
+The existing converter return value must remain `{ title, markdown, images, blockCount, textLength, renderer: "native_doc" }`.
+
+- [ ] **Step 2: Write the failing Node tests**
+
+Create `tests_js/feishu_converter_scroll.test.js`:
+
+```javascript
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { createRequire } = require('node:module');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const exporterPath = path.join(repoRoot, 'plugins', 'feishu', 'backend', 'export_feishu.py');
+const desktopRequire = createRequire(path.join(repoRoot, 'wandao_electron', 'package.json'));
+const { parseHTML } = desktopRequire('linkedom');
+
+function loadScrollApi() {
+  const source = fs.readFileSync(exporterPath, 'utf8');
+  const match = source.match(/FEISHU_CONVERTER_JS = r?"""([\s\S]*?)"""/);
+  assert.ok(match, 'FEISHU_CONVERTER_JS was not found');
+  const { document, window } = parseHTML('<!doctype html><html><body></body></html>');
+  // Provide browser globals used by the helper source.
+  global.document = document;
+  global.window = window;
+  global.getComputedStyle = (el) => {
+    const overflowY = el.getAttribute('data-overflow-y') || 'visible';
+    return { overflowY };
+  };
+  // Evaluate only the helper definitions by executing the converter factory once
+  // against a tiny document, then reading globalThis.__feishuConverterScrollApi.
+  delete globalThis.__feishuConverterScrollApi;
+  const factory = Function(
+    'document',
+    'window',
+    'getComputedStyle',
+    `"use strict"; return (${match[1]});`
+  );
+  // Call with a title so the async function starts; ignore the promise and use the API side-effect.
+  factory(document, window, getComputedStyle)('title');
+  assert.ok(globalThis.__feishuConverterScrollApi, 'scroll api was not exported');
+  return globalThis.__feishuConverterScrollApi;
+}
+
+function makeLazyDoc() {
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="shell" data-overflow-y="visible" style="height:200px">
+      <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+        <div class="root-render-unit-container">
+          <div class="render-unit-wrapper"></div>
+        </div>
+      </div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  // Fake geometry because linkedom does not implement layout.
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 400;
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = value;
+      // After the first time we reach the old bottom, grow and mount more blocks.
+      if (scrollTop >= scrollHeight - 200 && wrapper.childElementCount < 4) {
+        scrollHeight = 900;
+        for (const [type, text] of [
+          ['paragraph', 'block-3'],
+          ['paragraph', 'block-4'],
+        ]) {
+          if ([...wrapper.children].some((el) => el.textContent === text)) continue;
+          const block = document.createElement('div');
+          block.setAttribute('data-block-type', type);
+          block.setAttribute('data-block-id', text);
+          block.textContent = text;
+          wrapper.appendChild(block);
+        }
+      }
+    },
+  });
+  // Seed the first viewport blocks.
+  for (const [id, text] of [
+    ['block-1', 'block-1'],
+    ['block-2', 'block-2'],
+  ]) {
+    const block = document.createElement('div');
+    block.setAttribute('data-block-type', 'paragraph');
+    block.setAttribute('data-block-id', id);
+    block.textContent = text;
+    wrapper.appendChild(block);
+  }
+  Object.defineProperty(window, 'innerHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(document.documentElement, 'clientHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(document.documentElement, 'scrollHeight', { configurable: true, get: () => 200 });
+  return { document, window, scroller, root: document.querySelector('.root-render-unit-container'), wrapper };
+}
+
+test('resolveFeishuDocScroller prefers the nested page scroller over window', () => {
+  const api = loadScrollApi();
+  const { document, root, scroller } = makeLazyDoc();
+  const resolved = api.resolveFeishuDocScroller(root, document);
+  assert.equal(resolved, scroller);
+});
+
+test('collectFeishuDocBlocks keeps scrolling after lazy scrollHeight growth', async () => {
+  const api = loadScrollApi();
+  const { document, root, scroller, wrapper } = makeLazyDoc();
+  const sleep = async () => {};
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root,
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 120,
+  });
+  assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
+  assert.equal(result.blockCount, 4);
+});
+```
+
+If the helper-loading approach above is awkward because the converter is `async (fallbackTitle) => { ... }`, adjust `loadScrollApi()` to extract and `Function`-evaluate only the helper function source after a clearer split marker comment such as `/* feishu-scroll-api:start */` … `/* feishu-scroll-api:end */`. Prefer that marker approach if Step 1’s side-effect export proves brittle.
+
+- [ ] **Step 3: Run the new tests and confirm the lazy-growth case fails on current loop semantics**
+
+Run from repo root (PowerShell):
+
+```powershell
+node --test tests_js/feishu_converter_scroll.test.js
+```
+
+Expected:
+- scroller-preference test may pass already with current ancestor walk, or fail if probe/allowlist not present yet
+- `collectFeishuDocBlocks keeps scrolling after lazy scrollHeight growth` **FAIL** because the old loop exits after bottom double-count before blocks 3/4 mount/stabilize
+
+If both accidentally pass before Task 2, tighten the fixture so growth happens one iteration after first bottom contact, matching the bug.
+
+- [ ] **Step 4: Commit the failing tests and helper stubs**
+
+```bash
+git add plugins/feishu/backend/export_feishu.py tests_js/feishu_converter_scroll.test.js
+git commit -m "$(cat <<'EOF'
+test(feishu): add failing native-doc scroll collector coverage
+
+Expose scroll helpers and lock in nested-scroller + lazy height
+fixtures for issue #129 before changing termination behavior.
+EOF
+)"
+```
+
+---
+
+### Task 2: Harden scroll resolution and collection loop
+
+**Files:**
+- Modify: `plugins/feishu/backend/export_feishu.py` (`FEISHU_CONVERTER_JS`, delete `materialize_doc_dom`)
+- Test: `tests_js/feishu_converter_scroll.test.js`
+- Test: `tests/test_feishu_session_and_markdown.py` (run only; no intentional edits)
+
+**Interfaces:**
+- Consumes: helper names from Task 1
+- Produces: updated `resolveFeishuDocScroller` / `collectFeishuDocBlocks` behavior per design
+
+- [ ] **Step 1: Implement `resolveFeishuDocScroller`**
+
+Replace the stub with:
+
+1. Walk ancestors from `root` toward `document.body`.
+2. Collect elements where `overflowY` matches `/(auto|scroll)/` and `scrollHeight > clientHeight + 30`.
+3. Also push any present allowlist matches, e.g. `.page-main`, `[class*="scroll"]` near the editor shell — keep the allowlist short and non-exclusive.
+4. Probe each candidate: save `scrollTop`, set `scrollTop = min(42, maxScroll)`, accept if it changed, restore original `scrollTop`.
+5. Prefer the deepest successful probed candidate; else fall back to `document.scrollingElement || document.documentElement`.
+
+- [ ] **Step 2: Implement hardened `collectFeishuDocBlocks`**
+
+Required semantics:
+
+- Start at `y = 0`, collect once.
+- Loop up to `maxIterations` default **120**.
+- Each iteration:
+  - `viewport = scrollWindow ? window.innerHeight : scroller.clientHeight`
+  - `maxY = max(0, scroller.scrollHeight - viewport)`
+  - if `y >= maxY` **and** `stable >= 4`: break
+  - else advance `y = min(maxY, y + max(360, floor(viewport * 0.7)))`, scroll, sleep (~260ms in production; tests inject no-op sleep)
+  - remember `heightBefore = scroller.scrollHeight`
+  - `collect()`
+  - if new blocks collected **or** `scroller.scrollHeight > heightBefore`: `stable = 0`
+  - else: `stable += 1`
+- Do **not** add the old extra `stable += 1` when `y >= maxY`.
+- Return `{ rendered, blockCount: rendered.length, scrollIterations }`.
+
+Wire the outer converter to:
+
+```javascript
+const scroller = resolveFeishuDocScroller(initialRoot, document);
+const collected = await collectFeishuDocBlocks({...});
+const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+```
+
+Keep Markdown rendering helpers unchanged.
+
+- [ ] **Step 3: Delete unused `materialize_doc_dom`**
+
+Remove `def materialize_doc_dom(...):` from `plugins/feishu/backend/export_feishu.py`. Grep the repo to confirm no remaining references:
+
+```powershell
+rg -n "materialize_doc_dom" .
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Run scroll tests**
+
+```powershell
+node --test tests_js/feishu_converter_scroll.test.js
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Run Feishu Python regressions**
+
+```powershell
+python -m unittest tests.test_feishu_session_and_markdown tests.test_feishu_readiness tests.test_feishu_selection_mismatch -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/feishu/backend/export_feishu.py tests_js/feishu_converter_scroll.test.js
+git commit -m "$(cat <<'EOF'
+fix(feishu): harden native-doc scroll collection for long pages
+
+Probe the real nested scroller, wait for lazy scrollHeight growth,
+and drop the unused window-only materialize helper (#129).
+EOF
+)"
+```
+
+---
+
+### Task 3: Plugin version bump and issue note
+
+**Files:**
+- Modify: `plugins/feishu/plugin.json`
+- Optional note only if this branch will be released alone: mention #129 in the PR body (no separate release-notes file required unless cutting a release)
+
+**Interfaces:**
+- Consumes: completed Task 2 behavior
+- Produces: `feishu` plugin patch bump `1.0.7` → `1.0.8`
+
+- [ ] **Step 1: Bump plugin version**
+
+In `plugins/feishu/plugin.json`:
+
+```json
+"version": "1.0.8"
+```
+
+- [ ] **Step 2: Confirm provider manifests do not hardcode the old version**
+
+```powershell
+rg -n "1\.0\.7" plugins/feishu
+```
+
+Update any same-plugin version pins if present; leave unrelated docs alone.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/feishu/plugin.json
+git commit -m "$(cat <<'EOF'
+chore(feishu): bump plugin to 1.0.8 for scroll export fix
+
+Ship the native-doc scroll completeness fix for issue #129.
+EOF
+)"
+```
+
+- [ ] **Step 4: Final verification**
+
+```powershell
+node --test tests_js/feishu_converter_scroll.test.js
+python -m unittest tests.test_feishu_session_and_markdown tests.test_feishu_readiness tests.test_feishu_selection_mismatch -v
+```
+
+Expected: all PASS.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Harden scroller resolution with probe + restore | Task 2 Step 1 |
+| Bottom stability needs no new blocks **and** no height growth | Task 2 Step 2 |
+| 4 stable rounds; ~120 iteration ceiling; remove bottom double-count | Task 2 Step 2 |
+| Keep Markdown rendering unchanged | Task 2 |
+| Remove / avoid dual scroll path (`materialize_doc_dom`) | Task 2 Step 3 |
+| No new incomplete warning contract | All tasks |
+| Synthetic nested-scroller + lazy-growth tests | Task 1 |
+| Existing Feishu tests remain green | Task 2 Step 5 / Task 3 Step 4 |
+| Plugin patch bump + #129 mention on ship | Task 3 |

--- a/docs/superpowers/specs/2026-08-23-feishu-export-scroll-incomplete-design.md
+++ b/docs/superpowers/specs/2026-08-23-feishu-export-scroll-incomplete-design.md
@@ -57,12 +57,12 @@ Keep incremental collection into `seen` / `rendered`, but change termination:
 
 - Recompute `maxY` every iteration from current `scrollHeight` / viewport.
 - After each scroll, wait briefly, then collect.
-- Treat “bottom reached” as provisional: require several consecutive stable rounds where **both**:
+- Treat “bottom reached” as provisional: require **4** consecutive stable rounds where **both**:
   - no new blocks were collected, and
   - `scrollHeight` did not grow.
 - If height grows or new blocks appear, reset the stable counter and continue.
-- Keep a hard iteration / time ceiling so a broken page cannot hang forever; surface whatever was collected (same as today) rather than inventing a new failure mode in this change.
-- Slightly increase bottom patience versus today’s `stable >= 2` with an extra `stable += 1` when already at bottom, which currently exits too eagerly while lazy content is still mounting.
+- Keep a hard ceiling of about **120** scroll iterations (up from 80) so a broken page cannot hang forever; surface whatever was collected (same as today) rather than inventing a new failure mode in this change.
+- Remove today’s extra `stable += 1` when already at `maxY`. That double-counts bottom contact and exits before lazy mounts finish.
 
 Do not change Markdown rendering rules in this pass.
 
@@ -77,7 +77,7 @@ Return existing converter fields (`blockCount`, `textLength`, `renderer: "native
 
 ### 5. Testing
 
-Add focused tests around the scroll/collection behavior, preferably by extracting the JS helpers into a testable string/module boundary already used by the exporter, or by evaluating the resolver/loop against a fake DOM in a Node/jsdom-style harness if the repo already has one; otherwise, unit-test the Python-side composition and include a pure-JS fixture exercised by the existing test runner if practical.
+Extract the scroll-container resolver and scroll/collect loop from `FEISHU_CONVERTER_JS` into named JS helper functions inside the same Python string (or a small adjacent JS snippet loaded by tests). Drive those helpers from Python unit tests with a minimal fake DOM object (no live browser, no Feishu credentials).
 
 Minimum scenarios:
 
@@ -85,7 +85,7 @@ Minimum scenarios:
 2. Lazy height growth after first bottom contact continues collection until height stabilizes.
 3. Existing Feishu session / Markdown-file tests still pass.
 
-Because live Feishu DOM is unavailable in CI, tests should use synthetic DOM fixtures that mimic:
+Synthetic fixtures must mimic:
 
 - nested overflow scroller
 - blocks mounted only after scrollTop crosses thresholds

--- a/docs/superpowers/specs/2026-08-23-feishu-export-scroll-incomplete-design.md
+++ b/docs/superpowers/specs/2026-08-23-feishu-export-scroll-incomplete-design.md
@@ -1,0 +1,109 @@
+# Feishu native-doc export scroll completeness (Issue #129)
+
+## Problem
+
+Users report that Feishu Wiki Markdown export sometimes only captures the beginning of a long native document. The suspect document in #129 is a native Feishu doc (`obj_type=22`) exported via DOM scraping, not the Markdown-file download path.
+
+Current native-doc conversion lives in `FEISHU_CONVERTER_JS` inside `plugins/feishu/backend/export_feishu.py`. It:
+
+1. Finds a scroll container from the editor root.
+2. Scrolls in steps while collecting `[data-block-type]` children.
+3. Stops after a short “stable at bottom” window (max 80 iterations).
+
+Feishu’s editor uses virtualized / lazily mounted blocks. If the wrong scroller is chosen, or `scrollHeight` grows after the loop already decided it was done, later blocks never enter the DOM and never get exported. The exporter still reports success with `contentIncomplete: false`.
+
+There is also an unused helper `materialize_doc_dom()` that only scrolls `window` and is not called from the export path, so it does not mitigate this bug.
+
+## Goals
+
+- Export long native Feishu docs as completely as practical by fixing DOM scroll collection.
+- Keep the existing DOM → Markdown rendering (`renderBlock` / `currentBlocks`) intact.
+- Stay compatible with current Feishu page structure; minimize behavioral churn outside scroll/collection.
+- Cover the fix with deterministic tests that simulate lazy height growth / wrong-scroller risk.
+
+## Non-goals
+
+- Do not switch native docs to a Feishu export/content API in this change.
+- Do not change the Markdown-file (`obj_type=12`) download / preview-fallback path.
+- Do not add a new user-facing incomplete/warning contract in this change (can be a follow-up).
+- Do not require live Feishu credentials for the automated tests.
+
+## Approach (chosen)
+
+Harden the existing DOM scroll collector in `FEISHU_CONVERTER_JS`.
+
+Rejected alternatives:
+
+- **Pre-scroll via `materialize_doc_dom` then convert**: easy to wire, but keeps a second, weaker scroll path and still fails if the container is wrong.
+- **Switch to Feishu export APIs**: better long-term completeness potential, but out of agreed scope and higher auth/contract risk.
+
+## Design
+
+### 1. Scroll-container resolution
+
+Replace the current “first ancestor with overflow scroll” heuristic with a small resolver:
+
+1. Walk ancestors of the editor root (`.root-render-unit-container` / `.page-main-item.editor` / `.editor-container`).
+2. Collect candidates that look scrollable (`overflowY` auto/scroll and `scrollHeight > clientHeight`).
+3. Also consider a short allowlist of common Feishu shell scrollers if present (e.g. page main / wiki content panes), without hard-depending on one brittle class forever.
+4. Prefer the candidate that can actually accept a temporary `scrollTop` change and restore it (probe + restore).
+5. Fall back to `document.scrollingElement` / `document.documentElement` only after candidates fail.
+
+The probe must restore scroll position so export does not leave the page scrolled mid-document if collection aborts early.
+
+### 2. Scroll + collect loop
+
+Keep incremental collection into `seen` / `rendered`, but change termination:
+
+- Recompute `maxY` every iteration from current `scrollHeight` / viewport.
+- After each scroll, wait briefly, then collect.
+- Treat “bottom reached” as provisional: require several consecutive stable rounds where **both**:
+  - no new blocks were collected, and
+  - `scrollHeight` did not grow.
+- If height grows or new blocks appear, reset the stable counter and continue.
+- Keep a hard iteration / time ceiling so a broken page cannot hang forever; surface whatever was collected (same as today) rather than inventing a new failure mode in this change.
+- Slightly increase bottom patience versus today’s `stable >= 2` with an extra `stable += 1` when already at bottom, which currently exits too eagerly while lazy content is still mounting.
+
+Do not change Markdown rendering rules in this pass.
+
+### 3. Call-site cleanup
+
+- Native-doc path continues to: navigate → `wait_for_doc_ready` → evaluate converter JS.
+- Remove unused `materialize_doc_dom` (or fold its intent into the converter only). Do not leave two scroll implementations.
+
+### 4. Observability (minimal)
+
+Return existing converter fields (`blockCount`, `textLength`, `renderer: "native_doc"`). No new incomplete flag in this change. Optional low-noise debug fields (e.g. scroll iterations / final scrollHeight) are allowed if cheap and useful for future triage, but not required for the user-facing report.
+
+### 5. Testing
+
+Add focused tests around the scroll/collection behavior, preferably by extracting the JS helpers into a testable string/module boundary already used by the exporter, or by evaluating the resolver/loop against a fake DOM in a Node/jsdom-style harness if the repo already has one; otherwise, unit-test the Python-side composition and include a pure-JS fixture exercised by the existing test runner if practical.
+
+Minimum scenarios:
+
+1. Correct nested scroller is chosen over `window` when only the nested pane scrolls.
+2. Lazy height growth after first bottom contact continues collection until height stabilizes.
+3. Existing Feishu session / Markdown-file tests still pass.
+
+Because live Feishu DOM is unavailable in CI, tests should use synthetic DOM fixtures that mimic:
+
+- nested overflow scroller
+- blocks mounted only after scrollTop crosses thresholds
+- growing `scrollHeight`
+
+### 6. Plugin / release notes
+
+Bump feishu plugin patch version when shipping the fix. Mention issue #129 in changelog / release notes for the plugin or app release that includes it.
+
+## Success criteria
+
+- Synthetic long-doc fixture that previously stopped early now collects all mounted blocks after lazy growth.
+- Nested-scroller fixture chooses the inner pane, not `window`.
+- Existing `tests/test_feishu_*.py` suite remains green.
+- No intentional change to Markdown-file export behavior.
+
+## Follow-ups (out of scope)
+
+- Mark native-doc exports incomplete when heuristics suggest truncation (e.g. suspiciously short body for a tall page).
+- Evaluate official/export API path if DOM virtualization keeps changing.
+- Re-test against the public sample wiki from #129 once a maintainer with access can verify end-to-end.

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1087,8 +1087,10 @@ async (fallbackTitle) => {
       } catch (_) {}
       return out;
     };
+    const containsContent = (el) => Boolean(
+      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
+    );
     const stepScrollables = (scrollables) => {
-      let moved = false;
       for (const el of scrollables) {
         try {
           const viewport = el.clientHeight || (win && win.innerHeight) || 600;
@@ -1098,12 +1100,10 @@ async (fallbackTitle) => {
           const step = Math.max(240, Math.floor(viewport * 0.75));
           // Even when already at the bottom, re-assign scrollTop = maxY so
           // Feishu's lazy-mount listeners (and our test fixtures) fire again
-          // after height growth. Skipping the re-assign was why later docs
-          // stopped scrolling after the first viewport.
+          // after height growth.
           const target = before >= maxY - 2 ? maxY : Math.min(maxY, before + step);
           el.scrollTop = target;
           try { el.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
-          if (Math.abs((el.scrollTop || 0) - before) > 0.5) moved = true;
         } catch (_) {}
       }
       // Always also scroll the last mounted block into view — this scrolls every
@@ -1113,11 +1113,15 @@ async (fallbackTitle) => {
         const last = blocks[blocks.length - 1];
         if (last && last.scrollIntoView) last.scrollIntoView({ block: "end", inline: "nearest" });
       } catch (_) {}
-      return moved;
     };
-    const allAtBottom = (scrollables) => {
-      if (!scrollables.length) return false;
-      return scrollables.every((el) => {
+    // Only require content-bearing scrollers to be at bottom. Outer window /
+    // shell panes often stay "not at bottom" forever and caused a full 180-iter
+    // stall + false incomplete after the real doc body was already collected.
+    const contentAtBottom = (scrollables) => {
+      const content = scrollables.filter(containsContent);
+      const pool = content.length ? content : scrollables;
+      if (!pool.length) return false;
+      return pool.every((el) => {
         try {
           const maxY = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
           return maxY <= 0 || (el.scrollTop || 0) >= maxY - 2;
@@ -1139,7 +1143,9 @@ async (fallbackTitle) => {
     };
 
     // Start at top, collect the first viewport, then keep stepping EVERY
-    // scrollable until no new blocks appear for several rounds while at bottom.
+    // scrollable until no new blocks / height growth for several rounds while
+    // the content scroller is at bottom. Do NOT treat scrollTop motion alone
+    // as progress — that kept the loop alive after the doc was already done.
     let scrollables = findScrollables();
     resetScroll(scrollables);
     await sleep(220);
@@ -1147,21 +1153,31 @@ async (fallbackTitle) => {
     let stable = 0;
     let scrollIterations = 0;
     let finalScrollHeight = 0;
+    let reachedBottom = false;
     for (let i = 0; i < maxIterations; i++) {
       scrollIterations = i + 1;
       scrollables = findScrollables();
       const heightBefore = maxScrollHeight(scrollables);
-      const moved = stepScrollables(scrollables);
-      await sleep(320);
+      stepScrollables(scrollables);
+      const atBottom = contentAtBottom(scrollables);
+      await sleep(atBottom ? 180 : 280);
       const changed = collect();
       finalScrollHeight = maxScrollHeight(scrollables);
-      const progressed = changed > 0 || finalScrollHeight > heightBefore + 2 || moved;
+      const progressed = changed > 0 || finalScrollHeight > heightBefore + 2;
       if (progressed) stable = 0;
       else stable += 1;
-      if (stable >= 4 && allAtBottom(scrollables)) break;
+      if (atBottom) reachedBottom = true;
+      if (stable >= 3 && atBottom) break;
     }
     resetScroll(scrollables);
-    return { rendered, blockCount: rendered.length, scrollIterations, finalScrollHeight };
+    return {
+      rendered,
+      blockCount: rendered.length,
+      scrollIterations,
+      finalScrollHeight,
+      reachedBottom,
+      hitIterationCeiling: scrollIterations >= maxIterations,
+    };
   }
 
   const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
@@ -1195,7 +1211,11 @@ async (fallbackTitle) => {
   result.scrollIterations = collected.scrollIterations;
   result.finalScrollHeight = collected.finalScrollHeight;
   if (scrollerHint) result.scroller = scrollerHint;
-  if (collected.scrollIterations >= 180) result.incomplete = true;
+  // Only flag incomplete when we exhausted the iteration ceiling WITHOUT
+  // reaching the bottom of the content scroller. A clean bottom stop means the
+  // document was fully collected; hitting the ceiling by itself used to cause
+  // false "内容可能不完整" reports on fully-exported docs.
+  if (collected.hitIterationCeiling && !collected.reachedBottom) result.incomplete = true;
   return result;
 }
 """

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -932,15 +932,17 @@ async (fallbackTitle) => {
       || document.querySelector(".page-main-item.editor")
       || document.querySelector(".editor-container");
     if (!root) return [];
-    // Prefer every top-level logical block under the editor root. Walk parents
-    // only up to `root` — do NOT use Element.closest(), which would also match
-    // outer shell nodes that happen to carry data-block-type and would filter
-    // out every real content block (producing empty exports).
+    // Prefer direct children of the render-unit wrapper — that is the pre-#129
+    // behaviour that successfully collected content. Also accept nested
+    // top-level blocks under intermediate wrappers, but only when the direct-
+    // child path would otherwise return nothing. Never use Element.closest()
+    // here: Feishu shell nodes may also carry data-block-type and would filter
+    // every real content block out (empty exports).
+    const direct = [...root.children].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
+    if (direct.length) return direct;
     const all = [...root.querySelectorAll("[data-block-type]")];
-    if (!all.length) {
-      return [...root.children].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
-    }
-    return all.filter((el) => {
+    if (!all.length) return [];
+    const topLevel = all.filter((el) => {
       let parent = el.parentElement;
       while (parent && parent !== root) {
         if (parent.getAttribute && parent.getAttribute("data-block-type")) return false;
@@ -948,6 +950,9 @@ async (fallbackTitle) => {
       }
       return true;
     });
+    // If nesting filters everything away (e.g. a shell data-block-type wraps
+    // the whole tree), fall back to the raw query so we still export something.
+    return topLevel.length ? topLevel : all;
   }
 
   /* feishu-scroll-api:start */

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -932,11 +932,22 @@ async (fallbackTitle) => {
       || document.querySelector(".page-main-item.editor")
       || document.querySelector(".editor-container");
     if (!root) return [];
-    // Prefer every top-level logical block (not nested inside another block) so
-    // Feishu's nested render-unit wrappers are not missed.
+    // Prefer every top-level logical block under the editor root. Walk parents
+    // only up to `root` — do NOT use Element.closest(), which would also match
+    // outer shell nodes that happen to carry data-block-type and would filter
+    // out every real content block (producing empty exports).
     const all = [...root.querySelectorAll("[data-block-type]")];
-    if (all.length) return all.filter(el => !el.parentElement || !el.parentElement.closest("[data-block-type]"));
-    return [...root.children].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
+    if (!all.length) {
+      return [...root.children].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
+    }
+    return all.filter((el) => {
+      let parent = el.parentElement;
+      while (parent && parent !== root) {
+        if (parent.getAttribute && parent.getAttribute("data-block-type")) return false;
+        parent = parent.parentElement;
+      }
+      return true;
+    });
   }
 
   /* feishu-scroll-api:start */

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -933,64 +933,99 @@ async (fallbackTitle) => {
       || document.querySelector(".editor-container");
     return [...(root ? root.children : [])].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
   }
+
+  /* feishu-scroll-api:start */
+  function resolveFeishuDocScroller(root, doc) {
+    const ownerDocument = doc || document;
+    let el = root;
+    while (el && el !== ownerDocument.body) {
+      const style = getComputedStyle(el);
+      if (el.scrollHeight > el.clientHeight + 30 && /(auto|scroll)/.test(style.overflowY)) return el;
+      el = el.parentElement;
+    }
+    return ownerDocument.scrollingElement || ownerDocument.documentElement;
+  }
+
+  async function collectFeishuDocBlocks(options) {
+    const {
+      scroller,
+      document: doc,
+      sleep,
+      setScroll: setScrollOpt,
+      currentBlocks: listBlocks,
+      renderBlock: renderOne,
+      maxIterations = 80,
+    } = options;
+    const ownerDocument = doc || document;
+    const scrollWindow = scroller === ownerDocument.scrollingElement
+      || scroller === ownerDocument.documentElement
+      || scroller === ownerDocument.body;
+    const setScroll = setScrollOpt || function setScroll(y) {
+      if (scrollWindow) window.scrollTo(0, y);
+      else {
+        scroller.scrollTop = y;
+        try { scroller.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
+      }
+    };
+    const seen = new Set();
+    const rendered = [];
+    const collect = () => {
+      for (const block of listBlocks()) {
+        const key = block.getAttribute("data-record-id")
+          || block.getAttribute("data-block-id")
+          || `${block.getAttribute("data-block-type")}:${clean(block.innerText || block.textContent || "").slice(0, 80)}:${rendered.length}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const md = renderOne(block);
+        if (md) rendered.push(md);
+      }
+    };
+    setScroll(0);
+    await sleep(220);
+    collect();
+    let y = 0;
+    let stable = 0;
+    let scrollIterations = 0;
+    for (let i = 0; i < maxIterations; i++) {
+      scrollIterations = i + 1;
+      const viewport = scrollWindow ? window.innerHeight : scroller.clientHeight;
+      const maxY = Math.max(0, scroller.scrollHeight - viewport);
+      if (y >= maxY && stable >= 2) break;
+      y = Math.min(maxY, y + Math.max(360, Math.floor(viewport * 0.7)));
+      setScroll(y);
+      await sleep(260);
+      const before = rendered.length;
+      collect();
+      stable = rendered.length === before ? stable + 1 : 0;
+      if (y >= maxY) stable += 1;
+    }
+    setScroll(0);
+    return { rendered, blockCount: rendered.length, scrollIterations };
+  }
+
+  const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
+  if (typeof globalThis !== "undefined") globalThis.__feishuConverterScrollApi = api;
+  /* feishu-scroll-api:end */
+
   const pageTitle = clean((document.querySelector(".page-block-content") || {}).innerText || fallbackTitle || document.title.replace(/\s*-\s*飞书云文档\s*$/, ""));
   const initialRoot = document.querySelector(".root-render-unit-container")
     || document.querySelector(".page-main-item.editor")
     || document.querySelector(".editor-container")
     || document.body;
-  function findScroller(root) {
-    let el = root;
-    while (el && el !== document.body) {
-      const style = getComputedStyle(el);
-      if (el.scrollHeight > el.clientHeight + 30 && /(auto|scroll)/.test(style.overflowY)) return el;
-      el = el.parentElement;
-    }
-    return document.scrollingElement || document.documentElement;
-  }
-  const scroller = findScroller(initialRoot);
-  const scrollWindow = scroller === document.scrollingElement || scroller === document.documentElement || scroller === document.body;
-  function setScroll(y) {
-    if (scrollWindow) window.scrollTo(0, y);
-    else {
-      scroller.scrollTop = y;
-      scroller.dispatchEvent(new Event("scroll", {bubbles: true}));
-    }
-  }
-  const seen = new Set();
-  const rendered = [];
+  const scroller = resolveFeishuDocScroller(initialRoot, document);
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-  const collect = () => {
-    for (const block of currentBlocks()) {
-      const key = block.getAttribute("data-record-id")
-        || block.getAttribute("data-block-id")
-        || `${block.getAttribute("data-block-type")}:${clean(block.innerText).slice(0, 80)}:${rendered.length}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      const md = renderBlock(block);
-      if (md) rendered.push(md);
-    }
-  };
-  setScroll(0);
-  await sleep(220);
-  collect();
-  let y = 0;
-  let stable = 0;
-  for (let i = 0; i < 80; i++) {
-    const viewport = scrollWindow ? window.innerHeight : scroller.clientHeight;
-    const maxY = Math.max(0, scroller.scrollHeight - viewport);
-    if (y >= maxY && stable >= 2) break;
-    y = Math.min(maxY, y + Math.max(360, Math.floor(viewport * 0.7)));
-    setScroll(y);
-    await sleep(260);
-    const before = rendered.length;
-    collect();
-    stable = rendered.length === before ? stable + 1 : 0;
-    if (y >= maxY) stable += 1;
-  }
-  setScroll(0);
-  const body = rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+  const collected = await collectFeishuDocBlocks({
+    root: initialRoot,
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 80,
+  });
+  const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
   const markdown = "# " + pageTitle + "\n\n" + body + "\n";
-  return {title: pageTitle, markdown, images: [...new Set(images)], blockCount: rendered.length, textLength: body.length, renderer: "native_doc"};
+  return {title: pageTitle, markdown, images: [...new Set(images)], blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
 }
 """
 

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1017,17 +1017,17 @@ async (fallbackTitle) => {
 
   async function collectFeishuDocBlocks(options) {
     const {
+      root,
       scroller,
       document: doc,
       sleep,
-      setScroll: setScrollOpt,
       currentBlocks: listBlocks,
       renderBlock: renderOne,
       maxIterations = 180,
     } = options;
-    const ownerDocument = doc || document;
-    // seen: key -> index in rendered; rendered holds md strings. Remounts may
-    // upgrade a block in place, so collect returns the number of changes.
+    const ownerDoc = doc || document;
+    const win = (ownerDoc.defaultView) || (typeof window !== "undefined" ? window : null);
+    // seen: key -> index in rendered; remounts may upgrade a block in place.
     const seen = new Map();
     const rendered = [];
     const keyFor = (block) => block.getAttribute("data-record-id")
@@ -1054,56 +1054,113 @@ async (fallbackTitle) => {
       }
       return changed;
     };
-    const ownerDoc = doc || document;
-    const scrollWindow = scroller === ownerDoc.scrollingElement
-      || scroller === ownerDoc.documentElement
-      || scroller === ownerDoc.body;
-    // Nudge whichever container actually scrolls. scrollIntoView on the last
-    // mounted block makes the browser scroll every real scrollable ancestor,
-    // which is far more robust than guessing which element is Feishu's scroller
-    // (e.g. DIV.scrollbar-container proved to be a dead end).
-    const scrollLastIntoView = () => {
+    // Discover every element that can currently scroll. Feishu often keeps the
+    // real virtual-list scroller nested; the first document after navigate may
+    // respond to window scroll while later documents only respond to an inner
+    // pane. Re-scanning each iteration avoids "first doc scrolls, rest don't".
+    const findScrollables = () => {
+      const out = [];
+      const push = (el) => {
+        if (!el || out.includes(el)) return;
+        const cls = String(el.className || "").toLowerCase();
+        if (cls.includes("scrollbar-container")) return;
+        let style;
+        try { style = getComputedStyle(el); } catch (_) { return; }
+        if (!/(auto|scroll)/.test(style.overflowY || "")) return;
+        const maxScroll = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
+        if (maxScroll <= 0) return;
+        out.push(el);
+      };
+      let el = root;
+      while (el && el !== ownerDoc.body) {
+        push(el);
+        el = el.parentElement;
+      }
+      push(scroller);
+      push(ownerDoc.scrollingElement);
+      push(ownerDoc.documentElement);
+      push(ownerDoc.body);
+      try {
+        for (const node of ownerDoc.querySelectorAll("[class*=\"scroll\"], .page-main, .editor-container, .wiki-main")) {
+          push(node);
+        }
+      } catch (_) {}
+      return out;
+    };
+    const stepScrollables = (scrollables) => {
+      let moved = false;
+      for (const el of scrollables) {
+        try {
+          const viewport = el.clientHeight || (win && win.innerHeight) || 600;
+          const maxY = Math.max(0, (el.scrollHeight || 0) - viewport);
+          if (maxY <= 0) continue;
+          const before = el.scrollTop || 0;
+          const step = Math.max(240, Math.floor(viewport * 0.75));
+          // Even when already at the bottom, re-assign scrollTop = maxY so
+          // Feishu's lazy-mount listeners (and our test fixtures) fire again
+          // after height growth. Skipping the re-assign was why later docs
+          // stopped scrolling after the first viewport.
+          const target = before >= maxY - 2 ? maxY : Math.min(maxY, before + step);
+          el.scrollTop = target;
+          try { el.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
+          if (Math.abs((el.scrollTop || 0) - before) > 0.5) moved = true;
+        } catch (_) {}
+      }
+      // Always also scroll the last mounted block into view — this scrolls every
+      // real ancestor the browser knows about, even ones we failed to list.
       try {
         const blocks = listBlocks();
         const last = blocks[blocks.length - 1];
-        if (last && last.scrollIntoView) last.scrollIntoView({ block: "end" });
+        if (last && last.scrollIntoView) last.scrollIntoView({ block: "end", inline: "nearest" });
       } catch (_) {}
+      return moved;
     };
-    const nudgeScroller = () => {
-      try {
-        if (!scroller || scroller.scrollTop === undefined) return;
-        const maxY = Math.max(0, (scroller.scrollHeight || 0) - (scroller.clientHeight || 0));
-        if (maxY > 0) {
-          scroller.scrollTop = maxY;
-          try { scroller.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
-        }
-      } catch (_) {}
+    const allAtBottom = (scrollables) => {
+      if (!scrollables.length) return false;
+      return scrollables.every((el) => {
+        try {
+          const maxY = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
+          return maxY <= 0 || (el.scrollTop || 0) >= maxY - 2;
+        } catch (_) { return true; }
+      });
     };
-    const resetScroll = () => {
-      try {
-        if (scroller) {
-          if (scrollWindow) ownerDoc.defaultView && ownerDoc.defaultView.scrollTo(0, 0);
-          else scroller.scrollTop = 0;
-        }
-      } catch (_) {}
+    const maxScrollHeight = (scrollables) => {
+      let best = 0;
+      for (const el of scrollables) {
+        try { best = Math.max(best, el.scrollHeight || 0); } catch (_) {}
+      }
+      return best;
     };
+    const resetScroll = (scrollables) => {
+      for (const el of scrollables) {
+        try { el.scrollTop = 0; } catch (_) {}
+      }
+      try { if (win) win.scrollTo(0, 0); } catch (_) {}
+    };
+
+    // Start at top, collect the first viewport, then keep stepping EVERY
+    // scrollable until no new blocks appear for several rounds while at bottom.
+    let scrollables = findScrollables();
+    resetScroll(scrollables);
+    await sleep(220);
     collect();
     let stable = 0;
     let scrollIterations = 0;
     let finalScrollHeight = 0;
     for (let i = 0; i < maxIterations; i++) {
       scrollIterations = i + 1;
+      scrollables = findScrollables();
+      const heightBefore = maxScrollHeight(scrollables);
+      const moved = stepScrollables(scrollables);
+      await sleep(320);
       const changed = collect();
-      scrollLastIntoView();
-      nudgeScroller();
-      await sleep(280);
-      const changedAfter = collect();
-      try { finalScrollHeight = scroller ? (scroller.scrollHeight || 0) : 0; } catch (_) {}
-      if (changed + changedAfter > 0) stable = 0;
+      finalScrollHeight = maxScrollHeight(scrollables);
+      const progressed = changed > 0 || finalScrollHeight > heightBefore + 2 || moved;
+      if (progressed) stable = 0;
       else stable += 1;
-      if (stable >= 4) break;
+      if (stable >= 4 && allAtBottom(scrollables)) break;
     }
-    resetScroll();
+    resetScroll(scrollables);
     return { rendered, blockCount: rendered.length, scrollIterations, finalScrollHeight };
   }
 
@@ -1125,7 +1182,7 @@ async (fallbackTitle) => {
     sleep,
     currentBlocks,
     renderBlock,
-    maxIterations: 120,
+    maxIterations: 180,
   });
   const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
   const markdown = "# " + pageTitle + "\n\n" + body + "\n";

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -931,7 +931,12 @@ async (fallbackTitle) => {
       || document.querySelector(".root-render-unit-container")
       || document.querySelector(".page-main-item.editor")
       || document.querySelector(".editor-container");
-    return [...(root ? root.children : [])].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
+    if (!root) return [];
+    // Prefer every top-level logical block (not nested inside another block) so
+    // Feishu's nested render-unit wrappers are not missed.
+    const all = [...root.querySelectorAll("[data-block-type]")];
+    if (all.length) return all.filter(el => !el.parentElement || !el.parentElement.closest("[data-block-type]"));
+    return [...root.children].filter(el => el.getAttribute && el.getAttribute("data-block-type"));
   }
 
   /* feishu-scroll-api:start */
@@ -987,7 +992,7 @@ async (fallbackTitle) => {
       setScroll: setScrollOpt,
       currentBlocks: listBlocks,
       renderBlock: renderOne,
-      maxIterations = 120,
+      maxIterations = 180,
     } = options;
     const ownerDocument = doc || document;
     const scrollWindow = scroller === ownerDocument.scrollingElement
@@ -1000,18 +1005,33 @@ async (fallbackTitle) => {
         try { scroller.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
       }
     };
-    const seen = new Set();
+    // seen: key -> index in rendered; rendered holds md strings. Remounts may
+    // upgrade a block in place, so collect returns {changed, count}.
+    const seen = new Map();
     const rendered = [];
+    const keyFor = (block) => block.getAttribute("data-record-id")
+      || block.getAttribute("data-block-id")
+      || `${block.getAttribute("data-block-type")}:${clean(block.innerText || block.textContent || "").slice(0, 80)}`;
     const collect = () => {
+      let changed = 0;
       for (const block of listBlocks()) {
-        const key = block.getAttribute("data-record-id")
-          || block.getAttribute("data-block-id")
-          || `${block.getAttribute("data-block-type")}:${clean(block.innerText || block.textContent || "").slice(0, 80)}:${rendered.length}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
+        const key = keyFor(block);
+        if (!key) continue;
         const md = renderOne(block);
-        if (md) rendered.push(md);
+        if (!md) continue;
+        if (seen.has(key)) {
+          const index = seen.get(key);
+          if (md.length > rendered[index].length) {
+            rendered[index] = md;
+            changed += 1;
+          }
+        } else {
+          seen.set(key, rendered.length);
+          rendered.push(md);
+          changed += 1;
+        }
       }
+      return changed;
     };
     setScroll(0);
     await sleep(220);
@@ -1019,22 +1039,26 @@ async (fallbackTitle) => {
     let y = 0;
     let stable = 0;
     let scrollIterations = 0;
+    let heightBefore = scroller.scrollHeight;
     for (let i = 0; i < maxIterations; i++) {
       scrollIterations = i + 1;
       const viewport = scrollWindow ? window.innerHeight : scroller.clientHeight;
       const maxY = Math.max(0, scroller.scrollHeight - viewport);
       if (y >= maxY && stable >= 4) break;
-      y = Math.min(maxY, y + Math.max(360, Math.floor(viewport * 0.7)));
+      const nearBottom = y >= maxY - viewport;
+      const step = nearBottom ? Math.max(120, Math.floor(viewport * 0.2)) : Math.max(360, Math.floor(viewport * 0.7));
+      y = Math.min(maxY, y + step);
       setScroll(y);
-      await sleep(260);
-      const heightBefore = scroller.scrollHeight;
-      const before = rendered.length;
-      collect();
-      if (rendered.length > before || scroller.scrollHeight > heightBefore) stable = 0;
+      const settle = nearBottom ? 500 : 260;
+      await sleep(settle);
+      const changed = collect();
+      const heightAfter = scroller.scrollHeight;
+      if (changed > 0 || heightAfter > heightBefore) stable = 0;
       else stable += 1;
+      heightBefore = heightAfter;
     }
     setScroll(0);
-    return { rendered, blockCount: rendered.length, scrollIterations };
+    return { rendered, blockCount: rendered.length, scrollIterations, finalScrollHeight: heightBefore };
   }
 
   const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
@@ -1059,7 +1083,17 @@ async (fallbackTitle) => {
   });
   const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
   const markdown = "# " + pageTitle + "\n\n" + body + "\n";
-  return {title: pageTitle, markdown, images: [...new Set(images)], blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
+  const scrollerHint = (() => {
+    try {
+      return (scroller && scroller.tagName || "") + ":" + (scroller.className ? String(scroller.className).split(/\s+/)[0] || "" : "");
+    } catch (_) { return ""; }
+  })();
+  const result = {title: pageTitle, markdown, images: [...new Set(images)], blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
+  result.scrollIterations = collected.scrollIterations;
+  result.finalScrollHeight = collected.finalScrollHeight;
+  if (scrollerHint) result.scroller = scrollerHint;
+  if (collected.scrollIterations >= 180) result.incomplete = true;
+  return result;
 }
 """
 
@@ -1335,7 +1369,7 @@ def extract_doc_markdown_current(
             value = evaluate_markdown_file(True)
     else:
         wait_for_doc_ready(cdp, timeout=35, args=args, node=node)
-        value = cdp.evaluate(f"({FEISHU_CONVERTER_JS})({js_string(node.get('title') or '未命名')})", timeout=60)
+        value = cdp.evaluate(f"({FEISHU_CONVERTER_JS})({js_string(node.get('title') or '未命名')})", timeout=120)
     if not isinstance(value, dict):
         raise ExportError(f"Unexpected Feishu doc response: {node.get('title')}")
     if value.get("renderer") == "markdown_preview_fallback":
@@ -1817,13 +1851,20 @@ def export_wiki(args: argparse.Namespace) -> dict[str, Any]:
                         {
                             "title": doc.get("title") or "",
                             "wiki_token": token,
-                            "error": "飞书原始 Markdown 下载失败，已保留页面预览兜底内容，但内容可能不完整",
+                            "error": "飞书原始 Markdown 下载失败，已保留页面预览兜底内容，但内容可能不完整"
+                            if result.get("renderer") == "markdown_preview_fallback"
+                            else "飞书原生文档滚动采集触达上限，内容可能不完整（已保留已采集内容）",
                             "local_path": str(md_path),
                         }
                     )
                 if checkpoint:
                     if incomplete:
-                        checkpoint.fail_item(item_key, "原始 Markdown 下载失败，页面预览兜底内容可能不完整")
+                        checkpoint.fail_item(
+                            item_key,
+                            "原始 Markdown 下载失败，页面预览兜底内容可能不完整"
+                            if result.get("renderer") == "markdown_preview_fallback"
+                            else "原生文档滚动采集触达上限，内容可能不完整",
+                        )
                     elif img_errors:
                         checkpoint.fail_item(item_key, f"{len(img_errors)} 个图片下载失败")
                     else:
@@ -1843,6 +1884,11 @@ def export_wiki(args: argparse.Namespace) -> dict[str, Any]:
                         "imageSuccessInDoc": count,
                         "imageFailuresInDoc": len(img_errors),
                         "contentIncomplete": incomplete,
+                        "scrollIterations": result.get("scrollIterations"),
+                        "finalScrollHeight": result.get("finalScrollHeight"),
+                        "scroller": result.get("scroller"),
+                        "blockCount": result.get("blockCount"),
+                        "textLength": result.get("textLength"),
                     },
                 )
             except ExportStopped:

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1026,18 +1026,8 @@ async (fallbackTitle) => {
       maxIterations = 180,
     } = options;
     const ownerDocument = doc || document;
-    const scrollWindow = scroller === ownerDocument.scrollingElement
-      || scroller === ownerDocument.documentElement
-      || scroller === ownerDocument.body;
-    const setScroll = setScrollOpt || function setScroll(y) {
-      if (scrollWindow) window.scrollTo(0, y);
-      else {
-        scroller.scrollTop = y;
-        try { scroller.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
-      }
-    };
     // seen: key -> index in rendered; rendered holds md strings. Remounts may
-    // upgrade a block in place, so collect returns {changed, count}.
+    // upgrade a block in place, so collect returns the number of changes.
     const seen = new Map();
     const rendered = [];
     const keyFor = (block) => block.getAttribute("data-record-id")
@@ -1064,32 +1054,57 @@ async (fallbackTitle) => {
       }
       return changed;
     };
-    setScroll(0);
-    await sleep(220);
+    const ownerDoc = doc || document;
+    const scrollWindow = scroller === ownerDoc.scrollingElement
+      || scroller === ownerDoc.documentElement
+      || scroller === ownerDoc.body;
+    // Nudge whichever container actually scrolls. scrollIntoView on the last
+    // mounted block makes the browser scroll every real scrollable ancestor,
+    // which is far more robust than guessing which element is Feishu's scroller
+    // (e.g. DIV.scrollbar-container proved to be a dead end).
+    const scrollLastIntoView = () => {
+      try {
+        const blocks = listBlocks();
+        const last = blocks[blocks.length - 1];
+        if (last && last.scrollIntoView) last.scrollIntoView({ block: "end" });
+      } catch (_) {}
+    };
+    const nudgeScroller = () => {
+      try {
+        if (!scroller || scroller.scrollTop === undefined) return;
+        const maxY = Math.max(0, (scroller.scrollHeight || 0) - (scroller.clientHeight || 0));
+        if (maxY > 0) {
+          scroller.scrollTop = maxY;
+          try { scroller.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
+        }
+      } catch (_) {}
+    };
+    const resetScroll = () => {
+      try {
+        if (scroller) {
+          if (scrollWindow) ownerDoc.defaultView && ownerDoc.defaultView.scrollTo(0, 0);
+          else scroller.scrollTop = 0;
+        }
+      } catch (_) {}
+    };
     collect();
-    let y = 0;
     let stable = 0;
     let scrollIterations = 0;
-    let heightBefore = scroller.scrollHeight;
+    let finalScrollHeight = 0;
     for (let i = 0; i < maxIterations; i++) {
       scrollIterations = i + 1;
-      const viewport = scrollWindow ? window.innerHeight : scroller.clientHeight;
-      const maxY = Math.max(0, scroller.scrollHeight - viewport);
-      if (y >= maxY && stable >= 4) break;
-      const nearBottom = y >= maxY - viewport;
-      const step = nearBottom ? Math.max(120, Math.floor(viewport * 0.2)) : Math.max(360, Math.floor(viewport * 0.7));
-      y = Math.min(maxY, y + step);
-      setScroll(y);
-      const settle = nearBottom ? 500 : 260;
-      await sleep(settle);
       const changed = collect();
-      const heightAfter = scroller.scrollHeight;
-      if (changed > 0 || heightAfter > heightBefore) stable = 0;
+      scrollLastIntoView();
+      nudgeScroller();
+      await sleep(280);
+      const changedAfter = collect();
+      try { finalScrollHeight = scroller ? (scroller.scrollHeight || 0) : 0; } catch (_) {}
+      if (changed + changedAfter > 0) stable = 0;
       else stable += 1;
-      heightBefore = heightAfter;
+      if (stable >= 4) break;
     }
-    setScroll(0);
-    return { rendered, blockCount: rendered.length, scrollIterations, finalScrollHeight: heightBefore };
+    resetScroll();
+    return { rendered, blockCount: rendered.length, scrollIterations, finalScrollHeight };
   }
 
   const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -937,11 +937,44 @@ async (fallbackTitle) => {
   /* feishu-scroll-api:start */
   function resolveFeishuDocScroller(root, doc) {
     const ownerDocument = doc || document;
+    const candidates = [];
+    const pushUnique = (el) => {
+      if (el && !candidates.includes(el)) candidates.push(el);
+    };
     let el = root;
     while (el && el !== ownerDocument.body) {
       const style = getComputedStyle(el);
-      if (el.scrollHeight > el.clientHeight + 30 && /(auto|scroll)/.test(style.overflowY)) return el;
+      if (el.scrollHeight > el.clientHeight + 30 && /(auto|scroll)/.test(style.overflowY || "")) {
+        pushUnique(el);
+      }
       el = el.parentElement;
+    }
+    const shell = (root && root.closest)
+      ? (root.closest(".page-main") || root.closest(".editor-container") || root.closest(".wiki-main") || root)
+      : root;
+    const allowlistRoots = [shell, ownerDocument].filter(Boolean);
+    for (const scope of allowlistRoots) {
+      try {
+        for (const node of scope.querySelectorAll(".page-main, [class*=\"scroll\"]")) {
+          pushUnique(node);
+        }
+      } catch (_) {}
+    }
+    // Prefer deepest (closest to editor root) candidates first.
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i];
+      const maxScroll = Math.max(0, (candidate.scrollHeight || 0) - (candidate.clientHeight || 0));
+      if (maxScroll <= 0) continue;
+      const original = candidate.scrollTop || 0;
+      const probe = Math.min(42, maxScroll);
+      try {
+        candidate.scrollTop = probe;
+        const accepted = Math.abs((candidate.scrollTop || 0) - original) > 0.5;
+        candidate.scrollTop = original;
+        if (accepted) return candidate;
+      } catch (_) {
+        try { candidate.scrollTop = original; } catch (__) {}
+      }
     }
     return ownerDocument.scrollingElement || ownerDocument.documentElement;
   }
@@ -954,7 +987,7 @@ async (fallbackTitle) => {
       setScroll: setScrollOpt,
       currentBlocks: listBlocks,
       renderBlock: renderOne,
-      maxIterations = 80,
+      maxIterations = 120,
     } = options;
     const ownerDocument = doc || document;
     const scrollWindow = scroller === ownerDocument.scrollingElement
@@ -990,14 +1023,15 @@ async (fallbackTitle) => {
       scrollIterations = i + 1;
       const viewport = scrollWindow ? window.innerHeight : scroller.clientHeight;
       const maxY = Math.max(0, scroller.scrollHeight - viewport);
-      if (y >= maxY && stable >= 2) break;
+      if (y >= maxY && stable >= 4) break;
       y = Math.min(maxY, y + Math.max(360, Math.floor(viewport * 0.7)));
       setScroll(y);
       await sleep(260);
+      const heightBefore = scroller.scrollHeight;
       const before = rendered.length;
       collect();
-      stable = rendered.length === before ? stable + 1 : 0;
-      if (y >= maxY) stable += 1;
+      if (rendered.length > before || scroller.scrollHeight > heightBefore) stable = 0;
+      else stable += 1;
     }
     setScroll(0);
     return { rendered, blockCount: rendered.length, scrollIterations };
@@ -1021,7 +1055,7 @@ async (fallbackTitle) => {
     sleep,
     currentBlocks,
     renderBlock,
-    maxIterations: 80,
+    maxIterations: 120,
   });
   const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
   const markdown = "# " + pageTitle + "\n\n" + body + "\n";
@@ -1254,16 +1288,6 @@ def wait_for_doc_ready(
         time.sleep(0.5)
     kind = "Markdown 文件预览" if markdown_file else "文档正文"
     raise ExportError(f"飞书{kind}没有加载完成：{(node or {}).get('title') or '未命名'}")
-
-
-def materialize_doc_dom(cdp: CDPClient) -> None:
-    cdp.evaluate(
-        "(async () => {"
-        "const h = Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);"
-        "for (const p of [0, 0.25, 0.5, 0.75, 1, 0]) { window.scrollTo(0, Math.floor(h * p)); await new Promise(r => setTimeout(r, 160)); }"
-        "})()",
-        timeout=10,
-    )
 
 
 def extract_doc_markdown_current(

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -962,42 +962,57 @@ async (fallbackTitle) => {
     const pushUnique = (el) => {
       if (el && !candidates.includes(el)) candidates.push(el);
     };
+    // 1) Ancestors of the editor root.
     let el = root;
     while (el && el !== ownerDocument.body) {
-      const style = getComputedStyle(el);
-      if (el.scrollHeight > el.clientHeight + 30 && /(auto|scroll)/.test(style.overflowY || "")) {
-        pushUnique(el);
-      }
+      pushUnique(el);
       el = el.parentElement;
     }
+    // 2) Known Feishu doc shells near the editor (short allowlist).
     const shell = (root && root.closest)
       ? (root.closest(".page-main") || root.closest(".editor-container") || root.closest(".wiki-main") || root)
       : root;
     const allowlistRoots = [shell, ownerDocument].filter(Boolean);
     for (const scope of allowlistRoots) {
       try {
-        for (const node of scope.querySelectorAll(".page-main, [class*=\"scroll\"]")) {
+        for (const node of scope.querySelectorAll(".page-main, .editor-container, [class*=\"scroll\"]")) {
           pushUnique(node);
         }
       } catch (_) {}
     }
-    // Prefer deepest (closest to editor root) candidates first.
-    for (let i = 0; i < candidates.length; i++) {
-      const candidate = candidates[i];
-      const maxScroll = Math.max(0, (candidate.scrollHeight || 0) - (candidate.clientHeight || 0));
-      if (maxScroll <= 0) continue;
-      const original = candidate.scrollTop || 0;
-      const probe = Math.min(42, maxScroll);
+    const isScrollbarChrome = (el) => {
+      const cls = String(el.className || "").toLowerCase();
+      if (cls.includes("scrollbar-container")) return true;
+      return false;
+    };
+    const acceptsScroll = (el) => {
+      if (isScrollbarChrome(el)) return false;
+      let style;
+      try { style = getComputedStyle(el); } catch (_) { return false; }
+      if (!/(auto|scroll)/.test(style.overflowY || "")) return false;
+      const maxScroll = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
+      if (maxScroll <= 0) return false;
+      const original = el.scrollTop || 0;
+      const probe = Math.min(64, maxScroll);
       try {
-        candidate.scrollTop = probe;
-        const accepted = Math.abs((candidate.scrollTop || 0) - original) > 0.5;
-        candidate.scrollTop = original;
-        if (accepted) return candidate;
+        el.scrollTop = probe;
+        const accepted = Math.abs((el.scrollTop || 0) - original) > 0.5;
+        el.scrollTop = original;
+        return accepted;
       } catch (_) {
-        try { candidate.scrollTop = original; } catch (__) {}
+        try { el.scrollTop = original; } catch (__) {}
+        return false;
       }
-    }
-    return ownerDocument.scrollingElement || ownerDocument.documentElement;
+    };
+    const containsContent = (el) => Boolean(
+      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
+    );
+    const active = candidates.filter(acceptsScroll);
+    // Prefer a scroller that actually contains document blocks (the deepest,
+    // nearest the editor root). Skip scrollbar chrome like .scrollbar-container.
+    const withContent = active.filter(containsContent);
+    const pool = withContent.length ? withContent : active;
+    return pool[0] || ownerDocument.scrollingElement || ownerDocument.documentElement;
   }
 
   async function collectFeishuDocBlocks(options) {

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -122,3 +122,104 @@ test('collectFeishuDocBlocks keeps scrolling after lazy scrollHeight growth', as
   assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
   assert.equal(result.blockCount, 4);
 });
+
+test('collectFeishuDocBlocks treats height growth during settle as progress', async () => {
+  const api = loadScrollApi();
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="root-render-unit-container"><div class="render-unit-wrapper"></div></div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 400;
+  let scrollTop = 0;
+  // Growth is delivered AFTER the settle sleep: the scroll setter only records
+  // the position; a separate "settle pass" grows the doc. A collector that
+  // samples height after sleep would miss this and stabilize too early.
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => { scrollTop = value; },
+  });
+  const mount = (id, text) => {
+    if ([...wrapper.children].some((el) => el.textContent === text)) return;
+    const block = document.createElement('div');
+    block.setAttribute('data-block-type', 'paragraph');
+    block.setAttribute('data-block-id', id);
+    block.textContent = text;
+    wrapper.appendChild(block);
+  };
+  mount('block-1', 'block-1');
+  mount('block-2', 'block-2');
+  let settleRounds = 0;
+  // The injected sleep is the "settle": on rounds 2 and 4 the document grows.
+  const sleep = async () => {
+    settleRounds += 1;
+    if (settleRounds === 2 && scrollHeight === 400) {
+      scrollHeight = 900;
+      mount('block-3', 'block-3');
+    }
+    if (settleRounds === 4 && scrollHeight === 900) {
+      scrollHeight = 1400;
+      mount('block-4', 'block-4');
+    }
+  };
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root: document.querySelector('.root-render-unit-container'),
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 40,
+  });
+  assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
+  assert.equal(result.finalScrollHeight, 1400);
+});
+
+test('collectFeishuDocBlocks upgrades a partially mounted block in place', async () => {
+  const api = loadScrollApi();
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="root-render-unit-container"><div class="render-unit-wrapper"></div></div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 400;
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => { scrollTop = value; },
+  });
+  const block1 = document.createElement('div');
+  block1.setAttribute('data-block-type', 'paragraph');
+  block1.setAttribute('data-block-id', 'block-1');
+  block1.textContent = 'partial text'; // mounted before full .ace-line text arrives
+  wrapper.appendChild(block1);
+  let settleRounds = 0;
+  const sleep = async () => {
+    settleRounds += 1;
+    if (settleRounds === 1) block1.textContent = 'partial text plus the rest of the sentence https://example.com/x';
+  };
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root: document.querySelector('.root-render-unit-container'),
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 20,
+  });
+  assert.deepEqual(result.rendered, ['partial text plus the rest of the sentence https://example.com/x']);
+});

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -1,0 +1,124 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { createRequire } = require('node:module');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const exporterPath = path.join(repoRoot, 'plugins', 'feishu', 'backend', 'export_feishu.py');
+const desktopRequire = createRequire(path.join(repoRoot, 'wandao_electron', 'package.json'));
+const { parseHTML } = desktopRequire('linkedom');
+
+function loadScrollApi() {
+  const source = fs.readFileSync(exporterPath, 'utf8');
+  const match = source.match(/FEISHU_CONVERTER_JS = r?"""([\s\S]*?)"""/);
+  assert.ok(match, 'FEISHU_CONVERTER_JS was not found');
+  const start = match[1].indexOf('/* feishu-scroll-api:start */');
+  const end = match[1].indexOf('/* feishu-scroll-api:end */');
+  assert.ok(start >= 0 && end > start, 'feishu scroll api markers were not found');
+  const helperSource = match[1].slice(start, end + '/* feishu-scroll-api:end */'.length);
+  const { document, window } = parseHTML('<!doctype html><html><body></body></html>');
+  global.document = document;
+  global.window = window;
+  global.getComputedStyle = (el) => {
+    const overflowY = el.getAttribute('data-overflow-y') || 'visible';
+    return { overflowY };
+  };
+  delete globalThis.__feishuConverterScrollApi;
+  const runner = Function(
+    'document',
+    'window',
+    'getComputedStyle',
+    'clean',
+    `"use strict";\n${helperSource}\nreturn globalThis.__feishuConverterScrollApi;`
+  );
+  const api = runner(document, window, getComputedStyle, (value) => String(value || '').trim());
+  assert.ok(api, 'scroll api was not exported');
+  return api;
+}
+
+function makeLazyDoc() {
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="shell" data-overflow-y="visible" style="height:200px">
+      <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+        <div class="root-render-unit-container">
+          <div class="render-unit-wrapper"></div>
+        </div>
+      </div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  // Fake geometry because linkedom does not implement layout.
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 400;
+  let scrollTop = 0;
+  let bottomContacts = 0;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = value;
+      // Defer lazy growth until the iteration after first bottom contact so the
+      // old double-count termination exits before blocks 3/4 appear.
+      if (scrollTop >= scrollHeight - 200 && wrapper.childElementCount < 4) {
+        bottomContacts += 1;
+        if (bottomContacts < 2) return;
+        scrollHeight = 900;
+        for (const [type, text] of [
+          ['paragraph', 'block-3'],
+          ['paragraph', 'block-4'],
+        ]) {
+          if ([...wrapper.children].some((el) => el.textContent === text)) continue;
+          const block = document.createElement('div');
+          block.setAttribute('data-block-type', type);
+          block.setAttribute('data-block-id', text);
+          block.textContent = text;
+          wrapper.appendChild(block);
+        }
+      }
+    },
+  });
+  // Seed the first viewport blocks.
+  for (const [id, text] of [
+    ['block-1', 'block-1'],
+    ['block-2', 'block-2'],
+  ]) {
+    const block = document.createElement('div');
+    block.setAttribute('data-block-type', 'paragraph');
+    block.setAttribute('data-block-id', id);
+    block.textContent = text;
+    wrapper.appendChild(block);
+  }
+  Object.defineProperty(window, 'innerHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(document.documentElement, 'clientHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(document.documentElement, 'scrollHeight', { configurable: true, get: () => 200 });
+  return { document, window, scroller, root: document.querySelector('.root-render-unit-container'), wrapper };
+}
+
+test('resolveFeishuDocScroller prefers the nested page scroller over window', () => {
+  const api = loadScrollApi();
+  const { document, root, scroller } = makeLazyDoc();
+  const resolved = api.resolveFeishuDocScroller(root, document);
+  assert.equal(resolved, scroller);
+});
+
+test('collectFeishuDocBlocks keeps scrolling after lazy scrollHeight growth', async () => {
+  const api = loadScrollApi();
+  const { document, root, scroller, wrapper } = makeLazyDoc();
+  const sleep = async () => {};
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root,
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 120,
+  });
+  assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
+  assert.equal(result.blockCount, 4);
+});

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -303,3 +303,59 @@ test('collectFeishuDocBlocks mounts blocks via scrollIntoView nudging', async ()
   });
   assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
 });
+
+test('collectFeishuDocBlocks stops cleanly at bottom without false incomplete', async () => {
+  const api = loadScrollApi();
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="root-render-unit-container"><div class="render-unit-wrapper"></div></div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 500;
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = Math.min(Math.max(value, 0), scrollHeight - 200);
+      // Mount all blocks on first reach of bottom; after that, nothing grows.
+      if (scrollTop >= scrollHeight - 200 && wrapper.childElementCount < 4) {
+        scrollHeight = 1400;
+        for (const id of ['block-3', 'block-4']) {
+          const block = document.createElement('div');
+          block.setAttribute('data-block-type', 'paragraph');
+          block.setAttribute('data-block-id', id);
+          block.textContent = id;
+          wrapper.appendChild(block);
+        }
+      }
+    },
+  });
+  for (const id of ['block-1', 'block-2']) {
+    const block = document.createElement('div');
+    block.setAttribute('data-block-type', 'paragraph');
+    block.setAttribute('data-block-id', id);
+    block.textContent = id;
+    wrapper.appendChild(block);
+  }
+  const sleep = async () => {};
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root: document.querySelector('.root-render-unit-container'),
+    scroller,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 180,
+  });
+  assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
+  assert.equal(result.reachedBottom, true);
+  assert.equal(result.hitIterationCeiling, false);
+  assert.ok(result.scrollIterations < 40, `should stop near bottom, got ${result.scrollIterations}`);
+});

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -261,3 +261,45 @@ test('resolveFeishuDocScroller skips scrollbar chrome that cannot scroll', () =>
   const resolved = api.resolveFeishuDocScroller(root, document);
   assert.equal(resolved, scroller);
 });
+
+test('collectFeishuDocBlocks mounts blocks via scrollIntoView nudging', async () => {
+  const api = loadScrollApi();
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="root-render-unit-container">
+      <div class="render-unit-wrapper"></div>
+    </div>
+  </body></html>`);
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  const root = document.querySelector('.root-render-unit-container');
+  // The collector no longer depends on a real scroller's scrollTop; a minimal
+  // window-scroll fallback is enough as long as scrollIntoView mounts blocks.
+  let nextId = 3;
+  const mk = (id, text) => {
+    const block = document.createElement('div');
+    block.setAttribute('data-block-type', 'paragraph');
+    block.setAttribute('data-block-id', id);
+    block.textContent = text;
+    block.scrollIntoView = () => {
+      if (wrapper.childElementCount < 4) {
+        const idNum = nextId++;
+        mk(`block-${idNum}`, `block-${idNum}`);
+      }
+    };
+    wrapper.appendChild(block);
+  };
+  mk('block-1', 'block-1');
+  mk('block-2', 'block-2');
+  const sleep = async () => {};
+  const currentBlocks = () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type'));
+  const renderBlock = (el) => el.textContent || '';
+  const result = await api.collectFeishuDocBlocks({
+    root,
+    scroller: document.documentElement,
+    document,
+    sleep,
+    currentBlocks,
+    renderBlock,
+    maxIterations: 40,
+  });
+  assert.deepEqual(result.rendered, ['block-1', 'block-2', 'block-3', 'block-4']);
+});

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -223,3 +223,41 @@ test('collectFeishuDocBlocks upgrades a partially mounted block in place', async
   });
   assert.deepEqual(result.rendered, ['partial text plus the rest of the sentence https://example.com/x']);
 });
+
+test('resolveFeishuDocScroller skips scrollbar chrome that cannot scroll', () => {
+  const api = loadScrollApi();
+  const { document, window } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="scrollbar-container" data-overflow-y="auto" style="height:200px">
+        <div class="root-render-unit-container">
+          <div class="render-unit-wrapper">
+            <div data-block-type="paragraph" data-block-id="a">hello</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const chrome = document.querySelector('.scrollbar-container');
+  const root = document.querySelector('.root-render-unit-container');
+  let chromeHeight = 200;
+  Object.defineProperty(chrome, 'clientHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(chrome, 'scrollHeight', { configurable: true, get: () => 200 });
+  let chromeTop = 0;
+  Object.defineProperty(chrome, 'scrollTop', {
+    configurable: true,
+    get: () => chromeTop,
+    set: (value) => { chromeTop = value; },
+  });
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollerHeight = 600;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollerHeight });
+  let scrollerTop = 0;
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollerTop,
+    set: (value) => { scrollerTop = value; },
+  });
+  const resolved = api.resolveFeishuDocScroller(root, document);
+  assert.equal(resolved, scroller);
+});

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -124,7 +124,7 @@ test('Feishu import tutorial pins all screenshots remotely and excludes them fro
   assert.equal(assets.reduce((total, name) => total + fs.statSync(path.join(remoteAssetRoot, name)).size, 0), 17317358);
   assert.deepEqual(new Set(Object.keys(provider.guideAssets)), new Set(imageReferences.map((match) => match[1])));
   assert.equal(Object.values(provider.guideAssets).every((asset) => asset.mime === 'image/png' && asset.bytes <= 3 * 1024 * 1024 && /^[a-f0-9]{64}$/.test(asset.sha256)), true);
-  assert.equal(plugin.version, '1.0.7');
+  assert.equal(plugin.version, '1.0.8');
 });
 
 test('guide hydration limits remote IPC concurrency and renders an offline fallback', () => {

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -124,7 +124,7 @@ test('Feishu import tutorial pins all screenshots remotely and excludes them fro
   assert.equal(assets.reduce((total, name) => total + fs.statSync(path.join(remoteAssetRoot, name)).size, 0), 17317358);
   assert.deepEqual(new Set(Object.keys(provider.guideAssets)), new Set(imageReferences.map((match) => match[1])));
   assert.equal(Object.values(provider.guideAssets).every((asset) => asset.mime === 'image/png' && asset.bytes <= 3 * 1024 * 1024 && /^[a-f0-9]{64}$/.test(asset.sha256)), true);
-  assert.equal(plugin.version, '1.0.8');
+  assert.equal(plugin.version, '1.0.9');
 });
 
 test('guide hydration limits remote IPC concurrency and renders an offline fallback', () => {


### PR DESCRIPTION
## Summary

Fix Feishu native-doc (`obj_type=22`) export only capturing the beginning of long documents. The exporter scrolls and collects `[data-block-type]` DOM blocks lazily mounted by Feishu's virtualized editor; when scrolling didn't actually reach the document bottom, later blocks never mounted and were silently missing (`contentIncomplete: false`).

Fixes #129

## What changed

`plugins/feishu/backend/export_feishu.py` (`FEISHU_CONVERTER_JS`):

- **Scroll every scrollable container, per document.** Re-scan all scrollable ancestors each iteration (skipping `scrollbar-container` chrome), step each by ~75% viewport, re-assign `scrollTop` even at the bottom so lazy-mount listeners fire after height growth, and also `scrollIntoView` the last mounted block. Previously the scroller was resolved once and often pointed at an outer window / `DIV.scrollbar-container` that never scrolled the real doc body — so the first doc sometimes exported fully but later docs did not.
- **Progress = new/upgraded blocks or height growth only.** Scroll motion alone no longer resets the stability counter.
- **Stop cleanly at the bottom.** Terminate after ~3 stable rounds with no progress once **content-bearing** scrollers are at their bottom (outer shell panes no longer keep the loop alive), so each doc doesn't stall for the full iteration ceiling.
- **Refresh partially-mounted blocks in place.** Re-render an already-seen block when a later mount yields longer text (fixes mid-URL cuts).
- **Widen block collection.** Collect top-level `[data-block-type]` via `querySelectorAll` with a safe fallback, preferring direct children first.
- **Correct incomplete reporting.** Flag `incomplete` only when the iteration ceiling is hit *without* reaching the content bottom; a clean bottom stop no longer produces false "内容可能不完整" warnings.
- **Diagnostics.** Return `scrollIterations` / `finalScrollHeight` / `scroller` / `blockCount` / `textLength` into the export-completed event for future triage.
- Bump native-doc CDP evaluate timeout 60s → 120s.

Also:
- Remove unused `materialize_doc_dom` (single scroll path).
- feishu plugin `1.0.7` → **`1.0.9`** (`plugin.json`), with `tests_js/guide_markdown.test.js` version pin synced.
- Spec + implementation plan under `docs/superpowers/` for #129.

## Tests

- `tests_js/feishu_converter_scroll.test.js` (7 tests): nested-scroller preference, lazy-height growth, height-growth-during-settle, partial-block refresh, scrollbar-chrome rejection, scrollIntoView mounting, clean bottom stop with no false ceiling.
- `tests_js/guide_markdown.test.js`: 10 tests (version pin `1.0.9`).
- Python: `tests.test_feishu_session_and_markdown tests.test_feishu_readiness tests.test_feishu_selection_mismatch` — 26 tests.

## Verification (manual, real Feishu account)

Exported the #129 wiki (`https://my.feishu.cn/wiki/Ka1SwSZkKiWmVTkGD0acBWVnnTe`, 25 docs) with the current branch in `tauri dev`:

- ✅ Every document now scrolls to the bottom and exports completely (previously only some did).
- ✅ Long docs that were truncated before (e.g. 开发环境配置 ~17KB with 56 headings) now export fully.
- ✅ No more stall at the bottom after the clean-stop change.
- ✅ No more false "内容可能不完整" reports after reaching the content bottom.

## Notes

- Stays on the DOM-scrape path; no Feishu content/export API switch (per #129 non-goals).
- Diagnostics remain low-noise and are not surfaced as a user-facing contract beyond the existing incomplete plumbing.