### PR TITLE
docs: 支持上传错误日志文件

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,9 +32,16 @@ body:
       label: 错误日志
       description: 建议粘贴软件里的错误报告或运行日志；没有日志可以填写“无”。
       render: text
+  - type: upload
+    id: log_file
+    attributes:
+      label: 上传错误日志文件（可选）
+      description: 日志较长时可以直接拖入文件或点击选择；支持 .log、.txt、.json、.csv、.zip，单个文件最大 25MB。
+    validations:
+      required: false
+      accept: ".log,.txt,.json,.csv,.zip"
   - type: textarea
     id: screenshot
     attributes:
       label: 截图
       description: 可以直接拖拽截图到这里；没有截图可以填写“无”。
-

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,126 +1,40 @@
 name: Bug 反馈
-description: 反馈导出、导入、界面、安装或打包问题
-title: "[Bug] 用一句话描述问题，例如：语雀导出到一半停止"
+description: 导入、导出、安装、界面或插件出现异常
+title: "[Bug] "
 labels: ["bug", "status:needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢反馈。请先搜索已有 Issue/PR，避免重复反馈同一个问题。
+        请尽量提供下面三项：问题描述、错误日志、截图。
 
-        请不要上传 Cookie、账号密码、App Secret、Token、API Key、私人知识库内容等敏感信息。
+        如果想认领这个问题，请直接在 Issue 评论区回复“认领”，不需要在表单中填写认领计划。
+
+        请不要上传 Cookie、账号密码、App Secret、Token、API Key 或私人知识库内容。
   - type: checkboxes
     id: precheck
     attributes:
-      label: 提交前确认
+      label: 提交前确认（可选）
       options:
-        - label: 我已经搜索过已有 Issue 和 PR，没有找到相同问题。
-          required: true
-        - label: 我已经确认日志、截图和样例中不包含 Cookie、Token、账号密码、App Secret、API Key 等敏感信息。
-          required: true
-  - type: dropdown
-    id: platform
-    attributes:
-      label: 涉及平台
-      options:
-        - 知识星球
-        - 语雀
-        - 飞书
-        - 阿里云 Thoughts
-        - 印象笔记
-        - 有道云笔记
-        - OneNote
-        - 为知笔记
-        - ima 知识库
-        - Notion 教程
-        - 桌面端界面
-        - 打包/安装
-        - Provider 插件机制
-        - 其他
-    validations:
-      required: true
-  - type: dropdown
-    id: action
-    attributes:
-      label: 涉及能力
-      options:
-        - 导出
-        - 导入
-        - 登录/保存凭证
-        - 读取目录
-        - 图片/附件
-        - 目录结构
-        - 任务中心/断点续跑
-        - 设置
-        - 教程公告
-        - 安装/启动
-        - 其他
-    validations:
-      required: true
+        - label: 我已经搜索过已有 Issue 和 PR，暂时没有找到相同问题。
+        - label: 我已经确认日志和截图中没有敏感信息。
   - type: textarea
-    id: problem
+    id: description
     attributes:
       label: 问题描述
-      description: 发生了什么？预期应该是什么？
-      placeholder: 例如：语雀导入时部分 Markdown 创建成功，但有 2 篇图片没有上传。
+      description: 请简单说明发生了什么；可以顺便写平台、万能导版本、系统和复现步骤。
+      placeholder: 例如：飞书导出时有两张图片没有保存，系统为 Windows 11，万能导 v1.4.4。
     validations:
       required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: 复现步骤
-      description: 请写清楚如何复现，方便定位。
-      placeholder: |
-        1. 打开 Wandao
-        2. 进入平台中心，选择 ...
-        3. 点击 ...
-        4. 出现 ...
-    validations:
-      required: true
-  - type: textarea
-    id: result
-    attributes:
-      label: 实际结果
-      description: 可以写错误提示、失败数量、缺失图片数量、导入导出效果等。
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: 期望结果
-      description: 你认为正确结果应该是什么？
   - type: textarea
     id: log
     attributes:
-      label: 运行日志或错误报告
-      description: 建议使用软件里的“复制错误报告”。请先确认已脱敏。
+      label: 错误日志
+      description: 建议粘贴软件里的错误报告或运行日志；没有日志可以填写“无”。
       render: text
-  - type: input
-    id: version
-    attributes:
-      label: 万能导版本
-      placeholder: 例如：v1.2.0 / main 分支 commit id
-    validations:
-      required: true
-  - type: input
-    id: os
-    attributes:
-      label: 系统环境
-      placeholder: 例如：Windows 11 / macOS 15 / Ubuntu 24.04
-    validations:
-      required: true
   - type: textarea
-    id: sample
+    id: screenshot
     attributes:
-      label: 脱敏样例或截图
-      description: 可补充目录结构、Markdown 片段、截图。请不要上传私人数据。
-  - type: dropdown
-    id: willing
-    attributes:
-      label: 是否愿意协助修复或测试
-      description: 仅反馈问题或协助测试没有时限。选择认领修复时，认领确认后 2 天内需提交 Draft PR 或可验证进展；复杂任务请说明情况并至少每 2 天同步一次。
-      options:
-        - 愿意协助测试
-        - 愿意认领修复
-        - 暂时只能反馈问题
-        - 其他
+      label: 截图
+      description: 可以直接拖拽截图到这里；没有截图可以填写“无”。
+

--- a/.github/ISSUE_TEMPLATE/docs_tutorial.yml
+++ b/.github/ISSUE_TEMPLATE/docs_tutorial.yml
@@ -1,61 +1,34 @@
 name: 教程 / 文档建议
-description: 补充教程、公告、迁移经验、排障文档或文档修正
+description: 补充教程、排障说明或修正文档
 title: "[Docs] "
 labels: ["documentation", "status:needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        适合提交平台教程、迁移经验、排障说明、公告内容或文档修正。
+        请简单说明希望新增或修改的内容。
 
-        如果教程涉及私人平台内容，请先脱敏。
+        如果想认领这个 Issue，请直接在评论区回复“认领”，不需要在表单中填写认领计划。
+
+        请先脱敏，不要提交私人内容或账号凭证。
   - type: checkboxes
     id: precheck
     attributes:
-      label: 提交前确认
+      label: 提交前确认（可选）
       options:
-        - label: 我已经搜索过已有 Issue 和 PR，没有找到相同文档建议。
-          required: true
-        - label: 我确认文档、截图和样例中不包含私人内容或敏感凭证。
-          required: true
-  - type: dropdown
-    id: docs_type
-    attributes:
-      label: 文档类型
-      options:
-        - 平台使用教程
-        - 导入/导出排障
-        - 迁移经验
-        - Provider 开发说明
-        - 公告内容
-        - README 修正
-        - 其他
-    validations:
-      required: true
-  - type: input
-    id: related_platform
-    attributes:
-      label: 相关平台
-      placeholder: 例如：语雀 / 飞书 / Notion / 无
+        - label: 我已经搜索过已有 Issue 和 PR，暂时没有找到相同建议。
+        - label: 我已经确认内容和截图中没有敏感信息。
   - type: textarea
-    id: content
+    id: description
     attributes:
-      label: 建议内容
-      description: 请说明希望新增或修改什么。
-      placeholder: 例如：建议补充 macOS 首次打开提示“应用已损坏”的处理方法。
+      label: 文档建议
+      description: 请说明哪里需要补充、修改或纠正。
+      placeholder: 例如：建议补充 macOS 首次打开应用时的处理说明。
     validations:
       required: true
   - type: textarea
     id: references
     attributes:
-      label: 参考资料
-      description: 可提供官方文档、公开教程或截图说明。
-  - type: dropdown
-    id: willing
-    attributes:
-      label: 是否愿意提交 PR
-      options:
-        - 愿意提交文档 PR
-        - 愿意协助校对
-        - 暂时只提供建议
-        - 其他
+      label: 参考资料或截图（可选）
+      description: 可以提供公开链接、截图或示例内容。
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,85 +1,32 @@
 name: 功能建议
-description: 建议已有平台增强、UI 优化、任务中心、设置或体验改进
+description: 建议已有平台、界面或任务功能改进
 title: "[Feature] "
 labels: ["enhancement", "status:needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        欢迎提出建议。请尽量描述真实使用场景，而不只是功能名。
+        如果是新增平台，请使用“新平台接入建议 / 共创认领”模板。
 
-        如果是新增平台，无论是否参与开发，请使用“新平台接入建议 / 共创认领”模板。
+        如果想认领这个 Issue，请直接在评论区回复“认领”，不需要在表单中填写认领计划。
   - type: checkboxes
     id: precheck
     attributes:
-      label: 提交前确认
+      label: 提交前确认（可选）
       options:
-        - label: 我已经搜索过已有 Issue 和 PR，没有找到相同建议。
-          required: true
-        - label: 这个建议不是新增平台；如果是新增平台，我会改用“新平台接入建议 / 共创认领”模板。
-          required: true
-  - type: dropdown
-    id: scope
-    attributes:
-      label: 功能范围
-      options:
-        - 已有平台导出增强
-        - 已有平台导入增强
-        - 图片/附件处理
-        - 目录选择/目录结构
-        - 任务中心/断点续跑/失败重试
-        - 桌面端界面
-        - 设置
-        - 教程公告
-        - 打包/安装/更新
-        - Provider 插件机制
-        - 文档教程
-        - 其他
-    validations:
-      required: true
-  - type: input
-    id: related_platform
-    attributes:
-      label: 相关平台
-      description: 如果只影响某个平台，请写平台名；不涉及平台可写“无”。
-      placeholder: 例如：语雀 / 飞书 / 无
+        - label: 我已经搜索过已有 Issue 和 PR，暂时没有找到相同建议。
+        - label: 这不是新增平台建议。
   - type: textarea
-    id: scenario
+    id: description
     attributes:
-      label: 使用场景
-      description: 你想解决什么问题？
-      placeholder: 例如：我想批量导出某平台内容，但失败后只能从头开始，希望可以重试失败项。
+      label: 功能建议
+      description: 请说明想解决什么问题，以及希望万能导怎么改。
+      placeholder: 例如：导出失败后，希望任务中心可以只重试失败的文档。
     validations:
       required: true
   - type: textarea
-    id: solution
+    id: references
     attributes:
-      label: 期望功能
-      description: 你希望万能导怎么支持？
-      placeholder: 例如：任务中心里显示失败项，并提供“只重试失败项”的按钮。
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: 你尝试过的替代方案
-      description: 可以写目前如何绕过、人工怎么做、已有工具怎么处理。
-  - type: textarea
-    id: examples
-    attributes:
-      label: 示例或参考
-      description: 可以提供公开页面、截图、参考工具或你期望的输出结构。请不要提供敏感信息。
-  - type: dropdown
-    id: willing
-    attributes:
-      label: 是否愿意认领实现
-      description: 只提供建议或协助测试没有时限。选择认领开发时，认领确认后 2 天内需提交 Draft PR 或可验证进展；复杂任务请说明情况并至少每 2 天同步一次。
-      options:
-        - 愿意认领开发
-        - 愿意协助测试
-        - 暂时只提供建议
-        - 其他
-  - type: textarea
-    id: extra
-    attributes:
-      label: 其他补充
+      label: 示例、参考资料或截图（可选）
+      description: 可以提供公开链接、截图或你期望的效果。
+

--- a/.github/ISSUE_TEMPLATE/new_provider.yml
+++ b/.github/ISSUE_TEMPLATE/new_provider.yml
@@ -1,25 +1,23 @@
 name: 新平台接入建议 / 共创认领
-description: 任何人都可以建议新平台，也可以认领导入、导出或教程能力
+description: 建议万能导支持新的平台
 title: "[Platform] "
 labels: ["enhancement", "help wanted", "plugin", "status:needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        任何人都可以使用这个模板建议万能导支持新的平台，不需要会开发，也不需要认领。你也可以提供平台资料、协助测试，或认领平台适配。
+        不需要会开发也可以提出新平台建议。
 
-        请先搜索已有 Issue 和 PR，避免重复建议或重复开发。只有选择认领开发时才适用认领规则：认领确认后 2 天内提交 Draft PR 或可验证进展；如果任务较复杂，请在 2 天内说明情况，此后至少每 2 天同步一次进度。
+        如果想认领这个平台，请直接在评论区回复“认领”，不需要填写认领计划或预计完成时间。
+
+        请不要提交 Cookie、Token、账号密码、App Secret、API Key 或私人内容。
   - type: checkboxes
     id: precheck
     attributes:
-      label: 提交前确认
+      label: 提交前确认（可选）
       options:
-        - label: 我已经搜索过已有 Issue 和 PR，没有找到相同平台或相同方向的适配。
-          required: true
-        - label: 我可以只提出新平台建议；如果准备开发，我会先在 Issue 中完成认领。
-          required: true
-        - label: 我不会提交 Cookie、Token、账号密码、App Secret、API Key 或私人知识库内容。
-          required: true
+        - label: 我已经搜索过已有 Issue 和 PR，暂时没有找到相同平台或方向。
+        - label: 我已经确认没有提交敏感信息。
   - type: input
     id: platform
     attributes:
@@ -27,92 +25,16 @@ body:
       placeholder: 例如：飞书 / 语雀 / 某某知识库
     validations:
       required: true
-  - type: input
-    id: platform_url
-    attributes:
-      label: 平台官网或入口示例
-      description: 优先提供公开官网、帮助文档或公开样例链接，不要提供私人内容链接。
-      placeholder: https://example.com
-  - type: checkboxes
-    id: capability
-    attributes:
-      label: 希望支持的能力
-      options:
-        - label: 导出为 Markdown
-        - label: 导入 Markdown
-        - label: 图片处理
-        - label: 附件处理
-        - label: 读取目录 / 保留目录结构
-        - label: 断点续跑 / 失败重试
-        - label: 教程文档
-        - label: 其他
-    validations:
-      required: true
-  - type: dropdown
-    id: contribution_type
-    attributes:
-      label: 参与方式
-      options:
-        - 我只想建议新增这个平台，暂不参与开发
-        - 我可以协助测试
-        - 我可以提供平台资料或脱敏样例
-        - 我想认领开发这个平台
-        - 我先提供平台调研和样例
-        - 其他
-    validations:
-      required: true
-  - type: dropdown
-    id: provider_type
-    attributes:
-      label: 预计接入方式
-      description: 不确定可以选“不确定”。
-      options:
-        - 标准 UI 插件
-        - 复杂流程插件（可包含多个 Provider）
-        - 教程型插件
-        - 旧 Provider v1 兼容维护
-        - 不确定
   - type: textarea
-    id: current_workflow
+    id: description
     attributes:
-      label: 当前平台的导入/导出方式
-      description: 平台本身是否支持导出？支持哪些格式？有没有官方 API？是否必须浏览器登录？
-      placeholder: |
-        例如：
-        - 平台官方支持导出 HTML/PDF，但不支持 Markdown。
-        - 网页端可以看到目录树。
-        - 图片需要单独下载。
+      label: 需求描述
+      description: 请简单说明希望支持什么，以及平台目前的导入或导出方式。
+      placeholder: 例如：希望支持导出为 Markdown，平台网页需要登录后才能查看内容。
     validations:
       required: true
-  - type: textarea
-    id: expected_output
-    attributes:
-      label: 期望效果
-      description: 描述导入/导出后希望得到什么结构。
-      placeholder: |
-        例如：
-        - 保留多层目录结构。
-        - 每篇文档一个 .md。
-        - 图片保存到 assets 目录，并替换为相对路径。
-    validations:
-      required: true
-  - type: textarea
-    id: test_material
-    attributes:
-      label: 可用于测试的材料
-      description: 可以说明是否有脱敏样例、公开页面、测试账号或可截图的目录结构。请不要直接贴敏感数据。
   - type: textarea
     id: references
     attributes:
-      label: 参考资料或开源项目
-      description: 如果参考第三方项目，请写清楚链接和许可证。
-  - type: input
-    id: eta
-    attributes:
-      label: 认领计划（仅认领者填写）
-      description: 认领确认后 2 天内应提交 Draft PR 或可验证进展。任务较复杂时，请说明原因和下一步，并至少每 2 天同步一次进度。
-      placeholder: 例如：2 天内提交 Draft PR / 任务较复杂，先完成登录流程并同步结果
-  - type: textarea
-    id: extra
-    attributes:
-      label: 其他补充
+      label: 官网、公开资料或测试材料（可选）
+      description: 可以提供公开链接、脱敏样例、截图或测试说明。


### PR DESCRIPTION
在 Bug Issue 表单中增加独立的错误日志文件上传字段。支持直接拖入或选择 .log、.txt、.json、.csv、.zip 文件，单文件最大 25MB；原有日志文本框继续保留，上传项不强制填写。