### PR TITLE
docs: 支持上传错误日志文件

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,9 +32,16 @@ body:
       label: 错误日志
       description: 建议粘贴软件里的错误报告或运行日志；没有日志可以填写“无”。
       render: text
+  - type: upload
+    id: log_file
+    attributes:
+      label: 上传错误日志文件（可选）
+      description: 日志较长时可以直接拖入文件或点击选择；支持 .log、.txt、.json、.csv、.zip，单个文件最大 25MB。
+    validations:
+      required: false
+      accept: ".log,.txt,.json,.csv,.zip"
   - type: textarea
     id: screenshot
     attributes:
       label: 截图
       description: 可以直接拖拽截图到这里；没有截图可以填写“无”。
-


### PR DESCRIPTION
在 Bug Issue 表单中增加独立的错误日志文件上传字段。支持直接拖入或选择 .log、.txt、.json、.csv、.zip 文件，单文件最大 25MB；原有日志文本框继续保留，上传项不强制填写。