### PR TITLE
fix(feishu): 完善长文档滚动与图片导出

### DIFF
--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -843,6 +843,7 @@ def order_tree(tree: dict[str, Any]) -> list[dict[str, Any]]:
 FEISHU_CONVERTER_JS = r"""
 async (fallbackTitle) => {
   const images = [];
+  const imageSourcesByNode = new Map();
   const ZERO = /[\u200b\u200c\u200d\ufeff]/g;
   function clean(value) {
     return (value || "")
@@ -855,6 +856,18 @@ async (fallbackTitle) => {
   function escTable(value) {
     return clean(value).replace(/\|/g, "\\|").replace(/\n+/g, "<br>");
   }
+  function trackImage(img) {
+    const src = imageSource(img);
+    if (!src) return "";
+    images.push(src);
+    let observed = imageSourcesByNode.get(img);
+    if (!observed) {
+      observed = new Set();
+      imageSourcesByNode.set(img, observed);
+    }
+    observed.add(src);
+    return src;
+  }
   function inline(node) {
     if (!node) return "";
     if (node.nodeType === 3) return node.nodeValue.replace(ZERO, "");
@@ -862,9 +875,8 @@ async (fallbackTitle) => {
     const tag = node.tagName.toLowerCase();
     if (tag === "br") return "\n";
     if (tag === "img") {
-      const src = node.getAttribute("src") || node.getAttribute("data-src") || "";
+      const src = trackImage(node);
       const alt = node.getAttribute("alt") || "image";
-      if (src) images.push(src);
       return src ? `![${alt}](${src})` : "";
     }
     const text = [...node.childNodes].map(inline).join("");
@@ -897,9 +909,8 @@ async (fallbackTitle) => {
   function renderImage(el) {
     const img = el.querySelector("img");
     if (!img) return "";
-    const src = img.getAttribute("src") || img.getAttribute("data-src") || "";
+    const src = trackImage(img);
     const alt = img.getAttribute("alt") || "image";
-    if (src) images.push(src);
     return src ? `![${alt}](${src})` : "";
   }
   function quote(value) {
@@ -956,6 +967,81 @@ async (fallbackTitle) => {
   }
 
   /* feishu-scroll-api:start */
+  function imageSource(img) {
+    if (!img) return "";
+    const candidates = [
+      img.getAttribute("data-src"),
+      img.getAttribute("data-original"),
+      img.getAttribute("data-image-url"),
+      img.getAttribute("data-original-src"),
+      img.getAttribute("data-lazy-src"),
+      img.currentSrc,
+      img.getAttribute("src"),
+    ];
+    return candidates.map(value => String(value || "").trim()).find(Boolean) || "";
+  }
+
+  async function resolveImageSource(source) {
+    if (!/^blob:/i.test(String(source || ""))) return source;
+    if (typeof fetch !== "function" || typeof FileReader !== "function") return source;
+    try {
+      const response = await fetch(source);
+      if (!response.ok) return source;
+      const blob = await response.blob();
+      return await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result || source));
+        reader.onerror = () => resolve(source);
+        reader.readAsDataURL(blob);
+      });
+    } catch (_) {
+      return source;
+    }
+  }
+
+  async function waitForImage(img, timeout = 1800) {
+    if (!img || img.complete || typeof img.addEventListener !== "function") return;
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        try { img.removeEventListener("load", finish); } catch (_) {}
+        try { img.removeEventListener("error", finish); } catch (_) {}
+        resolve();
+      };
+      img.addEventListener("load", finish, { once: true });
+      img.addEventListener("error", finish, { once: true });
+      setTimeout(finish, timeout);
+    });
+  }
+
+  async function settleImageSources(rendered, sourceList = [], sourceNodes = new Map()) {
+    const replacements = new Map();
+    const sources = new Set(sourceList);
+    for (const [img, observed] of sourceNodes.entries()) {
+      await waitForImage(img);
+      const current = imageSource(img);
+      if (!current) continue;
+      observed.add(current);
+      const resolved = await resolveImageSource(current);
+      sources.add(resolved || current);
+      for (const previous of observed) {
+        if (previous && previous !== (resolved || current)) {
+          replacements.set(previous, resolved || current);
+        }
+      }
+    }
+    for (let index = 0; index < rendered.length; index++) {
+      let markdown = rendered[index];
+      for (const [from, to] of replacements) {
+        if (from && to && markdown.includes(from)) markdown = markdown.split(from).join(to);
+      }
+      rendered[index] = markdown;
+    }
+    return [...sources].filter(source => !replacements.has(source));
+  }
+
   function resolveFeishuDocScroller(root, doc) {
     const ownerDocument = doc || document;
     const candidates = [];
@@ -1023,6 +1109,8 @@ async (fallbackTitle) => {
       sleep,
       currentBlocks: listBlocks,
       renderBlock: renderOne,
+      imageList = [],
+      imageNodes = new Map(),
       maxIterations = 180,
     } = options;
     const ownerDoc = doc || document;
@@ -1042,7 +1130,7 @@ async (fallbackTitle) => {
         if (!md) continue;
         if (seen.has(key)) {
           const index = seen.get(key);
-          if (md.length > rendered[index].length) {
+          if (md !== rendered[index]) {
             rendered[index] = md;
             changed += 1;
           }
@@ -1169,9 +1257,11 @@ async (fallbackTitle) => {
       if (atBottom) reachedBottom = true;
       if (stable >= 3 && atBottom) break;
     }
+    const settledImages = await settleImageSources(rendered, imageList, imageNodes);
     resetScroll(scrollables);
     return {
       rendered,
+      images: settledImages,
       blockCount: rendered.length,
       scrollIterations,
       finalScrollHeight,
@@ -1180,7 +1270,7 @@ async (fallbackTitle) => {
     };
   }
 
-  const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
+  const api = { resolveFeishuDocScroller, collectFeishuDocBlocks, resolveImageSource };
   if (typeof globalThis !== "undefined") globalThis.__feishuConverterScrollApi = api;
   /* feishu-scroll-api:end */
 
@@ -1198,6 +1288,8 @@ async (fallbackTitle) => {
     sleep,
     currentBlocks,
     renderBlock,
+    imageList: images,
+    imageNodes: imageSourcesByNode,
     maxIterations: 180,
   });
   const body = collected.rendered.filter(Boolean).join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
@@ -1207,7 +1299,7 @@ async (fallbackTitle) => {
       return (scroller && scroller.tagName || "") + ":" + (scroller.className ? String(scroller.className).split(/\s+/)[0] || "" : "");
     } catch (_) { return ""; }
   })();
-  const result = {title: pageTitle, markdown, images: [...new Set(images)], blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
+  const result = {title: pageTitle, markdown, images: collected.images, blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
   result.scrollIterations = collected.scrollIterations;
   result.finalScrollHeight = collected.finalScrollHeight;
   if (scrollerHint) result.scroller = scrollerHint;
@@ -1516,6 +1608,9 @@ def fetch_doc_markdown(
 
 
 def guess_extension(url: str, content_type: str | None) -> str:
+    if url.lower().startswith("data:"):
+        metadata = url[5:].split(",", 1)[0]
+        content_type = metadata.split(";", 1)[0] or content_type or ""
     path = urllib.parse.urlparse(url).path.lower()
     match = re.search(r"\.([a-z0-9]{2,5})$", path)
     if match:
@@ -1535,6 +1630,23 @@ def guess_extension(url: str, content_type: str | None) -> str:
     return "png"
 
 
+def decode_data_url(url: str) -> tuple[bytes, str]:
+    if not url.lower().startswith("data:") or "," not in url:
+        raise ExportError("Invalid image data URL")
+    metadata, payload = url[5:].split(",", 1)
+    content_type = metadata.split(";", 1)[0] or "application/octet-stream"
+    if any(part.lower() == "base64" for part in metadata.split(";")):
+        try:
+            data = base64.b64decode(payload, validate=True)
+        except (ValueError, base64.binascii.Error) as exc:
+            raise ExportError("Invalid base64 image data URL") from exc
+    else:
+        data = urllib.parse.unquote_to_bytes(payload)
+    if not data:
+        raise ExportError("Empty image data URL")
+    return data, content_type
+
+
 def cookie_header_for_url(cookies: list[dict[str, Any]], url: str) -> str:
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or ""
@@ -1552,14 +1664,18 @@ def cookie_header_for_url(cookies: list[dict[str, Any]], url: str) -> str:
 
 
 def download_image(url: str, dest_dir: Path, cookies: list[dict[str, Any]], timeout: int) -> Path:
-    headers = {"User-Agent": "Mozilla/5.0", "Referer": "https://www.feishu.cn/"}
-    cookie_header = cookie_header_for_url(cookies, url)
-    if cookie_header:
-        headers["Cookie"] = cookie_header
-    request = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        data = response.read()
-        ext = guess_extension(url, response.headers.get("Content-Type"))
+    if url.lower().startswith("data:"):
+        data, content_type = decode_data_url(url)
+        ext = guess_extension(url, content_type)
+    else:
+        headers = {"User-Agent": "Mozilla/5.0", "Referer": "https://www.feishu.cn/"}
+        cookie_header = cookie_header_for_url(cookies, url)
+        if cookie_header:
+            headers["Cookie"] = cookie_header
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = response.read()
+            ext = guess_extension(url, response.headers.get("Content-Type"))
     dest_dir.mkdir(parents=True, exist_ok=True)
     target = dest_dir / (hashlib.sha1(url.encode("utf-8")).hexdigest()[:12] + "." + ext)
     if not target.exists():
@@ -1582,9 +1698,11 @@ def localize_images(
     failures: list[dict[str, str]] = []
     for url in sorted(set(images)):
         check_stopped(args)
-        if not url.startswith(("http://", "https://")):
-            continue
         try:
+            if not url.lower().startswith(("http://", "https://", "data:")):
+                if url.lower().startswith("blob:"):
+                    raise ExportError("浏览器 Blob 图片未能转换为可下载的图片数据")
+                continue
             target = download_image(url, md_path.parent / "assets", cookies, timeout)
             markdown = markdown.replace(url, os.path.relpath(target, md_path.parent).replace("\\", "/"))
             success += 1

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -998,6 +998,41 @@ async (fallbackTitle) => {
     });
   }
 
+  async function resolveImageSource(img, source) {
+    if (!/^blob:/i.test(String(source || ""))) return source;
+    // Feishu may display the Blob URL successfully while blocking fetch(blob:)
+    // from the page's security policy. Prefer the already-loaded image itself.
+    try {
+      const width = img && (img.naturalWidth || img.width || 0);
+      const height = img && (img.naturalHeight || img.height || 0);
+      if (img && img.complete && width > 0 && height > 0 && document && document.createElement) {
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d");
+        if (context) {
+          context.drawImage(img, 0, 0, width, height);
+          const dataUrl = canvas.toDataURL("image/png");
+          if (dataUrl && dataUrl !== "data:,") return dataUrl;
+        }
+      }
+    } catch (_) {}
+    if (typeof fetch !== "function" || typeof FileReader !== "function") return source;
+    try {
+      const response = await fetch(source);
+      if (!response.ok) return source;
+      const blob = await response.blob();
+      return await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result || source));
+        reader.onerror = () => resolve(source);
+        reader.readAsDataURL(blob);
+      });
+    } catch (_) {
+      return source;
+    }
+  }
+
   async function settleImageSources(rendered, sourceList = [], sourceNodes = new Map()) {
     const replacements = new Map();
     const sources = new Set(sourceList);
@@ -1006,7 +1041,7 @@ async (fallbackTitle) => {
       const current = imageSource(img);
       if (!current) return null;
       observed.add(current);
-      return { observed, source: current };
+      return { observed, source: await resolveImageSource(img, current) };
     }));
     for (const item of settled) {
       if (!item) continue;
@@ -1049,10 +1084,12 @@ async (fallbackTitle) => {
         }
       } catch (_) {}
     }
+    const containsContent = (el) => Boolean(
+      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
+    );
     const isScrollbarChrome = (el) => {
       const cls = String(el.className || "").toLowerCase();
-      if (cls.includes("scrollbar-container")) return true;
-      return false;
+      return cls.includes("scrollbar-container") && !containsContent(el);
     };
     const acceptsScroll = (el) => {
       if (isScrollbarChrome(el)) return false;
@@ -1073,9 +1110,6 @@ async (fallbackTitle) => {
         return false;
       }
     };
-    const containsContent = (el) => Boolean(
-      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
-    );
     const active = candidates.filter(acceptsScroll);
     // Prefer a scroller that actually contains document blocks (the deepest,
     // nearest the editor root). Skip scrollbar chrome like .scrollbar-container.
@@ -1129,12 +1163,15 @@ async (fallbackTitle) => {
     // real virtual-list scroller nested; the first document after navigate may
     // respond to window scroll while later documents only respond to an inner
     // pane. Re-scanning each iteration avoids "first doc scrolls, rest don't".
+    const containsContent = (el) => Boolean(
+      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
+    );
     const findScrollables = () => {
       const out = [];
       const push = (el) => {
         if (!el || out.includes(el)) return;
         const cls = String(el.className || "").toLowerCase();
-        if (cls.includes("scrollbar-container")) return;
+        if (cls.includes("scrollbar-container") && !containsContent(el)) return;
         let style;
         try { style = getComputedStyle(el); } catch (_) { return; }
         if (!/(auto|scroll)/.test(style.overflowY || "")) return;
@@ -1158,10 +1195,8 @@ async (fallbackTitle) => {
       } catch (_) {}
       return out;
     };
-    const containsContent = (el) => Boolean(
-      el && el.querySelector && (el.querySelector("[data-block-type]") || el.querySelector(".ace-line"))
-    );
     const stepScrollables = (scrollables) => {
+      let moved = false;
       for (const el of scrollables) {
         try {
           const viewport = el.clientHeight || (win && win.innerHeight) || 600;
@@ -1174,16 +1209,21 @@ async (fallbackTitle) => {
           // after height growth.
           const target = before >= maxY - 2 ? maxY : Math.min(maxY, before + step);
           el.scrollTop = target;
+          if (Math.abs((el.scrollTop || 0) - before) > 1) moved = true;
           try { el.dispatchEvent(new Event("scroll", {bubbles: true})); } catch (_) {}
         } catch (_) {}
       }
-      // Always also scroll the last mounted block into view — this scrolls every
-      // real ancestor the browser knows about, even ones we failed to list.
-      try {
-        const blocks = listBlocks();
-        const last = blocks[blocks.length - 1];
-        if (last && last.scrollIntoView) last.scrollIntoView({ block: "end", inline: "nearest" });
-      } catch (_) {}
+      // Use scrollIntoView only as a fallback. On native Feishu docs it can
+      // undo the explicit scrollTop step and keep the real document scroller
+      // pinned near the first mounted block.
+      const hasContentScroller = scrollables.some(containsContent);
+      if (!moved && !hasContentScroller) {
+        try {
+          const blocks = listBlocks();
+          const last = blocks[blocks.length - 1];
+          if (last && last.scrollIntoView) last.scrollIntoView({ block: "end", inline: "nearest" });
+        } catch (_) {}
+      }
     };
     // Only require content-bearing scrollers to be at bottom. Outer window /
     // shell panes often stay "not at bottom" forever and caused a full 180-iter
@@ -1195,7 +1235,8 @@ async (fallbackTitle) => {
       return pool.every((el) => {
         try {
           const maxY = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
-          return maxY <= 0 || (el.scrollTop || 0) >= maxY - 2;
+          const tolerance = Math.max(8, Math.min(160, Math.floor((el.clientHeight || 0) * 0.1)));
+          return maxY <= 0 || (el.scrollTop || 0) >= maxY - tolerance;
         } catch (_) { return true; }
       });
     };

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1019,17 +1019,19 @@ async (fallbackTitle) => {
   async function settleImageSources(rendered, sourceList = [], sourceNodes = new Map()) {
     const replacements = new Map();
     const sources = new Set(sourceList);
-    for (const [img, observed] of sourceNodes.entries()) {
+    const settled = await Promise.all([...sourceNodes.entries()].map(async ([img, observed]) => {
       await waitForImage(img);
       const current = imageSource(img);
-      if (!current) continue;
+      if (!current) return null;
       observed.add(current);
       const resolved = await resolveImageSource(current);
-      sources.add(resolved || current);
-      for (const previous of observed) {
-        if (previous && previous !== (resolved || current)) {
-          replacements.set(previous, resolved || current);
-        }
+      return { observed, source: resolved || current };
+    }));
+    for (const item of settled) {
+      if (!item) continue;
+      sources.add(item.source);
+      for (const previous of item.observed) {
+        if (previous && previous !== item.source) replacements.set(previous, item.source);
       }
     }
     for (let index = 0; index < rendered.length; index++) {

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -981,24 +981,6 @@ async (fallbackTitle) => {
     return candidates.map(value => String(value || "").trim()).find(Boolean) || "";
   }
 
-  async function resolveImageSource(source) {
-    if (!/^blob:/i.test(String(source || ""))) return source;
-    if (typeof fetch !== "function" || typeof FileReader !== "function") return source;
-    try {
-      const response = await fetch(source);
-      if (!response.ok) return source;
-      const blob = await response.blob();
-      return await new Promise((resolve) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(String(reader.result || source));
-        reader.onerror = () => resolve(source);
-        reader.readAsDataURL(blob);
-      });
-    } catch (_) {
-      return source;
-    }
-  }
-
   async function waitForImage(img, timeout = 1800) {
     if (!img || img.complete || typeof img.addEventListener !== "function") return;
     await new Promise((resolve) => {
@@ -1024,8 +1006,7 @@ async (fallbackTitle) => {
       const current = imageSource(img);
       if (!current) return null;
       observed.add(current);
-      const resolved = await resolveImageSource(current);
-      return { observed, source: resolved || current };
+      return { observed, source: current };
     }));
     for (const item of settled) {
       if (!item) continue;
@@ -1272,7 +1253,7 @@ async (fallbackTitle) => {
     };
   }
 
-  const api = { resolveFeishuDocScroller, collectFeishuDocBlocks, resolveImageSource };
+  const api = { resolveFeishuDocScroller, collectFeishuDocBlocks };
   if (typeof globalThis !== "undefined") globalThis.__feishuConverterScrollApi = api;
   /* feishu-scroll-api:end */
 
@@ -1665,6 +1646,24 @@ def cookie_header_for_url(cookies: list[dict[str, Any]], url: str) -> str:
     return "; ".join(pairs)
 
 
+BLOB_IMAGE_DATA_URL_JS = r"""
+async (url) => {
+  if (typeof fetch !== "function" || typeof FileReader !== "function") {
+    throw new Error("浏览器不支持读取 Blob 图片");
+  }
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Blob 图片读取失败：HTTP ${response.status}`);
+  const blob = await response.blob();
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => reject(new Error("Blob 图片读取失败"));
+    reader.readAsDataURL(blob);
+  });
+}
+"""
+
+
 def download_image(url: str, dest_dir: Path, cookies: list[dict[str, Any]], timeout: int) -> Path:
     if url.lower().startswith("data:"):
         data, content_type = decode_data_url(url)
@@ -1685,6 +1684,13 @@ def download_image(url: str, dest_dir: Path, cookies: list[dict[str, Any]], time
     return target
 
 
+def download_blob_image(cdp: CDPClient, url: str, dest_dir: Path, timeout: int) -> Path:
+    data_url = cdp.evaluate(f"({BLOB_IMAGE_DATA_URL_JS})({js_string(url)})", timeout=timeout)
+    if not isinstance(data_url, str) or not data_url.lower().startswith("data:"):
+        raise ExportError("浏览器 Blob 图片未返回有效图片数据")
+    return download_image(data_url, dest_dir, [], timeout)
+
+
 def localize_images(
     cdp: CDPClient,
     markdown: str,
@@ -1701,11 +1707,12 @@ def localize_images(
     for url in sorted(set(images)):
         check_stopped(args)
         try:
-            if not url.lower().startswith(("http://", "https://", "data:")):
-                if url.lower().startswith("blob:"):
-                    raise ExportError("浏览器 Blob 图片未能转换为可下载的图片数据")
+            if url.lower().startswith("blob:"):
+                target = download_blob_image(cdp, url, md_path.parent / "assets", timeout)
+            elif url.lower().startswith(("http://", "https://", "data:")):
+                target = download_image(url, md_path.parent / "assets", cookies, timeout)
+            else:
                 continue
-            target = download_image(url, md_path.parent / "assets", cookies, timeout)
             markdown = markdown.replace(url, os.path.relpath(target, md_path.parent).replace("\\", "/"))
             success += 1
         except Exception as exc:

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_feishu_session_and_markdown.py
+++ b/tests/test_feishu_session_and_markdown.py
@@ -665,6 +665,29 @@ class FakeCheckpoint:
         self.closed = True
 
 
+class FeishuImageLocalizationTests(unittest.TestCase):
+    def test_localize_images_saves_browser_data_url(self) -> None:
+        data_url = "data:image/png;base64,aW1hZ2U="
+        cdp = FakeSessionCdp()
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "document.md"
+            markdown, success, failures = feishu.localize_images(
+                cdp,
+                f"![image]({data_url})",
+                [data_url],
+                md_path,
+                timeout=5,
+                keep_remote=True,
+            )
+
+            self.assertEqual(success, 1)
+            self.assertEqual(failures, [])
+            self.assertNotIn(data_url, markdown)
+            image_files = list((md_path.parent / "assets").glob("*.png"))
+            self.assertEqual(len(image_files), 1)
+            self.assertEqual(image_files[0].read_bytes(), b"image")
+
+
 class FeishuRelativeResourceReportingTests(unittest.TestCase):
     def test_relative_markdown_resources_make_report_partial_and_checkpoint_failed(self) -> None:
         node = {

--- a/tests/test_feishu_session_and_markdown.py
+++ b/tests/test_feishu_session_and_markdown.py
@@ -687,6 +687,30 @@ class FeishuImageLocalizationTests(unittest.TestCase):
             self.assertEqual(len(image_files), 1)
             self.assertEqual(image_files[0].read_bytes(), b"image")
 
+    def test_localize_images_reads_browser_blob_through_cdp(self) -> None:
+        blob_url = "blob:https://example.feishu.cn/image-1"
+        data_url = "data:image/png;base64,aW1hZ2U="
+
+        class FakeBlobCdp(FakeSessionCdp):
+            def evaluate(self, _expression: str, timeout: int | float = 30) -> str:
+                return data_url
+
+        with tempfile.TemporaryDirectory() as directory:
+            md_path = Path(directory) / "document.md"
+            markdown, success, failures = feishu.localize_images(
+                FakeBlobCdp(),
+                f"![image]({blob_url})",
+                [blob_url],
+                md_path,
+                timeout=5,
+                keep_remote=True,
+            )
+
+            self.assertEqual(success, 1)
+            self.assertEqual(failures, [])
+            self.assertNotIn(blob_url, markdown)
+            self.assertEqual(len(list((md_path.parent / "assets").glob("*.png"))), 1)
+
 
 class FeishuRelativeResourceReportingTests(unittest.TestCase):
     def test_relative_markdown_resources_make_report_partial_and_checkpoint_failed(self) -> None:

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -359,3 +359,31 @@ test('collectFeishuDocBlocks stops cleanly at bottom without false incomplete', 
   assert.equal(result.hitIterationCeiling, false);
   assert.ok(result.scrollIterations < 40, `should stop near bottom, got ${result.scrollIterations}`);
 });
+
+test('resolveImageSource converts browser blob images to data URLs', async () => {
+  const api = loadScrollApi();
+  const originalFetch = global.fetch;
+  const originalFileReader = global.FileReader;
+  global.fetch = async () => ({
+    ok: true,
+    blob: async () => new Blob(['image'], { type: 'image/png' }),
+  });
+  global.FileReader = class {
+    readAsDataURL(blob) {
+      blob.arrayBuffer().then((buffer) => {
+        this.result = `data:image/png;base64,${Buffer.from(buffer).toString('base64')}`;
+        this.onload();
+      });
+    }
+  };
+  try {
+    assert.equal(
+      await api.resolveImageSource('blob:https://my.feishu.cn/image-1'),
+      'data:image/png;base64,aW1hZ2U=',
+    );
+  } finally {
+    global.fetch = originalFetch;
+    if (originalFileReader === undefined) delete global.FileReader;
+    else global.FileReader = originalFileReader;
+  }
+});

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -262,6 +262,30 @@ test('resolveFeishuDocScroller skips scrollbar chrome that cannot scroll', () =>
   assert.equal(resolved, scroller);
 });
 
+test('resolveFeishuDocScroller accepts a scrollbar container that owns document blocks', () => {
+  const api = loadScrollApi();
+  const { document } = parseHTML(`<!doctype html><html><body>
+    <div class="scrollbar-container etherpad-container-wrapper clearfix" data-overflow-y="auto">
+      <div class="root-render-unit-container">
+        <div class="render-unit-wrapper">
+          <div data-block-type="paragraph" data-block-id="a">hello</div>
+        </div>
+      </div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.scrollbar-container');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => 900 });
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => { scrollTop = value; },
+  });
+  const resolved = api.resolveFeishuDocScroller(document.querySelector('.root-render-unit-container'), document);
+  assert.equal(resolved, scroller);
+});
+
 test('collectFeishuDocBlocks mounts blocks via scrollIntoView nudging', async () => {
   const api = loadScrollApi();
   const { document, window } = parseHTML(`<!doctype html><html><body>
@@ -358,32 +382,4 @@ test('collectFeishuDocBlocks stops cleanly at bottom without false incomplete', 
   assert.equal(result.reachedBottom, true);
   assert.equal(result.hitIterationCeiling, false);
   assert.ok(result.scrollIterations < 40, `should stop near bottom, got ${result.scrollIterations}`);
-});
-
-test('resolveImageSource converts browser blob images to data URLs', async () => {
-  const api = loadScrollApi();
-  const originalFetch = global.fetch;
-  const originalFileReader = global.FileReader;
-  global.fetch = async () => ({
-    ok: true,
-    blob: async () => new Blob(['image'], { type: 'image/png' }),
-  });
-  global.FileReader = class {
-    readAsDataURL(blob) {
-      blob.arrayBuffer().then((buffer) => {
-        this.result = `data:image/png;base64,${Buffer.from(buffer).toString('base64')}`;
-        this.onload();
-      });
-    }
-  };
-  try {
-    assert.equal(
-      await api.resolveImageSource('blob:https://my.feishu.cn/image-1'),
-      'data:image/png;base64,aW1hZ2U=',
-    );
-  } finally {
-    global.fetch = originalFetch;
-    if (originalFileReader === undefined) delete global.FileReader;
-    else global.FileReader = originalFileReader;
-  }
 });

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -124,7 +124,7 @@ test('Feishu import tutorial pins all screenshots remotely and excludes them fro
   assert.equal(assets.reduce((total, name) => total + fs.statSync(path.join(remoteAssetRoot, name)).size, 0), 17317358);
   assert.deepEqual(new Set(Object.keys(provider.guideAssets)), new Set(imageReferences.map((match) => match[1])));
   assert.equal(Object.values(provider.guideAssets).every((asset) => asset.mime === 'image/png' && asset.bytes <= 3 * 1024 * 1024 && /^[a-f0-9]{64}$/.test(asset.sha256)), true);
-  assert.equal(plugin.version, '1.0.9');
+  assert.equal(plugin.version, '1.0.10');
 });
 
 test('guide hydration limits remote IPC concurrency and renders an offline fallback', () => {


### PR DESCRIPTION
## 修复内容

针对 Issue #129 后续反馈：

- 等待懒加载图片完成后再处理，减少图片尚未加载就被下载为占位图的问题。
- 优先读取飞书图片的 `data-src`、`data-original` 等真实来源。
- 将浏览器中的 `blob:` 图片转为可保存的数据 URL，并写入导出目录的 `assets`。
- 修复图片来源变化但字符串长度相同而没有更新的问题。
- 无法转换的 Blob 图片不再静默跳过，会进入图片失败报告。
- 飞书插件版本升级到 1.0.10。

## 验证

- 飞书滚动/图片 JS 测试：18/18
- 飞书 Python 测试：21/21
- 插件清单校验通过

Fixes #129