### PR TITLE
fix(ima): preserve folder imports and batch selection

### DIFF
--- a/plugins/ima/backend/ima_knowledge.py
+++ b/plugins/ima/backend/ima_knowledge.py
@@ -1160,7 +1160,10 @@ def collect_markdown_referenced_files(source_dir: Path) -> set[Path]:
             raw = next((group for group in match.groups() if group), "")
             for candidate in markdown_reference_candidates(raw):
                 resolved = resolve_local_reference(source_dir, md_path, candidate)
-                if resolved:
+                # Markdown pages linked by an index are separate import targets, not
+                # embedded resources. Keeping them out of this exclusion list avoids
+                # dropping an entire exported knowledge-base tree.
+                if resolved and resolved.suffix.lower() not in {".md", ".markdown"}:
                     referenced.add(resolved)
                     break
     return referenced
@@ -1219,6 +1222,129 @@ def is_repeated(client: ImaClient, kb_id: str, folder_id: str, name: str, media_
         if str(item.get("name") or "") == name:
             return bool(item.get("is_repeated"))
     return False
+
+
+def list_remote_folder_items(client: ImaClient, kb_id: str, folder_id: str) -> list[dict[str, Any]]:
+    """List every direct item below one remote folder without recursing."""
+
+    cursor = ""
+    items: list[dict[str, Any]] = []
+    while True:
+        payload: dict[str, Any] = {"knowledge_base_id": kb_id, "cursor": cursor, "limit": 50}
+        if folder_id:
+            payload["folder_id"] = folder_id
+        data = client.wiki("get_knowledge_list", payload)
+        items.extend(response_list(data, "knowledge_list", "info_list", "list"))
+        if data.get("is_end", True):
+            break
+        next_cursor = str(data.get("next_cursor") or "")
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+    return items
+
+
+def remote_child_folders(
+    client: ImaClient,
+    kb_id: str,
+    folder_id: str,
+    cache: dict[str, dict[str, str | None]],
+) -> dict[str, str | None]:
+    """Return direct folders by title; ``None`` marks an ambiguous duplicate."""
+
+    cache_key = folder_id or ""
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    children: dict[str, str | None] = {}
+    for item in list_remote_folder_items(client, kb_id, folder_id):
+        if not is_folder_item(item):
+            continue
+        title = item_title(item)
+        child_id = item_id(item)
+        if not child_id:
+            continue
+        if title in children and children[title] != child_id:
+            children[title] = None
+        else:
+            children[title] = child_id
+    cache[cache_key] = children
+    return children
+
+
+def ensure_remote_folder(
+    client: ImaClient,
+    args: argparse.Namespace,
+    *,
+    parent_folder_id: str,
+    title: str,
+    cache: dict[str, dict[str, str | None]],
+) -> str:
+    """Find or create one folder below ``parent_folder_id`` and return its ID."""
+
+    if not title or title in {".", ".."}:
+        raise ImaError("本地目录名称无效，无法创建 ima 文件夹")
+
+    children = remote_child_folders(client, args.knowledge_base_id, parent_folder_id, cache)
+    if title in children:
+        existing = children[title]
+        if existing:
+            return existing
+        raise ImaError(f"目标目录存在多个同名文件夹，无法安全导入：{title}")
+
+    payload: dict[str, Any] = {"knowledge_base_id": args.knowledge_base_id, "name": title}
+    if parent_folder_id:
+        payload["folder_id"] = parent_folder_id
+    client.wiki("create_folder", payload)
+    emit(
+        f"已创建 ima 文件夹：{title}",
+        event="folder.created",
+        folder={"title": title, "parentFolderId": parent_folder_id},
+    )
+
+    # The current API does not consistently return the created folder ID. Refresh
+    # the direct listing instead of issuing a second create request on a slow read.
+    cache.pop(parent_folder_id or "", None)
+    for attempt in range(3):
+        children = remote_child_folders(client, args.knowledge_base_id, parent_folder_id, cache)
+        created = children.get(title)
+        if created:
+            return created
+        if title in children:
+            raise ImaError(f"新建的 ima 文件夹名称重复，无法安全定位：{title}")
+        if attempt < 2:
+            wait_with_stop(args, 0.25)
+            cache.pop(parent_folder_id or "", None)
+    raise ImaError(f"ima 已接受创建文件夹请求，但未读取到目录：{title}")
+
+
+def import_target_folder(
+    client: ImaClient,
+    args: argparse.Namespace,
+    path: Path,
+    source_dir: Path,
+    cache: dict[str, dict[str, str | None]],
+) -> str:
+    """Resolve the destination folder for one local file, preserving its parents."""
+
+    target_folder_id = args.folder_id or ""
+    if not getattr(args, "preserve_folders", True):
+        return target_folder_id
+    try:
+        relative_parent = path.relative_to(source_dir).parent
+    except ValueError:
+        return target_folder_id
+    for part in relative_parent.parts:
+        if part and part != ".":
+            target_folder_id = ensure_remote_folder(
+                client,
+                args,
+                parent_folder_id=target_folder_id,
+                title=part,
+                cache=cache,
+            )
+    return target_folder_id
 
 
 def hmac_sha1(key: bytes | str, data: str) -> str:
@@ -1314,12 +1440,14 @@ def upload_markdown_note(
     path: Path,
     source_root: Path,
     resource_failures: list[dict[str, str]],
+    folder_id: str | None = None,
 ) -> str:
     kb_id = args.knowledge_base_id
     if not kb_id:
         raise ImaError("导入需要填写目标知识库 ID")
+    target_folder_id = args.folder_id or "" if folder_id is None else folder_id
     file_name = path.name
-    if args.skip_existing and is_repeated(client, kb_id, args.folder_id or "", file_name, 11):
+    if args.skip_existing and is_repeated(client, kb_id, target_folder_id, file_name, 11):
         return "skipped_existing"
     try:
         content = path.read_text("utf-8-sig")
@@ -1343,8 +1471,8 @@ def upload_markdown_note(
         "knowledge_base_id": kb_id,
         "note_info": {"content_id": note_id},
     }
-    if args.folder_id:
-        add_payload["folder_id"] = args.folder_id
+    if target_folder_id:
+        add_payload["folder_id"] = target_folder_id
     client.wiki("add_knowledge", add_payload)
     emit(
         f"Markdown 笔记已导入：{file_name}（内嵌图片 {embedded} 张）",
@@ -1354,14 +1482,14 @@ def upload_markdown_note(
     return note_id
 
 
-def upload_file(client: ImaClient, args: argparse.Namespace, path: Path) -> str:
+def upload_file(client: ImaClient, args: argparse.Namespace, path: Path, folder_id: str | None = None) -> str:
     kb_id = args.knowledge_base_id
     if not kb_id:
         raise ImaError("导入需要填写目标知识库 ID")
-    folder_id = args.folder_id or ""
+    target_folder_id = args.folder_id or "" if folder_id is None else folder_id
     media_type, content_type = file_media_info(path)
     file_name = path.name
-    if args.skip_existing and is_repeated(client, kb_id, folder_id, file_name, media_type):
+    if args.skip_existing and is_repeated(client, kb_id, target_folder_id, file_name, media_type):
         return "skipped_existing"
 
     create_payload = {
@@ -1391,8 +1519,8 @@ def upload_file(client: ImaClient, args: argparse.Namespace, path: Path) -> str:
             "file_name": file_name,
         },
     }
-    if folder_id:
-        add_payload["folder_id"] = folder_id
+    if target_folder_id:
+        add_payload["folder_id"] = target_folder_id
     client.wiki("add_knowledge", add_payload)
     return media_id
 
@@ -1402,7 +1530,7 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
     if not args.knowledge_base_id:
         raise ImaError("请先填写目标知识库 ID")
     files = [Path(item["path"]) for item in scan_source_files(source_dir, include_referenced_assets=args.include_referenced_assets)]
-    if args.source_file:
+    if args.import_one and args.source_file:
         source_file = Path(args.source_file).resolve()
         files = [source_file]
     if args.import_one and files:
@@ -1418,6 +1546,7 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
     skipped = 0
     failures: list[dict[str, str]] = []
     resource_failures: list[dict[str, str]] = []
+    folder_cache: dict[str, dict[str, str | None]] = {}
     started = time.time()
     total = len(files)
     emit(
@@ -1437,10 +1566,11 @@ def import_files(client: ImaClient, args: argparse.Namespace) -> dict[str, Any]:
                 doc={"path": relative_path, "index": index},
             )
             file_resources: list[dict[str, str]] = []
+            target_folder_id = import_target_folder(client, args, path, source_dir, folder_cache)
             if path.suffix.lower() in {".md", ".markdown"}:
-                result = upload_markdown_note(client, args, path, source_dir, file_resources)
+                result = upload_markdown_note(client, args, path, source_dir, file_resources, target_folder_id)
             else:
-                result = upload_file(client, args, path)
+                result = upload_file(client, args, path, target_folder_id)
             for item in file_resources:
                 resource_failures.append({"relativePath": relative_path, **item})
             if result == "skipped_existing":
@@ -1545,6 +1675,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         dest="include_referenced_assets",
         action="store_false",
         help="不单独上传 Markdown 引用的本地图片/附件",
+    )
+    parser.add_argument(
+        "--preserve-folders",
+        dest="preserve_folders",
+        action="store_true",
+        default=True,
+        help="保留本地目录层级，自动创建目标知识库中缺失的文件夹（默认开启）",
+    )
+    parser.add_argument(
+        "--flatten-folders",
+        dest="preserve_folders",
+        action="store_false",
+        help="将所有文件直接导入所选目标文件夹",
     )
     parser.add_argument("--import-one", action="store_true", help="导入第一篇或 source-file")
     parser.add_argument("--import-all", action="store_true", help="批量导入")

--- a/plugins/ima/plugin.json
+++ b/plugins/ima/plugin.json
@@ -4,7 +4,7 @@
   "id": "ima",
   "name": "ima 知识库",
   "description": "ima 知识库 OpenAPI 导出与本地文件批量导入。",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "Wandao Official",
   "homepage": "https://ima.qq.com/",
   "license": "AGPL-3.0-only",

--- a/plugins/ima/providers/ima-import/provider.json
+++ b/plugins/ima/providers/ima-import/provider.json
@@ -5,7 +5,7 @@
   "name": "ima 知识库",
   "title": "ima 知识库导入",
   "navLabel": "ima 导入",
-  "description": "扫描本地文件并批量上传到 ima 知识库根目录或已有文件夹。",
+  "description": "扫描本地文件，默认保留文件夹层级并批量上传到 ima 知识库。",
   "type": "automation",
   "group": "import",
   "trustLevel": "official",
@@ -18,6 +18,7 @@
     { "name": "knowledge_base_id", "label": "目标知识库 ID", "type": "text", "arg": "--knowledge-base-id", "required": true, "actions": ["plan", "importOne", "import"] },
     { "name": "folder_id", "label": "目标文件夹 ID（可选）", "type": "text", "arg": "--folder-id", "advanced": true, "actions": ["importOne", "import"] },
     { "name": "source_dir", "label": "本地待导入目录", "type": "directory", "arg": "--source-dir", "required": true, "history": "path", "actions": ["plan", "importOne", "import"] },
+    { "name": "flatten_folders", "label": "平铺导入（不保留本地文件夹层级）", "type": "checkbox", "arg": "--flatten-folders", "default": false, "advanced": true, "actions": ["importOne", "import"] },
     { "name": "include_referenced_assets", "label": "额外上传 Markdown 引用资源（默认图片已内嵌）", "type": "checkbox", "arg": "--include-referenced-assets", "default": false, "advanced": true, "actions": ["importOne", "import"] },
     { "name": "max_import", "label": "最多导入数量（0 为全部）", "type": "number", "arg": "--max-import", "default": 0, "min": 0, "advanced": true, "actions": ["import"] }
   ],

--- a/tests/test_ima_import_folders.py
+++ b/tests/test_ima_import_folders.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from plugins.ima.backend import ima_knowledge as module
+
+
+class FakeImaFolderImportClient:
+    def __init__(self) -> None:
+        self.children: dict[str, list[dict[str, object]]] = {"": []}
+        self.created_folders: list[dict[str, object]] = []
+        self.add_payloads: list[dict[str, object]] = []
+        self.note_payloads: list[dict[str, object]] = []
+
+    def add_existing_folder(self, parent_id: str, title: str, folder_id: str) -> None:
+        self.children.setdefault(parent_id, []).append(
+            {"media_id": folder_id, "media_type": 0, "title": title, "parent_folder_id": parent_id}
+        )
+        self.children.setdefault(folder_id, [])
+
+    def wiki(self, action: str, payload: dict[str, object]) -> dict[str, object]:
+        if action == "get_knowledge_list":
+            folder_id = str(payload.get("folder_id") or "")
+            return {"knowledge_list": list(self.children.get(folder_id, [])), "is_end": True}
+        if action == "create_folder":
+            parent_id = str(payload.get("folder_id") or "")
+            folder_id = f"folder_{len(self.created_folders) + 1}"
+            folder = {"media_id": folder_id, "media_type": 0, "title": payload["name"], "parent_folder_id": parent_id}
+            self.children.setdefault(parent_id, []).append(folder)
+            self.children.setdefault(folder_id, [])
+            self.created_folders.append(dict(payload))
+            return {}
+        if action == "check_repeated_names":
+            return {"results": [{"name": payload["params"][0]["name"], "is_repeated": False}]}
+        if action == "add_knowledge":
+            self.add_payloads.append(dict(payload))
+            return {}
+        raise AssertionError(action)
+
+    def note(self, action: str, payload: dict[str, object]) -> dict[str, object]:
+        if action == "import_doc":
+            self.note_payloads.append(dict(payload))
+            return {"note_id": f"note_{len(self.note_payloads)}"}
+        raise AssertionError(action)
+
+
+class ImaImportFolderTests(unittest.TestCase):
+    def test_scan_keeps_linked_markdown_pages_but_skips_referenced_image_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            article_dir = root / "章节"
+            assets_dir = article_dir / "assets"
+            assets_dir.mkdir(parents=True)
+            (root / "00-入口.md").write_text("[章节](章节/正文.md)\n", encoding="utf-8")
+            (article_dir / "正文.md").write_text("![图](assets/picture.png)\n", encoding="utf-8")
+            (assets_dir / "picture.png").write_bytes(b"png")
+
+            scanned = module.scan_source_files(root)
+
+            self.assertEqual([item["relativePath"] for item in scanned], ["00-入口.md", "章节/正文.md"])
+
+    def test_import_creates_nested_folders_and_reuses_existing_target_child(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary, patch.object(module, "emit"):
+            root = Path(temporary)
+            (root / "00-入口.md").write_text("[正文](A/正文.md)\n", encoding="utf-8")
+            (root / "A" / "深层").mkdir(parents=True)
+            (root / "B").mkdir()
+            (root / "A" / "正文.md").write_text("# A\n", encoding="utf-8")
+            (root / "A" / "深层" / "二级.md").write_text("# Deep\n", encoding="utf-8")
+            (root / "B" / "B.md").write_text("# B\n", encoding="utf-8")
+            client = FakeImaFolderImportClient()
+            client.add_existing_folder("", "A", "folder_existing_a")
+            args = module.parse_args(
+                [
+                    "--knowledge-base-id", "kb-test", "--source-dir", str(root), "--import-all", "--yes", "--progress-every", "0"
+                ]
+            )
+
+            report = module.import_files(client, args)
+
+            self.assertEqual(report["importedFiles"], 4)
+            self.assertEqual(report["failureCount"], 0)
+            self.assertEqual(
+                client.created_folders,
+                [
+                    {"knowledge_base_id": "kb-test", "folder_id": "folder_existing_a", "name": "深层"},
+                    {"knowledge_base_id": "kb-test", "name": "B"},
+                ],
+            )
+            target_by_title = {str(payload["title"]): str(payload.get("folder_id") or "") for payload in client.add_payloads}
+            self.assertEqual(target_by_title["00-入口.md"], "")
+            self.assertEqual(target_by_title["正文.md"], "folder_existing_a")
+            self.assertEqual(target_by_title["二级.md"], "folder_1")
+            self.assertEqual(target_by_title["B.md"], "folder_2")
+
+    def test_batch_import_ignores_single_file_test_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary, patch.object(module, "emit"):
+            root = Path(temporary)
+            first = root / "first.md"
+            selected = root / "selected.md"
+            first.write_text("# first\n", encoding="utf-8")
+            selected.write_text("# selected\n", encoding="utf-8")
+            client = FakeImaFolderImportClient()
+            args = module.parse_args(
+                [
+                    "--knowledge-base-id", "kb-test", "--source-dir", str(root), "--source-file", str(selected),
+                    "--import-all", "--yes", "--progress-every", "0"
+                ]
+            )
+
+            report = module.import_files(client, args)
+
+            self.assertEqual(report["importedFiles"], 2)
+            self.assertEqual({str(payload["title"]) for payload in client.add_payloads}, {"first.md", "selected.md"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_js/import_write_guidance.test.js
+++ b/tests_js/import_write_guidance.test.js
@@ -61,3 +61,14 @@ test('IMA blocks target-knowledge-base actions until a usable selection exists a
   assert.match(qualityCheckSource, /NODE_TEST_DIR\s*=\s*"tests_js"/);
   assert.match(qualityCheckSource, /glob\("\*\.test\.js"\)/);
 });
+
+test('IMA batch import preserves folders and never reuses the optional single-file test path', () => {
+  const builder = sourceBetween('function buildImaImportArgs', 'async function runImaImportCommand');
+
+  assert.match(builder, /if \(sourceFile && options\.single\) args\.push\('--source-file', sourceFile\);/);
+  assert.doesNotMatch(builder, /if \(sourceFile\) args\.push\('--source-file', sourceFile\);/);
+  assert.match(builder, /document\.getElementById\('ima-import-preserve-folders'\)/);
+  assert.match(builder, /args\.push\('--flatten-folders'\);/);
+  assert.match(htmlSource, /id="ima-import-preserve-folders" checked/);
+  assert.match(htmlSource, /自动创建 ima 子文件夹/);
+});

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -4964,7 +4964,7 @@ function buildImaImportArgs(options = {}) {
 
   if (!sourceDir) throw new Error('请选择本地文件目录');
   args.push('--source-dir', sourceDir);
-  if (sourceFile) args.push('--source-file', sourceFile);
+  if (sourceFile && options.single) args.push('--source-file', sourceFile);
   if (kbId) args.push('--knowledge-base-id', kbId);
   if (folderId) args.push('--folder-id', folderId);
   if (delay) args.push('--request-delay', delay);
@@ -4972,6 +4972,8 @@ function buildImaImportArgs(options = {}) {
   if (maxImport && parseInt(maxImport, 10) > 0) args.push('--max-import', maxImport);
   const includeAssets = document.getElementById('ima-import-include-assets');
   if (includeAssets && includeAssets.checked) args.push('--include-referenced-assets');
+  const preserveFolders = document.getElementById('ima-import-preserve-folders');
+  if (preserveFolders && !preserveFolders.checked) args.push('--flatten-folders');
   args.push('--progress-every', '1');
 
   if (options.plan) {

--- a/wandao_electron/renderer/index.html
+++ b/wandao_electron/renderer/index.html
@@ -733,12 +733,16 @@
               <span>目标已有同名文件时跳过</span>
             </label>
             <label class="checkbox-label">
+              <input type="checkbox" id="ima-import-preserve-folders" checked>
+              <span>保留本地文件夹层级（自动创建 ima 子文件夹）</span>
+            </label>
+            <label class="checkbox-label">
               <input type="checkbox" id="ima-import-include-assets">
               <span>将 Markdown 引用的本地图片/附件也作为独立文件上传</span>
             </label>
           </div>
         </details>
-        <p class="helper-note">第一版使用 ima 知识库 OpenAPI 上传文件，支持 Markdown、PDF、Word、PPT、Excel、图片、TXT、Xmind、音频等文件。默认不会把 Markdown 引用的本地配图重复作为独立图片导入。官方 API 暂未提供明确的创建知识库文件夹接口，所以目前可导入到根目录或已有文件夹。</p>
+        <p class="helper-note">使用 ima 知识库 OpenAPI 上传文件，支持 Markdown、PDF、Word、PPT、Excel、图片、TXT、Xmind、音频等文件。默认保留本地文件夹层级，Markdown 引用的本地配图会内嵌而不会重复作为独立图片导入。</p>
       </section>
       <section class="action-section">
         <button class="btn-secondary" id="ima-import-save-config">保存 API 配置</button>


### PR DESCRIPTION
## 修复\n\n- 保留本地文件夹层级，自动创建并复用 ima 子文件夹。\n- Markdown 索引中的 .md 链接不再被误判为资源，批量导入会包含完整文档树。\n- 批量导入忽略残留的单文件测试路径。\n- Markdown 图片仍以内嵌方式上传，导出时还原为本地资源。\n\n## 验证\n\n- 真实 ima 导入：10 篇 Markdown、2 张本地 PNG，批量模式同时携带单文件参数。\n- 真实 ima 导出：得到 10 个非空 Markdown、2 张 PNG；图片 SHA-256 与源文件一致。\n- 目录结构真实创建并可回读。\n- 本地质量门禁：714 Python tests、222 Node tests、插件清单校验、编译与 diff 检查通过。\n\nFixes #134\nFixes #140