### PR TITLE
fix(wiz): 修复资源告警重复重试

### DIFF
--- a/plugins/wiz/backend/export_wiz.py
+++ b/plugins/wiz/backend/export_wiz.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import html
 import json
 import mimetypes
@@ -30,6 +31,7 @@ from wandao_core.browser import (
     CDPClient,
     ExportError,
     ExportStopped,
+    check_stopped,
     chrome_debug_available,
     default_data_dir,
     emit,
@@ -51,6 +53,15 @@ DEFAULT_PROFILE = ".wiz-chrome-profile"
 DEFAULT_AUTH_FILE = ".wiz_auth.json"
 WIZ_APP_URL = "https://www.wiz.cn/xapp"
 FORBIDDEN_FILENAME_CHARS = r'<>:"/\|?*'
+WIZ_NOTE_DOWNLOAD_TIMEOUT = 12.0
+WIZ_EMPTY_BODY_RETRY_TIMEOUT = 4.0
+WIZ_EMPTY_BODY_RETRY_DELAY = 0.4
+WIZ_OT_DOCUMENT_TIMEOUT = 6.0
+WIZ_PAGE_HEALTH_TIMEOUT = 2.0
+WIZ_PAGE_RECOVERY_LOGIN_TIMEOUT = 20
+WIZ_IMAGE_TOTAL_TIMEOUT = 12.0
+WIZ_IMAGE_PRIMARY_TIMEOUT = 8.0
+WIZ_EXTERNAL_IMAGE_TIMEOUT = 8.0
 
 
 @dataclass
@@ -74,6 +85,14 @@ class WizFolder:
     parent_location: str
     position: int
     note_count: int
+
+
+class WizPageSessionLost(ExportError):
+    """The Wiz tab is reachable through CDP but its readonly jobs no longer finish."""
+
+
+class WizPageSessionUnrecoverable(ExportError):
+    """A fresh readonly Wiz tab could not restore the current export."""
 
 
 def default_profile_path() -> Path:
@@ -102,6 +121,20 @@ def markdown_link_path(value: str) -> str:
     return value.replace("\\", "/").replace(" ", "%20")
 
 
+def safe_resource_url(value: str) -> str:
+    """Keep credentials and tracking parameters out of checkpoint records."""
+    parsed = urllib.parse.urlsplit(str(value or ""))
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def wiz_resource_key(doc: WizDoc, resource_type: str, source: str) -> str:
+    source = str(source or "").strip()
+    if not source:
+        return ""
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:20]
+    return f"wiz:doc:{doc.doc_guid}:{resource_type}:{digest}"
+
+
 def js_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
@@ -115,14 +148,39 @@ def page_for_wiz(port: int) -> dict[str, Any] | None:
     return None
 
 
-def connect_wiz_browser(args: argparse.Namespace, initial_url: str = WIZ_APP_URL) -> tuple[CDPClient, subprocess.Popen[Any] | None]:
+def open_fresh_wiz_page(port: int, initial_url: str) -> dict[str, Any]:
+    """Open a new Wiz target instead of reconnecting to a stalled renderer."""
+    existing_ids = {
+        str(page.get("id") or "")
+        for page in http_json(f"http://127.0.0.1:{port}/json/list", timeout=5)
+    }
+    open_tab(port, initial_url)
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        for page in http_json(f"http://127.0.0.1:{port}/json/list", timeout=5):
+            if (
+                page.get("type") == "page"
+                and "wiz.cn" in str(page.get("url") or "")
+                and str(page.get("id") or "") not in existing_ids
+            ):
+                return page
+        time.sleep(0.2)
+    raise ExportError("无法创建新的为知笔记网页标签页。")
+
+
+def connect_wiz_browser(
+    args: argparse.Namespace,
+    initial_url: str = WIZ_APP_URL,
+    *,
+    force_new_page: bool = False,
+) -> tuple[CDPClient, subprocess.Popen[Any] | None]:
     chrome_proc: subprocess.Popen[Any] | None = None
     if not chrome_debug_available(args.port):
         profile = Path(args.profile_dir).resolve() if args.profile_dir else default_profile_path()
         chrome_proc = start_chrome(args.port, profile, initial_url, getattr(args, "browser_path", None))
         wait_for_debug_port(args.port, timeout=30)
 
-    page = page_for_wiz(args.port)
+    page = open_fresh_wiz_page(args.port, initial_url) if force_new_page and chrome_proc is None else page_for_wiz(args.port)
     if not page:
         open_tab(args.port, initial_url)
         time.sleep(2)
@@ -141,9 +199,39 @@ def connect_wiz_browser(args: argparse.Namespace, initial_url: str = WIZ_APP_URL
     return cdp, chrome_proc
 
 
+def ensure_same_wiz_account(expected: dict[str, Any], actual: dict[str, Any]) -> None:
+    """Never resume on a Wiz tab that selected a different account."""
+    expected_account = expected.get("account") or {}
+    actual_account = actual.get("account") or {}
+    for key in ("userGuid", "userId"):
+        expected_value = str(expected_account.get(key) or "").strip()
+        actual_value = str(actual_account.get(key) or "").strip()
+        if expected_value and expected_value != actual_value:
+            raise ExportError("为知浏览器恢复后的账号与任务开始时不一致，已停止任务。")
+
+
+def recover_wiz_page(
+    args: argparse.Namespace,
+    previous_cdp: CDPClient,
+    expected_snapshot: dict[str, Any],
+) -> tuple[CDPClient, dict[str, Any], subprocess.Popen[Any] | None]:
+    """Replace a stalled Wiz target with a fresh readonly target for the same account."""
+    previous_cdp.close()
+    cdp, chrome_proc = connect_wiz_browser(args, force_new_page=True)
+    try:
+        snapshot = wait_for_login_state(cdp, timeout=WIZ_PAGE_RECOVERY_LOGIN_TIMEOUT)
+        ensure_same_wiz_account(expected_snapshot, snapshot)
+    except Exception:
+        cdp.close()
+        if chrome_proc and getattr(args, "close_started_chrome", False):
+            chrome_proc.terminate()
+        raise
+    return cdp, snapshot, chrome_proc
+
+
 WIZ_HELPER_JS = r"""
 (() => {
-  if (window.__wandaoWiz && window.__wandaoWiz.version === 2) return true;
+  if (window.__wandaoWiz && window.__wandaoWiz.version === 5) return true;
 
   const reqToPromise = (req) => new Promise((resolve, reject) => {
     req.onsuccess = () => resolve(req.result);
@@ -247,6 +335,14 @@ WIZ_HELPER_JS = r"""
     return result;
   };
 
+  const health = async () => {
+    const account = await currentAccount();
+    const dbName = await userDbName(account);
+    if (!account || !dbName) throw new Error("为知本地会话不可用");
+    await getOne(dbName, "docs", "__wandao_health_probe__");
+    return { userGuid: account.userGuid || "", userId: account.userId || "" };
+  };
+
   const tokenHeaders = async () => {
     const account = await currentAccount();
     if (!account || !account.token) throw new Error("为知登录 token 不可用，请重新登录。");
@@ -260,12 +356,20 @@ WIZ_HELPER_JS = r"""
     const url = `${kbServer}/ks/note/download/${encodeURIComponent(kbGuid)}/${encodeURIComponent(docGuid)}?downloadInfo=1&downloadData=1`;
     const response = await fetch(url, { headers: { "x-wiz-token": account.token }, credentials: "include" });
     const text = await response.text();
+    const meta = {
+      httpStatus: response.status,
+      contentType: response.headers.get("content-type") || "",
+      bodyLength: text.length,
+    };
     let data = null;
     try { data = JSON.parse(text); } catch (_error) {}
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${text.slice(0, 200)}`);
+      throw new Error(`HTTP ${response.status} (${meta.contentType || "unknown"}, ${meta.bodyLength} bytes)`);
     }
-    return data || { html: text };
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return { ...data, __wandaoNoteMeta: meta };
+    }
+    return { html: text, __wandaoNoteMeta: meta };
   };
 
   const otDoc = async (kbGuid, docGuid) => {
@@ -292,24 +396,29 @@ WIZ_HELPER_JS = r"""
     };
   };
 
-  const fetchBase64 = async (url) => {
+  const fetchBase64 = async (url, timeoutMs = 8000) => {
     const headers = await tokenHeaders().catch(() => ({}));
-    let response = null;
-    let firstError = null;
-    try {
-      response = await fetch(url, { headers, credentials: "include" });
-    } catch (error) {
-      firstError = error;
-    }
-    if (!response || !response.ok) {
+    const deadline = Date.now() + Math.max(500, Number(timeoutMs) || 8000);
+    const fetchBody = async (requestHeaders) => {
+      const controller = new AbortController();
+      const remaining = Math.max(1, deadline - Date.now());
+      const timer = window.setTimeout(() => controller.abort(), remaining);
       try {
-        response = await fetch(url, { credentials: "include" });
-      } catch (error) {
-        throw firstError || error;
+        const response = await fetch(url, { headers: requestHeaders, credentials: "include", signal: controller.signal });
+        if (!response.ok) throw new Error(`HTTP ${response.status}: ${url}`);
+        return { response, buffer: await response.arrayBuffer() };
+      } finally {
+        window.clearTimeout(timer);
       }
+    };
+    let result;
+    let firstError = null;
+    try { result = await fetchBody(headers); } catch (error) { firstError = error; }
+    if (!result && Date.now() < deadline) {
+      try { result = await fetchBody({}); } catch (error) { throw firstError || error; }
     }
-    if (!response.ok) throw new Error(`HTTP ${response.status}: ${url}`);
-    const buffer = await response.arrayBuffer();
+    if (!result) throw firstError || new Error(`图片下载超时: ${url}`);
+    const { response, buffer } = result;
     const bytes = new Uint8Array(buffer);
     let binary = "";
     for (let index = 0; index < bytes.length; index += 1) {
@@ -322,37 +431,53 @@ WIZ_HELPER_JS = r"""
     };
   };
 
-  const beginImageLoad = (url) => {
+  const beginImageLoad = (url, timeoutMs = 12000) => {
     const key = `wandao-image-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     window.__wandaoWizImages = window.__wandaoWizImages || {};
     const image = new Image();
     image.decoding = "async";
+    const timer = window.setTimeout(() => {
+      image.src = "";
+      delete window.__wandaoWizImages[key];
+    }, Math.max(500, Number(timeoutMs) || 12000));
     image.src = String(url || "");
-    window.__wandaoWizImages[key] = image;
+    window.__wandaoWizImages[key] = { image, timer };
     return key;
   };
 
+  const cancelImageLoad = (key) => {
+    const state = window.__wandaoWizImages && window.__wandaoWizImages[key];
+    if (!state) return false;
+    window.clearTimeout(state.timer);
+    state.image.src = "";
+    delete window.__wandaoWizImages[key];
+    return true;
+  };
+
   window.__wandaoWiz = {
-    version: 2,
+    version: 5,
     snapshot,
+    health,
     noteDownload,
     otDoc,
     resourceCache,
     fetchBase64,
     beginImageLoad,
+    cancelImageLoad,
   };
   return true;
 })()
 """
 
 
-def install_helpers(cdp: CDPClient) -> None:
-    cdp.evaluate(WIZ_HELPER_JS, timeout=30)
+def install_helpers(cdp: CDPClient, *, timeout: float = 30) -> None:
+    cdp.evaluate(WIZ_HELPER_JS, timeout=timeout)
 
 
-def read_snapshot(cdp: CDPClient) -> dict[str, Any]:
-    install_helpers(cdp)
-    data = cdp.evaluate("window.__wandaoWiz.snapshot()", timeout=60)
+def read_snapshot(cdp: CDPClient, *, timeout: float = 60) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    install_helpers(cdp, timeout=timeout)
+    data = cdp.evaluate("window.__wandaoWiz.snapshot()", timeout=max(0.5, deadline - time.time()))
     if not isinstance(data, dict):
         raise ExportError("读取为知笔记登录状态失败：页面没有返回有效数据。")
     account = data.get("account") or {}
@@ -366,10 +491,11 @@ def wait_for_login_state(cdp: CDPClient, timeout: int = 20) -> dict[str, Any]:
     last_error = ""
     while time.time() < deadline:
         try:
-            return read_snapshot(cdp)
+            remaining = max(0.5, deadline - time.time())
+            return read_snapshot(cdp, timeout=min(60.0, remaining))
         except Exception as exc:  # noqa: BLE001 - keep polling after login redirect.
             last_error = str(exc)
-            time.sleep(1)
+            time.sleep(min(1.0, max(0.0, deadline - time.time())))
     raise ExportError(last_error or "未检测到为知笔记登录态。")
 
 
@@ -568,7 +694,16 @@ def extension_from_name(name: str, content_type: str = "") -> str:
 
 
 class ResourceSaver:
-    def __init__(self, cdp: CDPClient, doc: WizDoc, md_path: Path, kb_server: str, args: argparse.Namespace) -> None:
+    def __init__(
+        self,
+        cdp: CDPClient,
+        doc: WizDoc,
+        md_path: Path,
+        kb_server: str,
+        args: argparse.Namespace,
+        checkpoint: Any | None = None,
+        item_key: str = "",
+    ) -> None:
         self.cdp = cdp
         self.doc = doc
         self.md_path = md_path
@@ -578,6 +713,57 @@ class ResourceSaver:
         self.saved: dict[str, str] = {}
         self.image_count = 0
         self.failures: list[dict[str, str]] = []
+        self.checkpoint = checkpoint
+        self.item_key = item_key
+        failed_hosts = getattr(args, "_wiz_unavailable_external_image_hosts", None)
+        if not isinstance(failed_hosts, set):
+            failed_hosts = set()
+            setattr(args, "_wiz_unavailable_external_image_hosts", failed_hosts)
+        self.unavailable_external_image_hosts: set[str] = failed_hosts
+
+    def start_image_resource(self, url: str) -> str:
+        resource_key = wiz_resource_key(self.doc, "image", url)
+        if self.checkpoint and resource_key:
+            self.checkpoint.upsert_resource(
+                self.item_key,
+                resource_key,
+                "image",
+                safe_resource_url(url),
+            )
+            self.checkpoint.start_resource(resource_key)
+        return resource_key
+
+    def complete_image_resource(self, resource_key: str, relative_path: str) -> None:
+        if self.checkpoint and resource_key and relative_path:
+            self.checkpoint.complete_resource(
+                resource_key,
+                local_path=str((self.md_path.parent / relative_path).resolve()),
+                target=relative_path,
+            )
+
+    def fail_image_resource(self, resource_key: str, error: Exception | str) -> None:
+        if self.checkpoint and resource_key:
+            self.checkpoint.fail_resource(resource_key, str(error))
+
+    def image_deadline(self) -> float:
+        check_stopped(self.args)
+        return time.time() + WIZ_IMAGE_TOTAL_TIMEOUT
+
+    def remaining_image_timeout(self, deadline: float) -> float:
+        check_stopped(self.args)
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            raise ExportError("图片下载超时")
+        return max(0.5, remaining)
+
+    def is_wiz_resource_url(self, url: str) -> bool:
+        target = urllib.parse.urlsplit(url)
+        trusted = urllib.parse.urlsplit(self.kb_server)
+        return bool(target.netloc) and target.scheme in {"http", "https"} and target.netloc.lower() == trusted.netloc.lower()
+
+    @staticmethod
+    def external_host(url: str) -> str:
+        return str(urllib.parse.urlsplit(url).netloc or "").lower()
 
     def build_collab_url(self, src: str) -> str:
         if re.match(r"^https?://", src, re.I):
@@ -602,79 +788,103 @@ class ResourceSaver:
         quoted = urllib.parse.quote(value, safe="/")
         return f"{self.kb_server}/ks/note/view/{self.doc.kb_guid}/{self.doc.doc_guid}/index_files/{quoted}"
 
-    def fetch_base64(self, url: str) -> dict[str, Any]:
+    def fetch_base64(self, url: str, *, timeout: float) -> dict[str, Any]:
         throttle_request(self.args)
-        expression = f"window.__wandaoWiz.fetchBase64({js_string(url)})"
-        return self.cdp.evaluate(expression, timeout=120)
+        check_stopped(self.args)
+        timeout = max(0.5, float(timeout))
+        expression = f"window.__wandaoWiz.fetchBase64({js_string(url)}, {int(timeout * 1000)})"
+        return self.cdp.evaluate(expression, timeout=timeout + 1)
 
-    def fetch_base64_via_browser(self, url: str) -> dict[str, Any]:
+    def fetch_base64_via_browser(self, url: str, *, deadline: float | None = None) -> dict[str, Any]:
         """Load an image as the logged-in browser and read its CDP response body."""
-        self.cdp.send("Network.enable", {}, timeout=10)
-        self.cdp.send("Network.setCacheDisabled", {"cacheDisabled": True}, timeout=10)
-        self.cdp.evaluate(f"window.__wandaoWiz.beginImageLoad({js_string(url)})", timeout=10)
-        response_event = self.cdp.wait_for_event(
-            "Network.responseReceived",
-            timeout=30,
-            predicate=lambda event: (
-                str(event.get("params", {}).get("response", {}).get("url") or "") == url
-                and str(event.get("params", {}).get("type") or "").lower() in {"image", "media"}
-            ),
-        )
-        params = response_event.get("params") or {}
-        request_id = str(params.get("requestId") or "")
-        response = params.get("response") or {}
-        status = int(response.get("status") or 0)
-        while 300 <= status < 400:
+        deadline = deadline if deadline is not None else self.image_deadline()
+        image_token = ""
+        try:
+            self.cdp.send("Network.enable", {}, timeout=self.remaining_image_timeout(deadline))
+            self.cdp.send("Network.setCacheDisabled", {"cacheDisabled": True}, timeout=self.remaining_image_timeout(deadline))
+            image_token = str(
+                self.cdp.evaluate(
+                    f"window.__wandaoWiz.beginImageLoad({js_string(url)}, {int(self.remaining_image_timeout(deadline) * 1000)})",
+                    timeout=self.remaining_image_timeout(deadline),
+                )
+                or ""
+            )
             response_event = self.cdp.wait_for_event(
                 "Network.responseReceived",
-                timeout=30,
-                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+                timeout=self.remaining_image_timeout(deadline),
+                predicate=lambda event: (
+                    str(event.get("params", {}).get("response", {}).get("url") or "") == url
+                    and str(event.get("params", {}).get("type") or "").lower() in {"image", "media"}
+                ),
             )
-            response = (response_event.get("params") or {}).get("response") or {}
+            params = response_event.get("params") or {}
+            request_id = str(params.get("requestId") or "")
+            response = params.get("response") or {}
             status = int(response.get("status") or 0)
-        headers = response.get("headers") or {}
-        content_type = str(response.get("mimeType") or next((value for key, value in headers.items() if str(key).lower() == "content-type"), ""))
-        if status < 200 or status >= 300:
-            raise ExportError(f"图片响应 HTTP {status}")
-        if not content_type.lower().startswith("image/"):
-            raise ExportError("浏览器响应不是图片")
-        try:
-            failed = self.cdp.wait_for_event(
-                "Network.loadingFailed",
-                timeout=0.1,
-                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
-            )
-        except Exception:
-            failed = None
-        if failed:
-            error_text = str((failed.get("params") or {}).get("errorText") or "图片加载失败")
-            raise ExportError(error_text)
-        try:
-            self.cdp.wait_for_event(
-                "Network.loadingFinished",
-                timeout=30,
-                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
-            )
-        except Exception:
-            for event in getattr(self.cdp, "pending_events", []):
-                event_params = event.get("params") or {}
-                if event.get("method") == "Network.loadingFailed" and str(event_params.get("requestId") or "") == request_id:
-                    raise ExportError(str(event_params.get("errorText") or "图片加载失败"))
-            raise
-        body = self.cdp.send("Network.getResponseBody", {"requestId": request_id}, timeout=30).get("result") or {}
-        raw = str(body.get("body") or "")
-        if not raw:
-            raise ExportError("浏览器没有返回图片响应体")
-        if not body.get("base64Encoded"):
-            raw = base64.b64encode(raw.encode("latin-1")).decode("ascii")
-        return {"base64": raw, "contentType": content_type, "finalUrl": str(response.get("url") or url)}
+            while 300 <= status < 400:
+                response_event = self.cdp.wait_for_event(
+                    "Network.responseReceived",
+                    timeout=self.remaining_image_timeout(deadline),
+                    predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+                )
+                response = (response_event.get("params") or {}).get("response") or {}
+                status = int(response.get("status") or 0)
+            headers = response.get("headers") or {}
+            content_type = str(response.get("mimeType") or next((value for key, value in headers.items() if str(key).lower() == "content-type"), ""))
+            if status < 200 or status >= 300:
+                raise ExportError(f"图片响应 HTTP {status}")
+            if not content_type.lower().startswith("image/"):
+                raise ExportError("浏览器响应不是图片")
+            try:
+                failed = self.cdp.wait_for_event(
+                    "Network.loadingFailed",
+                    timeout=0.1,
+                    predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+                )
+            except Exception:
+                failed = None
+            if failed:
+                error_text = str((failed.get("params") or {}).get("errorText") or "图片加载失败")
+                raise ExportError(error_text)
+            try:
+                self.cdp.wait_for_event(
+                    "Network.loadingFinished",
+                    timeout=self.remaining_image_timeout(deadline),
+                    predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+                )
+            except Exception:
+                for event in getattr(self.cdp, "pending_events", []):
+                    event_params = event.get("params") or {}
+                    if event.get("method") == "Network.loadingFailed" and str(event_params.get("requestId") or "") == request_id:
+                        raise ExportError(str(event_params.get("errorText") or "图片加载失败"))
+                raise
+            body = self.cdp.send(
+                "Network.getResponseBody",
+                {"requestId": request_id},
+                timeout=self.remaining_image_timeout(deadline),
+            ).get("result") or {}
+            raw = str(body.get("body") or "")
+            if not raw:
+                raise ExportError("浏览器没有返回图片响应体")
+            if not body.get("base64Encoded"):
+                raw = base64.b64encode(raw.encode("latin-1")).decode("ascii")
+            return {"base64": raw, "contentType": content_type, "finalUrl": str(response.get("url") or url)}
+        finally:
+            if image_token:
+                try:
+                    self.cdp.evaluate(f"window.__wandaoWiz.cancelImageLoad({js_string(image_token)})", timeout=1)
+                except Exception:
+                    pass
 
-    def fetch_cache_base64(self, name: str) -> dict[str, Any] | None:
+    def fetch_cache_base64(self, name: str, *, deadline: float | None = None) -> dict[str, Any] | None:
+        deadline = deadline if deadline is not None else self.image_deadline()
         expression = f"window.__wandaoWiz.resourceCache({js_string(name)})"
-        return self.cdp.evaluate(expression, timeout=60)
+        return self.cdp.evaluate(expression, timeout=self.remaining_image_timeout(deadline))
 
-    def fetch_external_base64(self, url: str) -> dict[str, Any]:
-        """Read a public external image when its host rejects the browser fallback."""
+    def fetch_external_base64(self, url: str, *, timeout: float = WIZ_EXTERNAL_IMAGE_TIMEOUT) -> dict[str, Any]:
+        """Read a public image without Wiz credentials or browser cookies."""
+        throttle_request(self.args)
+        check_stopped(self.args)
         request = urllib.request.Request(
             url,
             headers={
@@ -682,13 +892,14 @@ class ResourceSaver:
                 "Referer": self.kb_server + "/",
             },
         )
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(request, timeout=max(0.5, timeout)) as response:
             status = int(getattr(response, "status", 200) or 200)
             if status < 200 or status >= 300:
                 raise ExportError(f"图片响应 HTTP {status}")
             headers = getattr(response, "headers", {})
             content_type = str(headers.get("Content-Type") or headers.get("content-type") or "")
             body = response.read()
+        check_stopped(self.args)
         if not body:
             raise ExportError("HTTP 图片响应体为空")
         return {
@@ -696,6 +907,50 @@ class ResourceSaver:
             "contentType": content_type,
             "finalUrl": url,
         }
+
+    def fetch_trusted_image(self, url: str, *, cache_name: str = "") -> dict[str, Any]:
+        deadline = self.image_deadline()
+        try:
+            return self.fetch_base64(url, timeout=min(WIZ_IMAGE_PRIMARY_TIMEOUT, self.remaining_image_timeout(deadline)))
+        except (ExportStopped, WizPageSessionLost):
+            raise
+        except Exception as primary_error:
+            raise_if_wiz_page_session_lost(self.cdp, "图片下载", primary_error)
+        try:
+            return self.fetch_base64_via_browser(url, deadline=deadline)
+        except (ExportStopped, WizPageSessionLost):
+            raise
+        except Exception as browser_error:
+            raise_if_wiz_page_session_lost(self.cdp, "图片浏览器兜底", browser_error)
+            if cache_name:
+                try:
+                    cached = self.fetch_cache_base64(cache_name, deadline=deadline)
+                    if cached:
+                        return cached
+                except (ExportStopped, WizPageSessionLost):
+                    raise
+                except Exception as cache_error:
+                    raise_if_wiz_page_session_lost(self.cdp, "图片本地缓存", cache_error)
+            raise ExportError(str(browser_error or primary_error)) from browser_error
+
+    def save_external_image(self, key: str, url: str, name: str, alt: str = "") -> str:
+        host = self.external_host(url)
+        if not host or host in self.unavailable_external_image_hosts:
+            return url
+        resource_key = self.start_image_resource(url)
+        try:
+            payload = self.fetch_external_base64(url)
+            relative_path = self.save_data(key, name, payload, alt)
+            self.complete_image_resource(resource_key, relative_path)
+            return relative_path
+        except ExportStopped:
+            self.fail_image_resource(resource_key, "stopped")
+            raise
+        except Exception as exc:
+            self.fail_image_resource(resource_key, exc)
+            self.unavailable_external_image_hosts.add(host)
+            self.failures.append({"url": url, "error": f"外部图片主机不可用：{exc}"})
+            return url
 
     def save_data(self, key: str, name: str, payload: dict[str, Any], alt: str = "") -> str:
         if key in self.saved:
@@ -720,23 +975,23 @@ class ResourceSaver:
         if key in self.saved:
             return self.saved[key]
         url = self.build_collab_url(src)
+        if not self.is_wiz_resource_url(url):
+            return self.save_external_image(key, url, file_name or src, alt)
+        resource_key = self.start_image_resource(url)
         try:
-            payload = self.fetch_base64(url)
-        except Exception as browser_exc:
-            try:
-                payload = self.fetch_base64_via_browser(url)
-            except Exception as browser_exc:
-                try:
-                    payload = self.fetch_cache_base64(src)
-                except Exception:
-                    payload = None
-                if not payload:
-                    self.failures.append({"url": url, "error": f"浏览器兜底失败：{browser_exc}"})
-                    return ""
-        if not payload:
-            self.failures.append({"url": url, "error": "图片下载失败"})
-            return ""
-        return self.save_data(key, file_name or src, payload, alt)
+            payload = self.fetch_trusted_image(url, cache_name=src)
+        except ExportStopped:
+            raise
+        except WizPageSessionLost:
+            self.fail_image_resource(resource_key, "Wiz page session lost")
+            raise
+        except Exception as exc:
+            self.fail_image_resource(resource_key, exc)
+            self.failures.append({"url": url, "error": str(exc)})
+            return url
+        relative_path = self.save_data(key, file_name or src, payload, alt)
+        self.complete_image_resource(resource_key, relative_path)
+        return relative_path
 
     def save_normal_image(self, src: str, alt: str = "") -> str:
         key = f"normal:{src}"
@@ -749,24 +1004,21 @@ class ResourceSaver:
             payload = {"contentType": match.group(1), "base64": match.group(2)}
             return self.save_data(key, alt or f"image{self.image_count + 1:03d}", payload, alt)
         url = self.build_normal_url(src)
+        if not self.is_wiz_resource_url(url):
+            return self.save_external_image(key, url, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, alt)
+        resource_key = self.start_image_resource(url)
         try:
-            payload = self.fetch_base64(url)
-            return self.save_data(key, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, payload, alt)
+            payload = self.fetch_trusted_image(url)
+            relative_path = self.save_data(key, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, payload, alt)
+            self.complete_image_resource(resource_key, relative_path)
+            return relative_path
+        except (ExportStopped, WizPageSessionLost):
+            self.fail_image_resource(resource_key, "stopped")
+            raise
         except Exception as exc:  # noqa: BLE001 - keep exporting the note body.
-            try:
-                payload = self.fetch_base64_via_browser(url)
-                return self.save_data(key, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, payload, alt)
-            except Exception as browser_exc:
-                parsed = urllib.parse.urlparse(url)
-                wiz_host = urllib.parse.urlparse(self.kb_server).netloc.lower()
-                if parsed.scheme in {"http", "https"} and parsed.netloc.lower() != wiz_host:
-                    try:
-                        payload = self.fetch_external_base64(url)
-                        return self.save_data(key, Path(PurePosixPath(parsed.path).name).name or src, payload, alt)
-                    except Exception:
-                        pass
-                self.failures.append({"url": url, "error": str(browser_exc or exc)})
-                return ""
+            self.fail_image_resource(resource_key, exc)
+            self.failures.append({"url": url, "error": str(exc)})
+            return url
 
 
 def blocks_to_markdown(doc: WizDoc, blocks: list[dict[str, Any]], saver: ResourceSaver) -> str:
@@ -986,54 +1238,175 @@ def get_kb_server(snapshot: dict[str, Any], doc: WizDoc) -> str:
     return str(account.get("kbServer") or "")
 
 
-def fetch_ot_document(cdp: CDPClient, doc: WizDoc) -> dict[str, Any] | None:
-    install_helpers(cdp)
+def is_timeout_error(error: BaseException) -> bool:
+    message = str(error).lower()
+    return "timeout" in message or "timed out" in message or "超时" in message
+
+
+def check_wiz_page_health(cdp: CDPClient) -> None:
+    """Verify that a lightweight readonly IndexedDB call still completes."""
+    deadline = time.time() + WIZ_PAGE_HEALTH_TIMEOUT
+    install_helpers(cdp, timeout=WIZ_PAGE_HEALTH_TIMEOUT)
+    result = cdp.evaluate("window.__wandaoWiz.health()", timeout=max(0.5, deadline - time.time()))
+    if not isinstance(result, dict) or not (result.get("userGuid") or result.get("userId")):
+        raise ExportError("为知网页健康检查未返回当前账号。")
+
+
+def raise_if_wiz_page_session_lost(cdp: CDPClient, source: str, error: BaseException) -> None:
+    if not is_timeout_error(error):
+        return
+    try:
+        check_wiz_page_health(cdp)
+    except Exception as health_error:
+        raise WizPageSessionLost(
+            f"为知网页会话无响应：{source} 超时后只读健康检查也失败：{health_error}"
+        ) from error
+
+
+def note_download_diagnostics(data: Any) -> str:
+    if not isinstance(data, dict):
+        return "无响应元数据"
+    metadata = data.get("__wandaoNoteMeta")
+    if not isinstance(metadata, dict):
+        return "无响应元数据"
+    status = metadata.get("httpStatus")
+    content_type = str(metadata.get("contentType") or "unknown")
+    body_length = metadata.get("bodyLength")
+    return f"HTTP {status if status is not None else 'unknown'}, {content_type}, bodyLength={body_length if body_length is not None else 'unknown'}"
+
+
+def document_metadata_hint(doc: WizDoc) -> str:
+    raw = doc.raw or {}
+    file_type = str(doc.file_type or raw.get("fileType") or "unknown")
+    try:
+        data_size = int(raw.get("dataSize") or 0)
+    except (TypeError, ValueError):
+        data_size = 0
+    try:
+        attachment_count = int(raw.get("attachmentCount") or 0)
+    except (TypeError, ValueError):
+        attachment_count = 0
+    return f"fileType={file_type}, dataSize={data_size}, attachmentCount={attachment_count}"
+
+
+def is_file_note(doc: WizDoc) -> bool:
+    file_type = str(doc.file_type or doc.raw.get("fileType") or "").lower()
+    title = str(doc.title or "").lower()
+    return "pdf" in file_type or title.endswith(".pdf")
+
+
+def fetch_ot_document(
+    cdp: CDPClient,
+    doc: WizDoc,
+    *,
+    timeout: float = WIZ_OT_DOCUMENT_TIMEOUT,
+) -> dict[str, Any] | None:
+    deadline = time.time() + timeout
+    install_helpers(cdp, timeout=timeout)
     expression = f"window.__wandaoWiz.otDoc({js_string(doc.kb_guid)}, {js_string(doc.doc_guid)})"
-    data = cdp.evaluate(expression, timeout=60)
+    data = cdp.evaluate(expression, timeout=max(0.5, deadline - time.time()))
     if not data or not data.get("text"):
         return None
     return json.loads(data["text"])
 
 
-def fetch_note_download(cdp: CDPClient, doc: WizDoc) -> dict[str, Any] | None:
-    install_helpers(cdp)
+def fetch_note_download(
+    cdp: CDPClient,
+    doc: WizDoc,
+    *,
+    timeout: float = WIZ_NOTE_DOWNLOAD_TIMEOUT,
+) -> dict[str, Any] | None:
+    deadline = time.time() + timeout
+    install_helpers(cdp, timeout=timeout)
     expression = f"window.__wandaoWiz.noteDownload({js_string(doc.kb_guid)}, {js_string(doc.doc_guid)})"
-    data = cdp.evaluate(expression, timeout=90)
+    data = cdp.evaluate(expression, timeout=max(0.5, deadline - time.time()))
     if not isinstance(data, dict) or int(data.get("returnCode") or data.get("return_code") or 200) != 200:
         return None
     return data
 
 
-def export_doc(cdp: CDPClient, snapshot: dict[str, Any], doc: WizDoc, md_path: Path, args: argparse.Namespace) -> tuple[int, list[dict[str, str]]]:
+def export_doc(
+    cdp: CDPClient,
+    snapshot: dict[str, Any],
+    doc: WizDoc,
+    md_path: Path,
+    args: argparse.Namespace,
+    checkpoint: Any | None = None,
+    item_key: str = "",
+) -> tuple[int, list[dict[str, str]]]:
     kb_server = get_kb_server(snapshot, doc)
     if not kb_server:
         raise ExportError(f"笔记 {doc.title} 缺少 kbServer，无法下载正文资源。")
-    saver = ResourceSaver(cdp, doc, md_path, kb_server, args)
+    saver = ResourceSaver(cdp, doc, md_path, kb_server, args, checkpoint, item_key)
     markdown = ""
+    html_text = ""
+    source_errors: list[str] = []
+    note_attempt_errors: list[str] = []
+    ot_attempted = False
+
+    def try_ot_document() -> None:
+        nonlocal markdown, ot_attempted
+        if ot_attempted:
+            return
+        ot_attempted = True
+        try:
+            ot_data = fetch_ot_document(cdp, doc)
+        except (ExportStopped, WizPageSessionLost):
+            raise
+        except Exception as exc:
+            source_errors.append(f"otDoc: {exc}")
+            raise_if_wiz_page_session_lost(cdp, "otDoc", exc)
+            return
+        if ot_data and isinstance(ot_data.get("blocks"), list):
+            markdown = blocks_to_markdown(doc, ot_data.get("blocks") or [], saver)
+        else:
+            source_errors.append("otDoc: 未返回本地正文数据")
+
+    def try_note_download(*, timeout: float = WIZ_NOTE_DOWNLOAD_TIMEOUT) -> str:
+        nonlocal markdown, html_text
+        try:
+            downloaded = fetch_note_download(cdp, doc, timeout=timeout)
+        except (ExportStopped, WizPageSessionLost):
+            raise
+        except Exception as exc:
+            note_attempt_errors.append(f"noteDownload: {exc}")
+            raise_if_wiz_page_session_lost(cdp, "noteDownload", exc)
+            return "error"
+        html_text = str((downloaded or {}).get("html") or "")
+        if not html_text:
+            note_attempt_errors.append(f"noteDownload: 未返回可用正文（{note_download_diagnostics(downloaded)}）")
+            return "empty"
+        parser = WizHtmlToMarkdown(saver.save_normal_image)
+        parser.feed(html_text)
+        markdown = parser.result()
+        if not markdown:
+            note_attempt_errors.append(f"noteDownload: 正文解析后为空（{note_download_diagnostics(downloaded)}）")
+            return "empty"
+        return "success"
 
     if doc.note_type == "collaboration":
-        ot_data = fetch_ot_document(cdp, doc)
-        if ot_data and isinstance(ot_data.get("blocks"), list):
-            markdown = blocks_to_markdown(doc, ot_data.get("blocks") or [], saver)
+        try_ot_document()
 
     if not markdown:
-        downloaded = fetch_note_download(cdp, doc)
-        html_text = str((downloaded or {}).get("html") or "")
-        if html_text:
-            parser = WizHtmlToMarkdown(saver.save_normal_image)
-            parser.feed(html_text)
-            markdown = parser.result()
+        note_status = try_note_download()
+        if note_status == "empty" and not is_file_note(doc) and not is_explicitly_empty_note_html(html_text):
+            check_stopped(args)
+            time.sleep(WIZ_EMPTY_BODY_RETRY_DELAY)
+            note_status = try_note_download(timeout=WIZ_EMPTY_BODY_RETRY_TIMEOUT)
+        if note_status != "success":
+            source_errors.extend(note_attempt_errors)
 
-    if not markdown:
-        ot_data = fetch_ot_document(cdp, doc)
-        if ot_data and isinstance(ot_data.get("blocks"), list):
-            markdown = blocks_to_markdown(doc, ot_data.get("blocks") or [], saver)
+    if not markdown and not ot_attempted:
+        try_ot_document()
 
     if not markdown and is_explicitly_empty_note_html(html_text):
         markdown = f"# {doc.title}\n"
 
     if not markdown:
-        raise ExportError("未能读取正文，可能是笔记尚未同步或登录态已失效。")
+        if is_file_note(doc):
+            source_errors.append(f"文件型笔记元数据：{document_metadata_hint(doc)}")
+        details = "；".join(source_errors) or "没有可用的正文来源"
+        raise ExportError(f"正文读取失败：{details}。")
 
     if not re.match(r"^#\s+", markdown.lstrip()):
         markdown = f"# {doc.title}\n\n{markdown.strip()}\n"
@@ -1088,6 +1461,52 @@ def should_skip_existing_doc(*, incremental: bool, path_exists: bool, retry_fail
     return bool(incremental and path_exists and not retry_failed)
 
 
+def export_doc_with_page_recovery(
+    args: argparse.Namespace,
+    cdp: CDPClient,
+    snapshot: dict[str, Any],
+    doc: WizDoc,
+    md_path: Path,
+    started_chrome: list[subprocess.Popen[Any]],
+    checkpoint: Any | None = None,
+    item_key: str = "",
+) -> tuple[CDPClient, dict[str, Any], int, list[dict[str, str]]]:
+    """Retry one document once after replacing an unresponsive Wiz target."""
+    for recovery_attempt in range(2):
+        try:
+            count, image_failures = export_doc(cdp, snapshot, doc, md_path, args, checkpoint, item_key)
+            return cdp, snapshot, count, image_failures
+        except WizPageSessionLost as exc:
+            if recovery_attempt:
+                raise WizPageSessionUnrecoverable(
+                    f"为知网页会话恢复后仍无响应，当前笔记“{doc.title}”未完成。"
+                    "为保留其余笔记的断点状态，导出已停止。"
+                ) from exc
+            emit(
+                args,
+                f"为知网页会话无响应，正在新建只读标签页后重试当前笔记：{doc.title}",
+                event="browser.page.recovery",
+                level="warn",
+            )
+            try:
+                cdp, snapshot, chrome_proc = recover_wiz_page(args, cdp, snapshot)
+            except ExportStopped:
+                raise
+            except Exception as recovery_error:
+                raise WizPageSessionUnrecoverable(
+                    f"为知网页会话无响应，无法恢复当前笔记“{doc.title}”：{recovery_error}"
+                ) from recovery_error
+            if chrome_proc:
+                started_chrome.append(chrome_proc)
+            emit(
+                args,
+                f"为知网页会话已恢复，正在重试当前笔记：{doc.title}",
+                event="browser.page.recovered",
+                level="warn",
+            )
+    raise AssertionError("unreachable")
+
+
 def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
     started = time.time()
     output = Path(args.output).resolve()
@@ -1095,6 +1514,7 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
     checkpoint = open_checkpoint_from_args(args, "wiz", "export")
 
     cdp, chrome_proc = connect_wiz_browser(args)
+    started_chrome = [chrome_proc] if chrome_proc else []
     try:
         snapshot = wait_for_login_state(cdp, timeout=30)
         docs = docs_from_snapshot(snapshot)
@@ -1122,7 +1542,23 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
                     metadata={"docGuid": doc.doc_guid, "kbGuid": doc.kb_guid, "category": doc.category},
                 )
             if getattr(args, "retry_failed", False):
-                docs = [doc for doc in docs if checkpoint.item_status(f"wiz:doc:{doc.doc_guid}") == "failed"]
+                retry_docs: list[WizDoc] = []
+                for doc in docs:
+                    item_key = f"wiz:doc:{doc.doc_guid}"
+                    if checkpoint.item_status(item_key) != "failed":
+                        continue
+                    md_path = doc_paths[doc.doc_guid]
+                    if md_path.is_file():
+                        # Earlier Wiz releases marked a fully written document as
+                        # failed when only a remote image was unavailable.
+                        checkpoint.complete_item(
+                            item_key,
+                            local_path=str(md_path),
+                            metadata={"docGuid": doc.doc_guid, "recoveredExistingMarkdown": True},
+                        )
+                        continue
+                    retry_docs.append(doc)
+                docs = retry_docs
 
         exported = 0
         skipped = 0
@@ -1162,7 +1598,16 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
                         event="document.export.started",
                         doc={"id": doc.doc_guid, "title": doc.title, "index": index, "path": str(md_path)},
                     )
-                    count, img_failures = export_doc(cdp, snapshot, doc, md_path, args)
+                    cdp, snapshot, count, img_failures = export_doc_with_page_recovery(
+                        args,
+                        cdp,
+                        snapshot,
+                        doc,
+                        md_path,
+                        started_chrome,
+                        checkpoint,
+                        item_key,
+                    )
                     image_success += count
                     image_failures.extend({"docGuid": doc.doc_guid, "title": doc.title, **item} for item in img_failures)
                     for failure in img_failures:
@@ -1177,10 +1622,11 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
                         )
                     exported += 1
                     if checkpoint:
-                        if img_failures:
-                            checkpoint.fail_item(item_key, f"{len(img_failures)} 个图片下载失败")
-                        else:
-                            checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"docGuid": doc.doc_guid})
+                        checkpoint.complete_item(
+                            item_key,
+                            local_path=str(md_path),
+                            metadata={"docGuid": doc.doc_guid, "imageFailureCount": len(img_failures)},
+                        )
                     emit(
                         args,
                         f"为知笔记导出完成：{doc.title}",
@@ -1191,6 +1637,20 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
             except ExportStopped:
                 if checkpoint:
                     checkpoint.fail_item(item_key, "stopped")
+                raise
+            except WizPageSessionUnrecoverable as exc:
+                if checkpoint:
+                    checkpoint.fail_item(item_key, str(exc))
+                    checkpoint.fail_task(str(exc), status="failed")
+                failures.append({"docGuid": doc.doc_guid, "title": doc.title, "error": str(exc)})
+                emit(
+                    args,
+                    f"为知笔记导出失败：{doc.title}：{exc}",
+                    event="document.export.failed",
+                    level="error",
+                    doc={"id": doc.doc_guid, "title": doc.title, "index": index, "path": str(md_path)},
+                    error={"type": type(exc).__name__, "message": str(exc)},
+                )
                 raise
             except Exception as exc:  # noqa: BLE001 - keep exporting other docs.
                 if checkpoint:
@@ -1237,7 +1697,7 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
         report = finalize_report(report, provider="wiz", mode="export", report_file=report_path, output=output)
         report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
         if checkpoint:
-            if failures or image_failures:
+            if failures:
                 checkpoint.fail_task(
                     f"{len(failures)} 个文档失败，{len(image_failures)} 个图片失败",
                     status="failed",
@@ -1261,8 +1721,9 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
         return report
     finally:
         cdp.close()
-        if chrome_proc and args.close_started_chrome:
-            chrome_proc.terminate()
+        if args.close_started_chrome:
+            for proc in started_chrome:
+                proc.terminate()
         if checkpoint:
             checkpoint.close()
 

--- a/plugins/wiz/backend/export_wiz.py
+++ b/plugins/wiz/backend/export_wiz.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import time
 import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
@@ -142,7 +143,7 @@ def connect_wiz_browser(args: argparse.Namespace, initial_url: str = WIZ_APP_URL
 
 WIZ_HELPER_JS = r"""
 (() => {
-  if (window.__wandaoWiz && window.__wandaoWiz.version === 1) return true;
+  if (window.__wandaoWiz && window.__wandaoWiz.version === 2) return true;
 
   const reqToPromise = (req) => new Promise((resolve, reject) => {
     req.onsuccess = () => resolve(req.result);
@@ -321,13 +322,24 @@ WIZ_HELPER_JS = r"""
     };
   };
 
+  const beginImageLoad = (url) => {
+    const key = `wandao-image-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    window.__wandaoWizImages = window.__wandaoWizImages || {};
+    const image = new Image();
+    image.decoding = "async";
+    image.src = String(url || "");
+    window.__wandaoWizImages[key] = image;
+    return key;
+  };
+
   window.__wandaoWiz = {
-    version: 1,
+    version: 2,
     snapshot,
     noteDownload,
     otDoc,
     resourceCache,
     fetchBase64,
+    beginImageLoad,
   };
   return true;
 })()
@@ -595,9 +607,95 @@ class ResourceSaver:
         expression = f"window.__wandaoWiz.fetchBase64({js_string(url)})"
         return self.cdp.evaluate(expression, timeout=120)
 
+    def fetch_base64_via_browser(self, url: str) -> dict[str, Any]:
+        """Load an image as the logged-in browser and read its CDP response body."""
+        self.cdp.send("Network.enable", {}, timeout=10)
+        self.cdp.send("Network.setCacheDisabled", {"cacheDisabled": True}, timeout=10)
+        self.cdp.evaluate(f"window.__wandaoWiz.beginImageLoad({js_string(url)})", timeout=10)
+        response_event = self.cdp.wait_for_event(
+            "Network.responseReceived",
+            timeout=30,
+            predicate=lambda event: (
+                str(event.get("params", {}).get("response", {}).get("url") or "") == url
+                and str(event.get("params", {}).get("type") or "").lower() in {"image", "media"}
+            ),
+        )
+        params = response_event.get("params") or {}
+        request_id = str(params.get("requestId") or "")
+        response = params.get("response") or {}
+        status = int(response.get("status") or 0)
+        while 300 <= status < 400:
+            response_event = self.cdp.wait_for_event(
+                "Network.responseReceived",
+                timeout=30,
+                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+            )
+            response = (response_event.get("params") or {}).get("response") or {}
+            status = int(response.get("status") or 0)
+        headers = response.get("headers") or {}
+        content_type = str(response.get("mimeType") or next((value for key, value in headers.items() if str(key).lower() == "content-type"), ""))
+        if status < 200 or status >= 300:
+            raise ExportError(f"图片响应 HTTP {status}")
+        if not content_type.lower().startswith("image/"):
+            raise ExportError("浏览器响应不是图片")
+        try:
+            failed = self.cdp.wait_for_event(
+                "Network.loadingFailed",
+                timeout=0.1,
+                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+            )
+        except Exception:
+            failed = None
+        if failed:
+            error_text = str((failed.get("params") or {}).get("errorText") or "图片加载失败")
+            raise ExportError(error_text)
+        try:
+            self.cdp.wait_for_event(
+                "Network.loadingFinished",
+                timeout=30,
+                predicate=lambda event: str(event.get("params", {}).get("requestId") or "") == request_id,
+            )
+        except Exception:
+            for event in getattr(self.cdp, "pending_events", []):
+                event_params = event.get("params") or {}
+                if event.get("method") == "Network.loadingFailed" and str(event_params.get("requestId") or "") == request_id:
+                    raise ExportError(str(event_params.get("errorText") or "图片加载失败"))
+            raise
+        body = self.cdp.send("Network.getResponseBody", {"requestId": request_id}, timeout=30).get("result") or {}
+        raw = str(body.get("body") or "")
+        if not raw:
+            raise ExportError("浏览器没有返回图片响应体")
+        if not body.get("base64Encoded"):
+            raw = base64.b64encode(raw.encode("latin-1")).decode("ascii")
+        return {"base64": raw, "contentType": content_type, "finalUrl": str(response.get("url") or url)}
+
     def fetch_cache_base64(self, name: str) -> dict[str, Any] | None:
         expression = f"window.__wandaoWiz.resourceCache({js_string(name)})"
         return self.cdp.evaluate(expression, timeout=60)
+
+    def fetch_external_base64(self, url: str) -> dict[str, Any]:
+        """Read a public external image when its host rejects the browser fallback."""
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151 Safari/537.36",
+                "Referer": self.kb_server + "/",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            status = int(getattr(response, "status", 200) or 200)
+            if status < 200 or status >= 300:
+                raise ExportError(f"图片响应 HTTP {status}")
+            headers = getattr(response, "headers", {})
+            content_type = str(headers.get("Content-Type") or headers.get("content-type") or "")
+            body = response.read()
+        if not body:
+            raise ExportError("HTTP 图片响应体为空")
+        return {
+            "base64": base64.b64encode(body).decode("ascii"),
+            "contentType": content_type,
+            "finalUrl": url,
+        }
 
     def save_data(self, key: str, name: str, payload: dict[str, Any], alt: str = "") -> str:
         if key in self.saved:
@@ -624,8 +722,17 @@ class ResourceSaver:
         url = self.build_collab_url(src)
         try:
             payload = self.fetch_base64(url)
-        except Exception:
-            payload = self.fetch_cache_base64(src)
+        except Exception as browser_exc:
+            try:
+                payload = self.fetch_base64_via_browser(url)
+            except Exception as browser_exc:
+                try:
+                    payload = self.fetch_cache_base64(src)
+                except Exception:
+                    payload = None
+                if not payload:
+                    self.failures.append({"url": url, "error": f"浏览器兜底失败：{browser_exc}"})
+                    return ""
         if not payload:
             self.failures.append({"url": url, "error": "图片下载失败"})
             return ""
@@ -646,8 +753,20 @@ class ResourceSaver:
             payload = self.fetch_base64(url)
             return self.save_data(key, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, payload, alt)
         except Exception as exc:  # noqa: BLE001 - keep exporting the note body.
-            self.failures.append({"url": url, "error": str(exc)})
-            return ""
+            try:
+                payload = self.fetch_base64_via_browser(url)
+                return self.save_data(key, Path(PurePosixPath(urllib.parse.urlparse(url).path).name).name or src, payload, alt)
+            except Exception as browser_exc:
+                parsed = urllib.parse.urlparse(url)
+                wiz_host = urllib.parse.urlparse(self.kb_server).netloc.lower()
+                if parsed.scheme in {"http", "https"} and parsed.netloc.lower() != wiz_host:
+                    try:
+                        payload = self.fetch_external_base64(url)
+                        return self.save_data(key, Path(PurePosixPath(parsed.path).name).name or src, payload, alt)
+                    except Exception:
+                        pass
+                self.failures.append({"url": url, "error": str(browser_exc or exc)})
+                return ""
 
 
 def blocks_to_markdown(doc: WizDoc, blocks: list[dict[str, Any]], saver: ResourceSaver) -> str:
@@ -704,6 +823,18 @@ def blocks_to_markdown(doc: WizDoc, blocks: list[dict[str, Any]], saver: Resourc
     if text and not re.match(r"^#\s+", text):
         text = f"# {doc.title}\n\n{text}"
     return text + "\n" if text else f"# {doc.title}\n"
+
+
+def is_explicitly_empty_note_html(value: str) -> bool:
+    """Recognize Wiz's successful empty-note markup without accepting unknown content."""
+    source = html.unescape(str(value or ""))
+    source = re.sub(r"<!--.*?-->", "", source, flags=re.S)
+    if not source.strip() or not re.search(r"<\s*(?:p|div|br)\b", source, flags=re.I):
+        return False
+    if re.search(r"<\s*(?:img|table|object|iframe|audio|video)\b", source, flags=re.I):
+        return False
+    text = re.sub(r"<[^>]*>", "", source)
+    return not text.replace("\xa0", " ").strip()
 
 
 class WizHtmlToMarkdown(HTMLParser):
@@ -898,6 +1029,9 @@ def export_doc(cdp: CDPClient, snapshot: dict[str, Any], doc: WizDoc, md_path: P
         if ot_data and isinstance(ot_data.get("blocks"), list):
             markdown = blocks_to_markdown(doc, ot_data.get("blocks") or [], saver)
 
+    if not markdown and is_explicitly_empty_note_html(html_text):
+        markdown = f"# {doc.title}\n"
+
     if not markdown:
         raise ExportError("未能读取正文，可能是笔记尚未同步或登录态已失效。")
 
@@ -943,6 +1077,15 @@ def select_wiz_documents(docs: list[WizDoc], selected_doc_ids: set[str] | None =
             "请重新读取目录后再试。未匹配 ID：" + preview
         )
     return selected
+
+
+def should_skip_existing_doc(*, incremental: bool, path_exists: bool, retry_failed: bool) -> bool:
+    """Skip an existing Markdown file only during a normal incremental export.
+
+    A retry of a failed document must run the exporter again so failed images
+    (or other resources) get another download attempt.
+    """
+    return bool(incremental and path_exists and not retry_failed)
 
 
 def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
@@ -1002,7 +1145,11 @@ def export_wiz(args: argparse.Namespace) -> dict[str, Any]:
                 if checkpoint and getattr(args, "resume", False) and checkpoint.item_status(item_key) == "completed":
                     skipped += 1
                     continue
-                if args.incremental and md_path.exists():
+                if should_skip_existing_doc(
+                    incremental=bool(args.incremental),
+                    path_exists=md_path.exists(),
+                    retry_failed=bool(getattr(args, "retry_failed", False)),
+                ):
                     if checkpoint:
                         checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"docGuid": doc.doc_guid, "skippedExisting": True})
                     skipped += 1

--- a/plugins/wiz/plugin.json
+++ b/plugins/wiz/plugin.json
@@ -4,7 +4,7 @@
   "id": "wiz",
   "name": "为知笔记",
   "description": "导出为知笔记网页版内容，保留目录、正文和本地图片。",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "Wandao Official",
   "homepage": "https://www.wiz.cn/",
   "license": "AGPL-3.0-only",

--- a/plugins/wiz/plugin.json
+++ b/plugins/wiz/plugin.json
@@ -4,7 +4,7 @@
   "id": "wiz",
   "name": "为知笔记",
   "description": "导出为知笔记网页版内容，保留目录、正文和本地图片。",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "publisher": "Wandao Official",
   "homepage": "https://www.wiz.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_checkpoint_provider_args.py
+++ b/tests/test_checkpoint_provider_args.py
@@ -86,13 +86,18 @@ class CheckpointProviderArgsTests(unittest.TestCase):
             "plugins/aliyun_thoughts/backend/export_aliyun_thoughts.py": "checkpoint.fail_item(item_key, f\"{len(img_errors)} 个图片或附件下载失败\")",
             "plugins/feishu/backend/export_feishu.py": "checkpoint.fail_item(item_key, f\"{len(img_errors)} 个图片下载失败\")",
             "plugins/yuque/backend/export_yuque.py": "checkpoint.fail_item(item_key, f\"{len(resource_errors)} 个图片或附件下载失败\")",
-            "plugins/wiz/backend/export_wiz.py": "checkpoint.fail_item(item_key, f\"{len(img_failures)} 个图片下载失败\")",
             "plugins/youdao/backend/export_youdao.py": "checkpoint.fail_item(item_key, f\"{resource_failures_in_doc} 个图片或附件下载失败\")",
         }
         for filename, marker in expected_markers.items():
             with self.subTest(script=filename):
                 source = (REPO_ROOT / filename).read_text(encoding="utf-8")
                 self.assertIn(marker, source)
+
+        # Wiz Markdown remains complete when only a remote image is
+        # unavailable, so retry-failed does not re-export the full document.
+        wiz_source = (REPO_ROOT / "plugins/wiz/backend/export_wiz.py").read_text(encoding="utf-8")
+        self.assertIn("checkpoint.fail_resource(resource_key, str(error))", wiz_source)
+        self.assertIn('metadata={"docGuid": doc.doc_guid, "imageFailureCount": len(img_failures)}', wiz_source)
 
         # Group exports use a cursor.  A timed-out image must remain a resource
         # warning, otherwise the desktop's generic retry action narrows a

--- a/tests/test_wiz_empty_note.py
+++ b/tests/test_wiz_empty_note.py
@@ -1,0 +1,31 @@
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from plugins.wiz.backend import export_wiz
+
+
+class WizEmptyNoteTests(unittest.TestCase):
+    def test_explicit_empty_html_exports_title_only_markdown(self) -> None:
+        doc = export_wiz.WizDoc("kb", "doc", "空白笔记", "/", "note", "", 0, 0, {})
+        args = argparse.Namespace(request_delay=0, request_jitter=0)
+        snapshot = {"kbs": [{"kbGuid": "kb", "kbServer": "https://example.invalid"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "空白笔记.md"
+            with patch.object(export_wiz, "fetch_note_download", return_value={"html": "<p><br></p>"}), patch.object(
+                export_wiz, "fetch_ot_document", return_value=None
+            ):
+                export_wiz.export_doc(object(), snapshot, doc, target, args)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "# 空白笔记\n")
+
+    def test_nonempty_html_is_not_treated_as_empty(self) -> None:
+        self.assertFalse(export_wiz.is_explicitly_empty_note_html("<p>正文</p>"))
+        self.assertTrue(export_wiz.is_explicitly_empty_note_html("<p><br></p>"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wiz_image_cdp.py
+++ b/tests/test_wiz_image_cdp.py
@@ -57,7 +57,7 @@ class WizImageCdpTests(unittest.TestCase):
                 return b"png"
 
         with patch("plugins.wiz.backend.export_wiz.urllib.request.urlopen", return_value=Response()) as opened:
-            result = saver.save_normal_image("https://gips1.baidu.com/image.png", "image")
+            result = saver.save_normal_image("https://images.example.invalid/image.png", "image")
         self.assertTrue(result)
         opened.assert_called_once()
 

--- a/tests/test_wiz_image_cdp.py
+++ b/tests/test_wiz_image_cdp.py
@@ -1,0 +1,104 @@
+import base64
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from plugins.wiz.backend.export_wiz import ResourceSaver, WizDoc, WIZ_HELPER_JS
+
+
+class FakeCdp:
+    def __init__(self, events):
+        self.events = list(events)
+        self.sent = []
+
+    def evaluate(self, expression, timeout=60):
+        if "beginImageLoad" in expression:
+            return "image-load-token"
+        raise AssertionError(f"unexpected evaluate: {expression}")
+
+    def wait_for_event(self, method, *, timeout=30, predicate=None):
+        for index, event in enumerate(self.events):
+            if event.get("method") != method:
+                continue
+            if predicate and not predicate(event):
+                continue
+            return self.events.pop(index)
+        raise AssertionError(f"missing event {method}")
+
+    def send(self, method, params=None, timeout=30):
+        self.sent.append((method, params))
+        if method == "Network.getResponseBody":
+            return {"result": {"body": base64.b64encode(b"png").decode(), "base64Encoded": True}}
+        return {"result": {}}
+
+
+def make_saver(cdp):
+    doc = WizDoc("kb", "doc", "测试", "/", "note", "", 0, 0, {})
+    args = SimpleNamespace()
+    return ResourceSaver(cdp, doc, __import__("pathlib").Path("out/test.md"), "https://example.com", args)
+
+
+class WizImageCdpTests(unittest.TestCase):
+    def test_external_image_uses_http_fallback_after_browser_rejection(self):
+        saver = make_saver(FakeCdp([]))
+        saver.fetch_base64 = lambda _url: (_ for _ in ()).throw(RuntimeError("cors"))
+        saver.fetch_base64_via_browser = lambda _url: (_ for _ in ()).throw(RuntimeError("HTTP 405"))
+
+        class Response:
+            headers = {"Content-Type": "image/png"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b"png"
+
+        with patch("plugins.wiz.backend.export_wiz.urllib.request.urlopen", return_value=Response()) as opened:
+            result = saver.save_normal_image("https://gips1.baidu.com/image.png", "image")
+        self.assertTrue(result)
+        opened.assert_called_once()
+
+    def test_browser_helper_version_is_bumped_for_new_image_loader(self):
+        self.assertIn("version === 2", WIZ_HELPER_JS)
+        self.assertIn("version: 2", WIZ_HELPER_JS)
+
+    def test_browser_fallback_reads_body_only_after_loading_finished(self):
+        request_id = "request-1"
+        cdp = FakeCdp(
+            [
+                {"method": "Network.responseReceived", "params": {"requestId": "preflight-1", "type": "Preflight", "response": {"url": "https://img.example/a.png", "status": 405, "mimeType": "text/plain"}}},
+                {"method": "Network.responseReceived", "params": {"requestId": request_id, "type": "Image", "response": {"url": "https://img.example/a.png", "status": 200, "mimeType": "image/png"}}},
+                {"method": "Network.loadingFinished", "params": {"requestId": request_id}},
+            ]
+        )
+        payload = make_saver(cdp).fetch_base64_via_browser("https://img.example/a.png")
+        self.assertEqual(payload["contentType"], "image/png")
+        self.assertEqual(cdp.sent[-1][0], "Network.getResponseBody")
+        self.assertIn(("Network.setCacheDisabled", {"cacheDisabled": True}), cdp.sent)
+
+    def test_browser_fallback_does_not_read_body_after_loading_failed(self):
+        request_id = "request-2"
+        cdp = FakeCdp(
+            [
+                {"method": "Network.responseReceived", "params": {"requestId": request_id, "response": {"url": "https://img.example/a.png", "status": 200, "mimeType": "image/png"}}},
+                {"method": "Network.loadingFailed", "params": {"requestId": request_id, "params": {"errorText": "blocked"}}},
+            ]
+        )
+        with self.assertRaises(Exception):
+            make_saver(cdp).fetch_base64_via_browser("https://img.example/a.png")
+        self.assertNotIn("Network.getResponseBody", [method for method, _params in cdp.sent])
+
+    def test_collab_failure_keeps_browser_fallback_stage(self):
+        saver = make_saver(FakeCdp([]))
+        saver.fetch_base64 = lambda _url: (_ for _ in ()).throw(RuntimeError("cors"))
+        saver.fetch_base64_via_browser = lambda _url: (_ for _ in ()).throw(RuntimeError("response timeout"))
+        saver.fetch_cache_base64 = lambda _name: None
+        self.assertEqual(saver.save_collab_image("image.png"), "")
+        self.assertIn("浏览器兜底失败", saver.failures[0]["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wiz_image_cdp.py
+++ b/tests/test_wiz_image_cdp.py
@@ -1,9 +1,9 @@
 import base64
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from plugins.wiz.backend.export_wiz import ResourceSaver, WizDoc, WIZ_HELPER_JS
+from plugins.wiz.backend.export_wiz import ResourceSaver, WizDoc, WizPageSessionLost, WIZ_HELPER_JS
 
 
 class FakeCdp:
@@ -39,10 +39,11 @@ def make_saver(cdp):
 
 
 class WizImageCdpTests(unittest.TestCase):
-    def test_external_image_uses_http_fallback_after_browser_rejection(self):
+    def test_external_image_downloads_without_browser_credentials(self):
         saver = make_saver(FakeCdp([]))
-        saver.fetch_base64 = lambda _url: (_ for _ in ()).throw(RuntimeError("cors"))
-        saver.fetch_base64_via_browser = lambda _url: (_ for _ in ()).throw(RuntimeError("HTTP 405"))
+        saver.fetch_base64 = Mock(side_effect=AssertionError("external image must not use Wiz credentials"))
+        saver.fetch_base64_via_browser = Mock(side_effect=AssertionError("external image must not use the browser"))
+        saver.save_data = Mock(return_value="test_assets/image.png")
 
         class Response:
             headers = {"Content-Type": "image/png"}
@@ -58,12 +59,31 @@ class WizImageCdpTests(unittest.TestCase):
 
         with patch("plugins.wiz.backend.export_wiz.urllib.request.urlopen", return_value=Response()) as opened:
             result = saver.save_normal_image("https://images.example.invalid/image.png", "image")
-        self.assertTrue(result)
+        self.assertEqual(result, "test_assets/image.png")
         opened.assert_called_once()
+        request = opened.call_args.args[0]
+        self.assertIsNone(request.get_header("x-wiz-token"))
+        self.assertIsNone(request.get_header("Cookie"))
+        saver.fetch_base64.assert_not_called()
+        saver.fetch_base64_via_browser.assert_not_called()
+
+    def test_failed_external_host_is_not_retried_for_later_images(self):
+        saver = make_saver(FakeCdp([]))
+        saver.fetch_external_base64 = Mock(side_effect=TimeoutError("timed out"))
+        first_url = "https://images.example.invalid/first.png"
+        second_url = "https://images.example.invalid/second.png"
+
+        self.assertEqual(saver.save_normal_image(first_url), first_url)
+        self.assertEqual(saver.save_normal_image(second_url), second_url)
+
+        saver.fetch_external_base64.assert_called_once_with(first_url)
+        self.assertEqual(len(saver.failures), 1)
 
     def test_browser_helper_version_is_bumped_for_new_image_loader(self):
-        self.assertIn("version === 2", WIZ_HELPER_JS)
-        self.assertIn("version: 2", WIZ_HELPER_JS)
+        self.assertIn("version === 5", WIZ_HELPER_JS)
+        self.assertIn("version: 5", WIZ_HELPER_JS)
+        self.assertIn("AbortController", WIZ_HELPER_JS)
+        self.assertIn("cancelImageLoad", WIZ_HELPER_JS)
 
     def test_browser_fallback_reads_body_only_after_loading_finished(self):
         request_id = "request-1"
@@ -93,11 +113,24 @@ class WizImageCdpTests(unittest.TestCase):
 
     def test_collab_failure_keeps_browser_fallback_stage(self):
         saver = make_saver(FakeCdp([]))
-        saver.fetch_base64 = lambda _url: (_ for _ in ()).throw(RuntimeError("cors"))
-        saver.fetch_base64_via_browser = lambda _url: (_ for _ in ()).throw(RuntimeError("response timeout"))
-        saver.fetch_cache_base64 = lambda _name: None
-        self.assertEqual(saver.save_collab_image("image.png"), "")
-        self.assertIn("浏览器兜底失败", saver.failures[0]["error"])
+        saver.fetch_base64 = Mock(side_effect=RuntimeError("cors"))
+        saver.fetch_base64_via_browser = Mock(side_effect=RuntimeError("response unavailable"))
+        saver.fetch_cache_base64 = Mock(return_value=None)
+
+        self.assertEqual(saver.save_collab_image("image.png"), "https://example.com/editor/kb/doc/resources/image.png")
+        saver.fetch_base64_via_browser.assert_called_once()
+        self.assertEqual(len(saver.failures), 1)
+
+    def test_trusted_image_timeout_with_failed_health_check_triggers_page_recovery(self):
+        saver = make_saver(FakeCdp([]))
+        saver.fetch_base64 = Mock(side_effect=TimeoutError("timed out"))
+
+        with patch(
+            "plugins.wiz.backend.export_wiz.check_wiz_page_health",
+            side_effect=TimeoutError("health timed out"),
+        ):
+            with self.assertRaises(WizPageSessionLost):
+                saver.save_collab_image("image.png")
 
 
 if __name__ == "__main__":

--- a/tests/test_wiz_page_session_recovery.py
+++ b/tests/test_wiz_page_session_recovery.py
@@ -1,0 +1,288 @@
+import argparse
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from plugins.wiz.backend import export_wiz
+
+
+class FakeCdp:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class CapturingCdp:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, float]] = []
+
+    def evaluate(self, expression: str, timeout: float = 60):
+        self.calls.append((expression, timeout))
+        if expression == export_wiz.WIZ_HELPER_JS:
+            return True
+        return {"html": "<p>正文</p>"}
+
+
+def make_doc(doc_guid: str, title: str) -> export_wiz.WizDoc:
+    return export_wiz.WizDoc("kb", doc_guid, title, "/", "note", "", 0, 0, {})
+
+
+def make_snapshot(*docs: export_wiz.WizDoc) -> dict[str, object]:
+    return {
+        "account": {"userGuid": "account-guid", "userId": "account-id", "hasToken": True},
+        "kbs": [{"kbGuid": "kb", "kbServer": "https://example.invalid"}],
+        "docs": [
+            {
+                "kbGuid": doc.kb_guid,
+                "docGuid": doc.doc_guid,
+                "title": doc.title,
+                "category": doc.category,
+                "type": doc.note_type,
+                "fileType": doc.file_type,
+            }
+            for doc in docs
+        ],
+    }
+
+
+def make_args(output: Path, checkpoint_file: str = "") -> argparse.Namespace:
+    return argparse.Namespace(
+        output=str(output),
+        checkpoint_file=checkpoint_file,
+        checkpoint_task_id="wiz-page-recovery",
+        reset_checkpoint=False,
+        selected_doc_ids=[],
+        incremental=False,
+        resume=False,
+        retry_failed=False,
+        progress_every=100,
+        close_started_chrome=False,
+        request_delay=0,
+        request_jitter=0,
+    )
+
+
+class WizPageSessionRecoveryTests(unittest.TestCase):
+    def test_note_read_keeps_helper_install_within_the_note_timeout_budget(self) -> None:
+        cdp = CapturingCdp()
+
+        export_wiz.fetch_note_download(cdp, make_doc("doc-1", "笔记"))
+
+        self.assertEqual(len(cdp.calls), 2)
+        self.assertTrue(all(timeout <= export_wiz.WIZ_NOTE_DOWNLOAD_TIMEOUT for _expression, timeout in cdp.calls))
+
+    def test_health_probe_keeps_helper_install_within_the_health_timeout_budget(self) -> None:
+        cdp = CapturingCdp()
+        cdp.evaluate = Mock(side_effect=export_wiz.ExportError("timed out"))
+
+        with self.assertRaises(export_wiz.ExportError):
+            export_wiz.check_wiz_page_health(cdp)
+
+        cdp.evaluate.assert_called_once_with(export_wiz.WIZ_HELPER_JS, timeout=export_wiz.WIZ_PAGE_HEALTH_TIMEOUT)
+
+    def test_empty_note_response_retries_only_the_current_note_once(self) -> None:
+        doc = make_doc("doc-1", "笔记")
+        args = make_args(Path("unused"))
+        snapshot = make_snapshot(doc)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "笔记.md"
+            with (
+                patch.object(export_wiz, "fetch_note_download", side_effect=[{}, {"html": "<p>正文</p>"}]) as download,
+                patch.object(export_wiz, "fetch_ot_document") as ot_document,
+                patch.object(export_wiz.time, "sleep") as sleep,
+            ):
+                export_wiz.export_doc(FakeCdp(), snapshot, doc, target, args)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "# 笔记\n\n正文\n")
+
+        self.assertEqual(download.call_count, 2)
+        self.assertEqual(download.call_args_list[1].kwargs["timeout"], export_wiz.WIZ_EMPTY_BODY_RETRY_TIMEOUT)
+        sleep.assert_called_once_with(export_wiz.WIZ_EMPTY_BODY_RETRY_DELAY)
+        ot_document.assert_not_called()
+
+    def test_persistent_empty_note_response_remains_a_failure(self) -> None:
+        doc = make_doc("doc-1", "笔记")
+        args = make_args(Path("unused"))
+        snapshot = make_snapshot(doc)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "笔记.md"
+            with (
+                patch.object(export_wiz, "fetch_note_download", side_effect=[{}, {}]),
+                patch.object(export_wiz, "fetch_ot_document", return_value=None),
+                patch.object(export_wiz.time, "sleep"),
+                self.assertRaisesRegex(export_wiz.ExportError, "noteDownload: 未返回可用正文"),
+            ):
+                export_wiz.export_doc(FakeCdp(), snapshot, doc, target, args)
+
+            self.assertFalse(target.exists())
+
+    def test_pdf_note_does_not_wait_for_another_empty_body_retry(self) -> None:
+        doc = export_wiz.WizDoc(
+            "kb",
+            "doc-1",
+            "示例附件.pdf",
+            "/",
+            "note",
+            "application/pdf",
+            0,
+            0,
+            {"fileType": "application/pdf", "dataSize": 123, "attachmentCount": 1},
+        )
+        args = make_args(Path("unused"))
+        snapshot = make_snapshot(doc)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "示例附件.pdf.md"
+            with (
+                patch.object(export_wiz, "fetch_note_download", return_value={"html": "<object data='file.pdf'></object>"}) as download,
+                patch.object(export_wiz, "fetch_ot_document", return_value=None),
+                patch.object(export_wiz.time, "sleep") as sleep,
+                self.assertRaisesRegex(export_wiz.ExportError, "文件型笔记元数据：fileType=application/pdf"),
+            ):
+                export_wiz.export_doc(FakeCdp(), snapshot, doc, target, args)
+
+        download.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_healthy_note_timeout_falls_back_to_ot_document(self) -> None:
+        doc = make_doc("doc-1", "笔记")
+        args = make_args(Path("unused"))
+        snapshot = make_snapshot(doc)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "笔记.md"
+            with (
+                patch.object(export_wiz, "fetch_note_download", side_effect=export_wiz.ExportError("request timed out")),
+                patch.object(export_wiz, "check_wiz_page_health") as health_check,
+                patch.object(export_wiz, "fetch_ot_document", return_value={"blocks": [{"type": "paragraph"}]}),
+                patch.object(export_wiz, "blocks_to_markdown", return_value="正文\n"),
+            ):
+                export_wiz.export_doc(FakeCdp(), snapshot, doc, target, args)
+
+            health_check.assert_called_once()
+            self.assertEqual(target.read_text(encoding="utf-8"), "# 笔记\n\n正文\n")
+
+    def test_timeout_with_failed_health_probe_marks_page_session_lost(self) -> None:
+        doc = make_doc("doc-1", "笔记")
+        args = make_args(Path("unused"))
+        snapshot = make_snapshot(doc)
+
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "笔记.md"
+            with (
+                patch.object(export_wiz, "fetch_note_download", side_effect=export_wiz.ExportError("request timed out")),
+                patch.object(export_wiz, "check_wiz_page_health", side_effect=export_wiz.ExportError("health timed out")),
+                self.assertRaises(export_wiz.WizPageSessionLost),
+            ):
+                export_wiz.export_doc(FakeCdp(), snapshot, doc, target, args)
+
+    def test_recovery_retries_only_the_current_document(self) -> None:
+        first_doc = make_doc("doc-1", "第一篇")
+        second_doc = make_doc("doc-2", "第二篇")
+        snapshot = make_snapshot(first_doc, second_doc)
+        initial_cdp = FakeCdp()
+        recovered_cdp = FakeCdp()
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = make_args(Path(directory) / "output")
+            with (
+                patch.object(export_wiz, "connect_wiz_browser", return_value=(initial_cdp, None)),
+                patch.object(export_wiz, "wait_for_login_state", return_value=snapshot),
+                patch.object(
+                    export_wiz,
+                    "export_doc",
+                    side_effect=[export_wiz.WizPageSessionLost("stalled"), (0, []), (0, [])],
+                ) as export_doc_mock,
+                patch.object(export_wiz, "recover_wiz_page", return_value=(recovered_cdp, snapshot, None)) as recover_mock,
+                patch.object(export_wiz, "emit"),
+            ):
+                report = export_wiz.export_wiz(args)
+
+        self.assertEqual(report["exported"], 2)
+        self.assertEqual([item.args[2].doc_guid for item in export_doc_mock.call_args_list], ["doc-1", "doc-1", "doc-2"])
+        recover_mock.assert_called_once_with(args, initial_cdp, snapshot)
+        self.assertTrue(recovered_cdp.closed)
+
+    def test_second_session_loss_stops_and_preserves_remaining_checkpoint_items(self) -> None:
+        first_doc = make_doc("doc-1", "第一篇")
+        second_doc = make_doc("doc-2", "第二篇")
+        snapshot = make_snapshot(first_doc, second_doc)
+        initial_cdp = FakeCdp()
+        recovered_cdp = FakeCdp()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoint_file = root / "checkpoint.sqlite"
+            args = make_args(root / "output", str(checkpoint_file))
+            with (
+                patch.object(export_wiz, "connect_wiz_browser", return_value=(initial_cdp, None)),
+                patch.object(export_wiz, "wait_for_login_state", return_value=snapshot),
+                patch.object(
+                    export_wiz,
+                    "export_doc",
+                    side_effect=[export_wiz.WizPageSessionLost("stalled"), export_wiz.WizPageSessionLost("stalled")],
+                ) as export_doc_mock,
+                patch.object(export_wiz, "recover_wiz_page", return_value=(recovered_cdp, snapshot, None)),
+                patch.object(export_wiz, "emit"),
+                self.assertRaises(export_wiz.WizPageSessionUnrecoverable),
+            ):
+                export_wiz.export_wiz(args)
+
+            connection = sqlite3.connect(checkpoint_file)
+            try:
+                task_status = connection.execute("SELECT status FROM tasks WHERE task_id = ?", ("wiz-page-recovery",)).fetchone()[0]
+                item_statuses = dict(
+                    connection.execute("SELECT item_key, status FROM items WHERE task_id = ?", ("wiz-page-recovery",)).fetchall()
+                )
+            finally:
+                connection.close()
+
+        self.assertEqual([item.args[2].doc_guid for item in export_doc_mock.call_args_list], ["doc-1", "doc-1"])
+        self.assertEqual(task_status, "failed")
+        self.assertEqual(item_statuses["wiz:doc:doc-1"], "failed")
+        self.assertEqual(item_statuses["wiz:doc:doc-2"], "pending")
+
+    def test_recovery_rejects_a_different_wiz_account(self) -> None:
+        previous_cdp = Mock()
+        fresh_cdp = Mock()
+        expected = {"account": {"userGuid": "expected", "userId": "expected-id"}}
+        actual = {"account": {"userGuid": "different", "userId": "different-id"}}
+        args = make_args(Path("unused"))
+
+        with (
+            patch.object(export_wiz, "connect_wiz_browser", return_value=(fresh_cdp, None)),
+            patch.object(export_wiz, "wait_for_login_state", return_value=actual),
+            self.assertRaises(export_wiz.ExportError),
+        ):
+            export_wiz.recover_wiz_page(args, previous_cdp, expected)
+
+        previous_cdp.close.assert_called_once()
+        fresh_cdp.close.assert_called_once()
+
+    def test_failed_recovery_closes_a_browser_started_for_this_run(self) -> None:
+        previous_cdp = Mock()
+        fresh_cdp = Mock()
+        chrome_proc = Mock()
+        args = make_args(Path("unused"))
+        args.close_started_chrome = True
+
+        with (
+            patch.object(export_wiz, "connect_wiz_browser", return_value=(fresh_cdp, chrome_proc)),
+            patch.object(export_wiz, "wait_for_login_state", side_effect=export_wiz.ExportError("登录未就绪")),
+            self.assertRaises(export_wiz.ExportError),
+        ):
+            export_wiz.recover_wiz_page(args, previous_cdp, {"account": {"userGuid": "expected"}})
+
+        previous_cdp.close.assert_called_once()
+        fresh_cdp.close.assert_called_once()
+        chrome_proc.terminate.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wiz_retry_failed.py
+++ b/tests/test_wiz_retry_failed.py
@@ -1,12 +1,48 @@
+import argparse
+import sqlite3
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from plugins.wiz.backend.export_wiz import should_skip_existing_doc
+from plugins.wiz.backend import export_wiz
+from wandao_core.checkpoint import WandaoCheckpoint
+
+
+class FakeCdp:
+    def close(self) -> None:
+        pass
+
+
+def make_doc_snapshot() -> dict[str, object]:
+    return {
+        "account": {"userGuid": "account-guid", "userId": "account-id", "hasToken": True},
+        "kbs": [{"kbGuid": "kb", "kbServer": "https://example.invalid"}],
+        "docs": [{"kbGuid": "kb", "docGuid": "doc-1", "title": "图片失败的笔记", "category": "/", "type": "note"}],
+    }
+
+
+def make_args(output: Path, checkpoint_file: Path, *, retry_failed: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        output=str(output),
+        checkpoint_file=str(checkpoint_file),
+        checkpoint_task_id="wiz-retry-failed",
+        reset_checkpoint=False,
+        selected_doc_ids=[],
+        incremental=False,
+        resume=retry_failed,
+        retry_failed=retry_failed,
+        progress_every=100,
+        close_started_chrome=False,
+        request_delay=0,
+        request_jitter=0,
+    )
 
 
 class WizRetryFailedTests(unittest.TestCase):
     def test_retry_failed_does_not_skip_existing_markdown(self) -> None:
         self.assertFalse(
-            should_skip_existing_doc(
+            export_wiz.should_skip_existing_doc(
                 incremental=True,
                 path_exists=True,
                 retry_failed=True,
@@ -15,12 +51,102 @@ class WizRetryFailedTests(unittest.TestCase):
 
     def test_incremental_export_still_skips_existing_markdown_normally(self) -> None:
         self.assertTrue(
-            should_skip_existing_doc(
+            export_wiz.should_skip_existing_doc(
                 incremental=True,
                 path_exists=True,
                 retry_failed=False,
             )
         )
+
+    def test_image_failure_completes_document_and_is_not_retried_as_content(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoint_file = root / "checkpoint.sqlite"
+            args = make_args(root / "output", checkpoint_file)
+            with (
+                patch.object(export_wiz, "connect_wiz_browser", return_value=(FakeCdp(), None)),
+                patch.object(export_wiz, "wait_for_login_state", return_value=make_doc_snapshot()),
+                patch.object(export_wiz, "fetch_note_download", return_value={"html": '<p>正文<img src="https://images.example.invalid/fail.png"></p>'}),
+                patch.object(export_wiz.ResourceSaver, "fetch_external_base64", side_effect=export_wiz.ExportError("timed out")),
+                patch.object(export_wiz, "emit"),
+            ):
+                report = export_wiz.export_wiz(args)
+
+            self.assertEqual(report["exported"], 1)
+            self.assertEqual(report["failureCount"], 0)
+            self.assertEqual(report["outcome"], "partial")
+
+            connection = sqlite3.connect(checkpoint_file)
+            try:
+                item_status = connection.execute(
+                    "SELECT status FROM items WHERE task_id = ? AND item_key = ?",
+                    ("wiz-retry-failed", "wiz:doc:doc-1"),
+                ).fetchone()[0]
+                resource = connection.execute(
+                    "SELECT status, source FROM resources WHERE task_id = ?",
+                    ("wiz-retry-failed",),
+                ).fetchone()
+                task_status = connection.execute(
+                    "SELECT status FROM tasks WHERE task_id = ?",
+                    ("wiz-retry-failed",),
+                ).fetchone()[0]
+            finally:
+                connection.close()
+
+            self.assertEqual(item_status, "completed")
+            self.assertEqual(resource, ("failed", "https://images.example.invalid/fail.png"))
+            self.assertEqual(task_status, "completed")
+
+            retry_args = make_args(root / "output", checkpoint_file, retry_failed=True)
+            with (
+                patch.object(export_wiz, "connect_wiz_browser", return_value=(FakeCdp(), None)),
+                patch.object(export_wiz, "wait_for_login_state", return_value=make_doc_snapshot()),
+                patch.object(export_wiz, "export_doc") as export_doc,
+                patch.object(export_wiz, "emit"),
+            ):
+                retry_report = export_wiz.export_wiz(retry_args)
+
+        self.assertEqual(retry_report["total"], 0)
+        export_doc.assert_not_called()
+
+    def test_retry_failed_migrates_legacy_image_failure_with_existing_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoint_file = root / "checkpoint.sqlite"
+            output = root / "output"
+            doc = export_wiz.docs_from_snapshot(make_doc_snapshot())[0]
+            md_path = export_wiz.PathPlanner(output).markdown_path(doc)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text("# 图片失败的笔记\n\n正文\n", encoding="utf-8")
+            checkpoint = WandaoCheckpoint.open(checkpoint_file, "wiz-retry-failed", "wiz", "export")
+            try:
+                checkpoint.start_task({"source": export_wiz.WIZ_APP_URL, "outputDir": str(output)})
+                checkpoint.upsert_item("wiz:doc:doc-1", title=doc.title, source_id=doc.doc_guid)
+                checkpoint.fail_item("wiz:doc:doc-1", "1 个图片下载失败")
+                checkpoint.fail_task("1 个图片下载失败")
+            finally:
+                checkpoint.close()
+
+            with (
+                patch.object(export_wiz, "connect_wiz_browser", return_value=(FakeCdp(), None)),
+                patch.object(export_wiz, "wait_for_login_state", return_value=make_doc_snapshot()),
+                patch.object(export_wiz, "export_doc") as export_doc,
+                patch.object(export_wiz, "emit"),
+            ):
+                retry_report = export_wiz.export_wiz(make_args(output, checkpoint_file, retry_failed=True))
+
+            connection = sqlite3.connect(checkpoint_file)
+            try:
+                item_status = connection.execute(
+                    "SELECT status FROM items WHERE task_id = ? AND item_key = ?",
+                    ("wiz-retry-failed", "wiz:doc:doc-1"),
+                ).fetchone()[0]
+            finally:
+                connection.close()
+
+        self.assertEqual(retry_report["total"], 0)
+        self.assertEqual(item_status, "completed")
+        export_doc.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_wiz_retry_failed.py
+++ b/tests/test_wiz_retry_failed.py
@@ -1,0 +1,27 @@
+import unittest
+
+from plugins.wiz.backend.export_wiz import should_skip_existing_doc
+
+
+class WizRetryFailedTests(unittest.TestCase):
+    def test_retry_failed_does_not_skip_existing_markdown(self) -> None:
+        self.assertFalse(
+            should_skip_existing_doc(
+                incremental=True,
+                path_exists=True,
+                retry_failed=True,
+            )
+        )
+
+    def test_incremental_export_still_skips_existing_markdown_normally(self) -> None:
+        self.assertTrue(
+            should_skip_existing_doc(
+                incremental=True,
+                path_exists=True,
+                retry_failed=False,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_js/task_resume.test.js
+++ b/tests_js/task_resume.test.js
@@ -189,17 +189,19 @@ test('manifest-provider actions treat code 130 as stopped before the failure bra
   assert.match(handler, /if \(isStoppedResult\(result\)\) \{[\s\S]*finishProgress\('stopped',[\s\S]*\} else if \(result\.success\) \{/);
 });
 
-test('resource warnings are not converted into retry-failed document commands', () => {
+test('resource failures are retried when the provider supports failed-item retry', () => {
   const appJs = fs.readFileSync('wandao_electron/renderer/app.js', 'utf8');
   const canResume = appJs.slice(appJs.indexOf('function canResumeTask'), appJs.indexOf('function resumeTaskDisabledReason'));
   const resumeArgs = appJs.slice(appJs.indexOf('function resumeTaskArgs'), appJs.indexOf('async function performTaskHistoryLoad'));
   const resumeTaskHandler = appJs.slice(appJs.indexOf('async function resumeTask'), appJs.indexOf('function latestResumableTask'));
+  const resultCard = appJs.slice(appJs.indexOf('function renderTaskResultCard'), appJs.indexOf('async function handleTaskAction'));
 
-  assert.match(canResume, /taskDocumentFailureCount\(task\)/);
-  assert.doesNotMatch(canResume, /taskFailureCount\(task\)/);
-  assert.match(resumeArgs, /taskDocumentFailureCount\(task\)/);
-  assert.match(resumeTaskHandler, /const documentFailures = taskDocumentFailureCount\(task\)/);
-  assert.match(resumeTaskHandler, /失败文档，共 \$\{documentFailures\} 个/);
+  assert.match(canResume, /taskFailureCount\(task\)/);
+  assert.match(resumeArgs, /taskFailureCount\(task\)/);
+  assert.match(resumeTaskHandler, /const retryableFailures = taskFailureCount\(task\)/);
+  assert.match(resumeTaskHandler, /失败项，共 \$\{retryableFailures\} 个/);
+  assert.match(resultCard, /图片或附件未完成。\$\{canResume \? '可仅重试失败项。'/);
+  assert.doesNotMatch(resultCard, /不会把它们误作“失败文档”自动重试/);
 });
 
 test('resource diagnostics are not duplicated after reports are finalized', () => {

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -1063,7 +1063,7 @@ function canResumeTask(task) {
   if (status === 'running' || status === 'stopping') return false;
   if (status !== 'completed' && status !== 'partial') return true;
   const provider = TOOLS[task.providerId] || {};
-  return Boolean(providerRetryFailureArg(provider) && taskDocumentFailureCount(task) > 0);
+  return Boolean(providerRetryFailureArg(provider) && taskFailureCount(task) > 0);
 }
 
 function resumeTaskDisabledReason(task) {
@@ -1072,13 +1072,7 @@ function resumeTaskDisabledReason(task) {
   const status = taskDisplayStatus(task);
   if (status === 'running' || status === 'stopping') return '任务正在运行或停止中，不能重复启动。';
   if (status !== 'completed' && status !== 'partial') return '';
-  const documentFailures = taskDocumentFailureCount(task);
-  const resourceFailures = taskResourceFailureCount(task);
-  if (documentFailures <= 0) {
-    return resourceFailures > 0
-      ? `任务有 ${resourceFailures} 个资源警告，但当前不会将资源问题误作可重试文档；请打开报告处理。`
-      : '任务已完成且没有失败项。';
-  }
+  if (taskFailureCount(task) <= 0) return '任务已完成且没有失败项。';
   const provider = TOOLS[task.providerId] || {};
   if (!providerRetryFailureArg(provider)) return '该平台暂未声明失败项重试能力，请复制报告后重新执行或反馈给开发者。';
   return '';
@@ -1089,12 +1083,12 @@ function resumeTaskArgs(task) {
   const retryArg = providerRetryFailureArg(provider);
   const helper = window.WandaoTaskResume?.buildResumeArgs;
   if (typeof helper === 'function') {
-    return helper(task, retryArg, taskDocumentFailureCount(task), provider);
+    return helper(task, retryArg, taskFailureCount(task), provider);
   }
   const args = Array.isArray(task?.args) ? [...task.args] : [];
   const interrupted = ['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase());
   if ((interrupted || taskHasDeferredDocuments(task)) && retryArg) return args.filter((arg) => arg !== retryArg);
-  if (retryArg && taskDocumentFailureCount(task) > 0 && !args.includes(retryArg)) {
+  if (retryArg && taskFailureCount(task) > 0 && !args.includes(retryArg)) {
     args.push(retryArg);
   }
   return args;
@@ -1102,13 +1096,13 @@ function resumeTaskArgs(task) {
 
 function taskResumeActionLabel(task) {
   const status = taskDisplayStatus(task);
-  const documentFailures = taskDocumentFailureCount(task);
+  const retryableFailures = taskFailureCount(task);
   if (taskHasDeferredDocuments(task)) {
     const count = (task.report?.deferred || task.resultData?.deferred || []).length;
     return `继续任务（${count} 篇待处理）`;
   }
-  if ((status === 'completed' || status === 'partial') && documentFailures > 0) {
-    return `重试失败文档${documentFailures > 1 ? `（${documentFailures}）` : ''}`;
+  if ((status === 'completed' || status === 'partial') && retryableFailures > 0) {
+    return `重试失败项${retryableFailures > 1 ? `（${retryableFailures}）` : ''}`;
   }
   return '继续任务';
 }
@@ -1432,7 +1426,7 @@ function renderTaskResultCard(task = latestFinishedTask()) {
   const canResume = canResumeTask(task);
   const resumeReason = resumeTaskDisabledReason(task);
   const resourceNotice = resourceFailures > 0
-    ? `<p class="task-result-resource-note">资源警告：${resourceFailures} 个图片或附件未完成。不会把它们误作“失败文档”自动重试，请打开报告处理。</p>`
+    ? `<p class="task-result-resource-note">资源警告：${resourceFailures} 个图片或附件未完成。${canResume ? '可仅重试失败项。' : '请打开报告处理。'}</p>`
     : '';
   const documentNotice = documentFailures > 0
     ? `<p class="task-result-document-note">文档失败：${documentFailures} 个。${canResume ? '可仅重试失败文档。' : '请查看报告后重新执行。'}</p>`
@@ -1677,19 +1671,19 @@ async function resumeTask(task) {
   const args = resumeTaskArgs(task);
   const provider = TOOLS[task.providerId] || {};
   const retryArg = providerRetryFailureArg(provider);
-  const documentFailures = taskDocumentFailureCount(task);
+  const retryableFailures = taskFailureCount(task);
   const shouldRetry = window.WandaoTaskResume?.shouldRetryFailureItems;
   const retryingFailures = typeof shouldRetry === 'function'
-    ? shouldRetry(task, retryArg, documentFailures, provider)
+    ? shouldRetry(task, retryArg, retryableFailures, provider)
     : Boolean(
       retryArg
       && !['stopped', 'interrupted'].includes(String(task?.status || '').toLowerCase())
       && !taskHasDeferredDocuments(task)
-      && documentFailures > 0
+      && retryableFailures > 0
       && args.includes(retryArg)
     );
   const confirmDetail = retryingFailures
-    ? `将只重试上次报告中的失败文档，共 ${documentFailures} 个。`
+    ? `将只重试上次报告中的失败项，共 ${retryableFailures} 个。`
     : '将按历史命令重新执行，适合增量任务或中断后继续。';
   if (!confirm(`继续任务：${task.title || task.script}\n${confirmDetail}\n\n确认继续吗？`)) {
     return;


### PR DESCRIPTION
## 变更
- 将图片资源失败与正文失败分开记录，正文已落盘时不再进入“重试失败项”。
- 兼容旧检查点：已有 Markdown 的历史资源失败自动修正为已完成。
- 图片资源记录会移除查询参数，避免保存潜在的凭证或追踪参数。
- 保留有限时的页面恢复、正文读取和图片下载兜底。

## 验证
- `python scripts/quality_check.py`