### PR TITLE
feat(notice): 将赞助信息迁移为独立分类

### DIFF
--- a/docs/announcements/fluxion-ai-sponsor.md
+++ b/docs/announcements/fluxion-ai-sponsor.md
@@ -1,0 +1,15 @@
+# Fluxion AI · 为 AI 辅助学习提供支持
+
+[![Fluxion AI：统一接入与管理全球主流 AI 模型；多线路动态路由、价格与用量透明。兑换码 WANNENGDAO 可获得 3 美元 API 额度](../images/fluxion-ai-sponsor-banner.png)](https://fluxionai.space/register?source=github&campaign=wandao)
+
+> 本区为赞助信息。万能导始终完全开源免费，AI 辅助学习不绑定任何模型或 API 服务。
+
+[**Fluxion AI**](https://fluxionai.space/register?source=github&campaign=wandao) 面向个人开发者、技术团队与企业，通过统一 API 接入全球主流 AI 模型，并以多线路调度提升可用性；模型质量、使用情况和费用可在一个平台集中管理。
+
+灵活的线路与计费方案带来更具竞争力的调用成本，实时价格和每笔消费均可查阅。
+
+## 兑换福利
+
+登录后在工作台「兑换」输入兑换码 `WANNENGDAO`，即可获得 $3 API 额度。
+
+[访问 Fluxion AI](https://fluxionai.space/register?source=github&campaign=wandao)

--- a/docs/tutorial-announcements.json
+++ b/docs/tutorial-announcements.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-29",
+  "updatedAt": "2026-08-30",
   "repository": "https://github.com/tllovesxs/wandao",
   "items": [
     {
@@ -32,6 +32,20 @@
         "提示词"
       ],
       "path": "prompts/项目学习导师提示词.md"
+    },
+    {
+      "id": "fluxion-ai-sponsor",
+      "type": "sponsor",
+      "title": "Fluxion AI · 为 AI 辅助学习提供支持",
+      "summary": "统一 API 接入和管理全球主流 AI 模型，支持多线路调度、用量与费用集中管理。",
+      "date": "2026-08-30",
+      "badge": "赞助商",
+      "tags": [
+        "赞助商",
+        "AI 辅助学习",
+        "API"
+      ],
+      "path": "docs/announcements/fluxion-ai-sponsor.md"
     },
     {
       "id": "wandao-ai-project-learning",

--- a/docs/使用教程.md
+++ b/docs/使用教程.md
@@ -17,7 +17,7 @@ npm start
 
 桌面端左侧是工作台入口。先进入“平台中心”，选择平台后再选择导出、导入或查看教程。进入具体操作页后，按界面提示填写链接、登录、读取目录并执行任务。
 
-侧边栏的“教程公告”会从 GitHub 读取 `docs/tutorial-announcements.json`，并展示置顶公告、最新公告、历史公告和教程文档。维护公告时，在 GitHub 修改这个 JSON 的 `items` 列表，再新增或更新对应的 Markdown 文件即可；用户点击“刷新公告”后会读取最新内容。每条内容建议包含 `id`、`type`、`title`、`summary`、`date`、`tags` 和 `path`，其中 `type` 可填写 `announcement` 或 `tutorial`，需要置顶时设置 `pinned: true`。
+侧边栏的“教程公告”会从 GitHub 读取 `docs/tutorial-announcements.json`，并按“公告”“赞助商”“教程”分组展示 Markdown 文档。维护内容时，在 GitHub 修改这个 JSON 的 `items` 列表，再新增或更新对应的 Markdown 文件即可；用户点击“刷新公告”后会读取最新内容。每条内容建议包含 `id`、`type`、`title`、`summary`、`date`、`tags` 和 `path`，其中 `type` 可填写 `announcement`、`sponsor` 或 `tutorial`，需要置顶时设置 `pinned: true`。
 
 顶部提供两个常用按钮：
 

--- a/scripts/validate_providers.py
+++ b/scripts/validate_providers.py
@@ -36,7 +36,7 @@ TRUST_LEVELS = {"official", "community", "local", "experimental", "guide"}
 STATUSES = {"stable", "beta", "experimental"}
 FIELD_TYPES = {"text", "password", "directory", "file", "checkbox", "select", "number", "textarea", "notice"}
 ACTION_KINDS = {"login", "scan", "export", "import", "plan", "check", "custom"}
-NOTICE_TYPES = {"announcement", "tutorial"}
+NOTICE_TYPES = {"announcement", "sponsor", "tutorial"}
 TOC_ADAPTERS = {"yinxiang-notebooks", "zsxq-column-groups"}
 
 
@@ -420,7 +420,7 @@ def validate_notice_manifest(repo_root: Path) -> list[ValidationIssue]:
         else:
             seen.add(item_id)
         if item.get("type") not in NOTICE_TYPES:
-            issues.append(ValidationIssue(path, f"items[{index}].type 必须是 announcement 或 tutorial"))
+            issues.append(ValidationIssue(path, f"items[{index}].type 必须是 announcement、sponsor 或 tutorial"))
         for key in ("title", "summary", "date", "path"):
             if not isinstance(item.get(key), str) or not item.get(key, "").strip():
                 issues.append(ValidationIssue(path, f"items[{index}].{key} 必须是非空字符串"))

--- a/tests/test_notice_center.py
+++ b/tests/test_notice_center.py
@@ -15,16 +15,26 @@ class NoticeCenterTests(unittest.TestCase):
 
         self.assertEqual(
             [item["id"] for item in items],
-            ["provider-co-creation-invite", "project-learning-ai-prompt", "wandao-ai-project-learning"],
+            ["provider-co-creation-invite", "project-learning-ai-prompt", "fluxion-ai-sponsor", "wandao-ai-project-learning"],
         )
         self.assertTrue(items[0]["pinned"])
         self.assertEqual(items[0]["type"], "announcement")
         self.assertEqual(items[1]["type"], "announcement")
         self.assertEqual(items[1]["badge"], "AI 学习")
-        self.assertEqual(items[2]["type"], "tutorial")
-        self.assertEqual(items[2]["title"], "用万能导 + Codex 辅助学习代码项目")
-        self.assertEqual(items[2]["date"], "2026-08-29")
-        self.assertEqual(items[2]["path"], "docs/tutorials/wandao-ai-project-learning.md")
+        self.assertEqual(items[2]["type"], "sponsor")
+        self.assertEqual(items[2]["badge"], "赞助商")
+        self.assertEqual(items[2]["path"], "docs/announcements/fluxion-ai-sponsor.md")
+        self.assertEqual(items[3]["type"], "tutorial")
+        self.assertEqual(items[3]["title"], "用万能导 + Codex 辅助学习代码项目")
+        self.assertEqual(items[3]["date"], "2026-08-29")
+        self.assertEqual(items[3]["path"], "docs/tutorials/wandao-ai-project-learning.md")
+
+    def test_fluxion_sponsor_is_a_standalone_markdown_notice(self) -> None:
+        sponsor = (REPO_ROOT / "docs" / "announcements" / "fluxion-ai-sponsor.md").read_text(encoding="utf-8")
+        self.assertIn("# Fluxion AI · 为 AI 辅助学习提供支持", sponsor)
+        self.assertIn("../images/fluxion-ai-sponsor-banner.png", sponsor)
+        self.assertIn("WANNENGDAO", sponsor)
+        self.assertIn("https://fluxionai.space/register?source=github&campaign=wandao", sponsor)
 
     def test_ai_project_learning_tutorial_keeps_expected_structure_and_original_images(self) -> None:
         tutorial = (REPO_ROOT / "docs" / "tutorials" / "wandao-ai-project-learning.md").read_text(encoding="utf-8")

--- a/tests_js/fluxion_sponsor.test.js
+++ b/tests_js/fluxion_sponsor.test.js
@@ -7,6 +7,8 @@ const vm = require('node:vm');
 const repoRoot = path.resolve(__dirname, '..');
 const appSource = fs.readFileSync(path.join(repoRoot, 'wandao_electron', 'renderer', 'app.js'), 'utf8');
 const stylesSource = fs.readFileSync(path.join(repoRoot, 'wandao_electron', 'renderer', 'styles.css'), 'utf8');
+const noticeManifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'docs', 'tutorial-announcements.json'), 'utf8'));
+const sponsorArticle = fs.readFileSync(path.join(repoRoot, 'docs', 'announcements', 'fluxion-ai-sponsor.md'), 'utf8');
 
 function sourceBetween(start, end, source = appSource) {
   const startIndex = source.indexOf(start);
@@ -62,15 +64,22 @@ test('all export completion entry points insert sponsor logs before structured d
   }
 });
 
-test('sponsor content is always rendered below the notice layout with safe rich log nodes', () => {
+test('sponsor content is a dedicated notice category instead of a footer on every document', () => {
   const noticePage = sourceBetween('function renderNoticeCenterPage() {', '\nfunction renderProviderModeSwitcher(');
-  assert.ok(noticePage.indexOf('</section>\n    ${renderFluxionSponsor()}') > noticePage.indexOf('class="notice-layout"'));
-  assert.match(appSource, /<details class="notice-sponsor" open>/);
-  assert.match(appSource, /Fluxion AI · 为 AI 辅助学习提供支持/);
-  assert.match(appSource, /data-notice-image=/);
+  const sponsor = noticeManifest.items.find((item) => item.id === 'fluxion-ai-sponsor');
+
+  assert.ok(noticePage.indexOf("renderNoticeListSection('赞助商', groups.sponsors") > noticePage.indexOf("renderNoticeListSection('公告', groups.announcements"));
+  assert.ok(noticePage.indexOf("renderNoticeListSection('教程', groups.tutorials") > noticePage.indexOf("renderNoticeListSection('赞助商', groups.sponsors"));
+  assert.doesNotMatch(noticePage, /renderFluxionSponsor/);
+  assert.doesNotMatch(appSource, /function renderFluxionSponsor/);
+  assert.doesNotMatch(stylesSource, /\.notice-sponsor\s*\{/);
+  assert.equal(sponsor?.type, 'sponsor');
+  assert.equal(sponsor?.path, 'docs/announcements/fluxion-ai-sponsor.md');
+  assert.match(sponsorArticle, /Fluxion AI · 为 AI 辅助学习提供支持/);
+  assert.match(sponsorArticle, /fluxion-ai-sponsor-banner\.png/);
+  assert.match(sponsorArticle, /WANNENGDAO/);
   assert.match(appSource, /presentation === 'fluxion-register'/);
   assert.match(appSource, /presentation === 'fluxion-redeem'/);
-  assert.match(stylesSource, /\.notice-sponsor\s*\{/);
   assert.match(stylesSource, /\.log-entry \.log-external-link\s*\{/);
 });
 

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -124,6 +124,20 @@ test('notice markdown resolves relative images to the safe GitHub docs scope', (
   assert.doesNotMatch(outside, /<img/);
 });
 
+test('sponsor notice keeps its tracked link and banner through Markdown rendering', () => {
+  const sponsorMarkdown = fs.readFileSync(path.join(repoRoot, 'docs', 'announcements', 'fluxion-ai-sponsor.md'), 'utf8');
+  const base = 'https://raw.githubusercontent.com/tllovesxs/wandao/main/docs/announcements/fluxion-ai-sponsor.md';
+  const html = markdownToHtml(sponsorMarkdown, {
+    resolveImageSource: (source) => new URL(source, base).href,
+    allowRemoteImage: context.__safeNoticeImageUrl,
+    remoteImageAttribute: 'data-notice-image'
+  });
+
+  assert.match(html, /href="https:\/\/fluxionai\.space\/register\?source=github&amp;campaign=wandao" data-external-link="true"/);
+  assert.match(html, /data-notice-image="https:\/\/raw\.githubusercontent\.com\/tllovesxs\/wandao\/main\/docs\/images\/fluxion-ai-sponsor-banner\.png"/);
+  assert.match(html, /兑换码 <code>WANNENGDAO<\/code>/);
+});
+
 test('guide markdown only accepts the pinned Wandao Feishu screenshot URLs', () => {
   const pinned = 'https://raw.githubusercontent.com/tllovesxs/wandao/82c027b054d9ece8449af30d79600814eb823e46/plugins/feishu/providers/feishu-import/images/20.png';
   const html = markdownToHtml(`![飞书截图](${pinned})`);

--- a/wandao_electron/renderer/app.js
+++ b/wandao_electron/renderer/app.js
@@ -13,10 +13,8 @@ const GITHUB_REPO_URL = 'https://github.com/tllovesxs/wandao';
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/tllovesxs/wandao/main/';
 const GITHUB_BLOB_BASE = 'https://github.com/tllovesxs/wandao/blob/main/';
 const NOTICE_CENTER_MANIFEST_URL = `${GITHUB_RAW_BASE}docs/tutorial-announcements.json`;
-const FLUXION_SITE_URL = 'https://fluxionai.space/';
 const FLUXION_REGISTER_URL = 'https://fluxionai.space/register?source=github&campaign=wandao';
 const FLUXION_REDEEM_MESSAGE = '兑换码：WANNENGDAO — 登录后在工作台「兑换」输入，即可获得 $3 API 额度。';
-const FLUXION_SPONSOR_BANNER_URL = `${GITHUB_RAW_BASE}docs/images/fluxion-ai-sponsor-banner.png`;
 const DEFAULT_BROWSER_DOWNLOAD_URL = 'https://www.google.com/chrome/';
 let pluginCatalogState = { status: 'idle', plugins: [], query: '', error: '', offline: false, experimentalError: '', updatedAt: '' };
 let pluginCatalogRequestId = 0;
@@ -25,7 +23,7 @@ let pluginBulkUpdateRunning = false;
 let customPluginMessageCleanup = null;
 const FALLBACK_NOTICE_CENTER = {
   version: 1,
-  updatedAt: '2026-07-28',
+  updatedAt: '2026-08-30',
   repository: GITHUB_REPO_URL,
   items: [
     {
@@ -51,6 +49,18 @@ const FALLBACK_NOTICE_CENTER = {
       tags: ['公告', 'AI', '项目学习', '提示词'],
       path: 'prompts/项目学习导师提示词.md',
       body: '# AI 辅助学习：项目学习导师提示词\n\n把万能导导出的教学文档和源码项目放在一起，再把项目学习导师提示词发给 AI，可以让 AI 结合真实代码和课程资料讲解项目。\n\n## 使用方式\n\n1. 用万能导导出你有权限访问的教学文档。\n2. 把 Markdown 文档放到源码项目旁边。\n3. 用 AI 编程工具打开整个项目目录。\n4. 复制 `prompts/项目学习导师提示词.md` 的内容给 AI。\n5. 按章节、功能或技术点继续提问。'
+    },
+    {
+      id: 'fluxion-ai-sponsor',
+      type: 'sponsor',
+      pinned: false,
+      title: 'Fluxion AI · 为 AI 辅助学习提供支持',
+      summary: '统一 API 接入和管理全球主流 AI 模型，支持多线路调度、用量与费用集中管理。',
+      date: '2026-08-30',
+      badge: '赞助商',
+      tags: ['赞助商', 'AI 辅助学习', 'API'],
+      path: 'docs/announcements/fluxion-ai-sponsor.md',
+      body: '# Fluxion AI · 为 AI 辅助学习提供支持\n\n[![Fluxion AI：统一接入与管理全球主流 AI 模型；多线路动态路由、价格与用量透明。兑换码 WANNENGDAO 可获得 3 美元 API 额度](../images/fluxion-ai-sponsor-banner.png)](https://fluxionai.space/register?source=github&campaign=wandao)\n\n> 本区为赞助信息。万能导始终完全开源免费，AI 辅助学习不绑定任何模型或 API 服务。\n\n[**Fluxion AI**](https://fluxionai.space/register?source=github&campaign=wandao) 面向个人开发者、技术团队与企业，通过统一 API 接入全球主流 AI 模型，并以多线路调度提升可用性；模型质量、使用情况和费用可在一个平台集中管理。\n\n灵活的线路与计费方案带来更具竞争力的调用成本，实时价格和每笔消费均可查阅。\n\n## 兑换福利\n\n登录后在工作台「兑换」输入兑换码 `WANNENGDAO`，即可获得 $3 API 额度。\n\n[访问 Fluxion AI](https://fluxionai.space/register?source=github&campaign=wandao)'
     }
   ]
 };
@@ -2284,20 +2294,23 @@ function normalizeNoticeManifest(raw) {
   return {
     ...manifest,
     items: items
-      .map((item, index) => ({
-        id: String(item.id || `notice-${index}`),
-        type: item.type === 'tutorial' ? 'tutorial' : 'announcement',
-        pinned: Boolean(item.pinned),
-        title: String(item.title || '未命名内容'),
-        summary: String(item.summary || ''),
-        date: String(item.date || manifest.updatedAt || ''),
-        badge: String(item.badge || ''),
-        tags: Array.isArray(item.tags) ? item.tags.map(String) : [],
-        path: item.path ? String(item.path) : '',
-        url: item.url ? String(item.url) : '',
-        htmlUrl: item.htmlUrl ? String(item.htmlUrl) : '',
-        body: item.body ? String(item.body) : ''
-      }))
+      .map((item, index) => {
+        const noticeType = String(item.type || '');
+        return {
+          id: String(item.id || `notice-${index}`),
+          type: noticeType === 'tutorial' || noticeType === 'sponsor' ? noticeType : 'announcement',
+          pinned: Boolean(item.pinned),
+          title: String(item.title || '未命名内容'),
+          summary: String(item.summary || ''),
+          date: String(item.date || manifest.updatedAt || ''),
+          badge: String(item.badge || ''),
+          tags: Array.isArray(item.tags) ? item.tags.map(String) : [],
+          path: item.path ? String(item.path) : '',
+          url: item.url ? String(item.url) : '',
+          htmlUrl: item.htmlUrl ? String(item.htmlUrl) : '',
+          body: item.body ? String(item.body) : ''
+        };
+      })
       .sort((a, b) => {
         if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
         return String(b.date).localeCompare(String(a.date)) || a.title.localeCompare(b.title, 'zh-Hans-CN');
@@ -2310,14 +2323,15 @@ function noticeItems() {
 }
 
 function noticeGroups(items = noticeItems()) {
-  const announcements = items.filter((item) => item.type !== 'tutorial');
+  const announcements = items.filter((item) => item.type === 'announcement');
+  const sponsors = items.filter((item) => item.type === 'sponsor');
   const tutorials = items.filter((item) => item.type === 'tutorial');
-  return { announcements, tutorials };
+  return { announcements, sponsors, tutorials };
 }
 
 function defaultNoticeId(items = noticeItems()) {
   const groups = noticeGroups(items);
-  return groups.announcements[0]?.id || groups.tutorials[0]?.id || items[0]?.id || '';
+  return groups.announcements[0]?.id || groups.tutorials[0]?.id || groups.sponsors[0]?.id || items[0]?.id || '';
 }
 
 async function readRemoteText(url) {
@@ -2403,6 +2417,7 @@ async function loadNoticeCenter(force = false) {
 function noticeKindLabel(item) {
   if (item.pinned) return '置顶公告';
   if (item.type === 'tutorial') return '教程';
+  if (item.type === 'sponsor') return item.badge || '赞助商';
   return item.badge || '公告';
 }
 
@@ -3029,20 +3044,6 @@ async function hydrateNoticeImages(container) {
   await Promise.all(Array.from({ length: workerCount }, () => loadNext()));
 }
 
-function renderFluxionSponsor() {
-  return `
-    <details class="notice-sponsor" open>
-      <summary><strong>Fluxion AI · 为 AI 辅助学习提供支持</strong></summary>
-      <a class="notice-sponsor-banner-link" href="${escapeHtml(FLUXION_SITE_URL)}" data-external-link="true">
-        <img class="notice-sponsor-banner" alt="Fluxion AI：统一接入与管理全球主流 AI 模型；多线路动态路由、价格与用量透明。兑换码 WANNENGDAO 可获得 3 美元 API 额度" data-notice-image="${escapeHtml(FLUXION_SPONSOR_BANNER_URL)}" loading="lazy">
-      </a>
-      <blockquote>本区为赞助信息。万能导始终完全开源免费，AI 辅助学习不绑定任何模型或 API 服务。</blockquote>
-      <p><a href="${escapeHtml(FLUXION_SITE_URL)}" data-external-link="true"><strong>Fluxion AI</strong></a> 面向个人开发者、技术团队与企业，通过统一 API 接入全球主流 AI 模型，并以多线路调度提升可用性；模型质量、使用情况和费用可在一个平台集中管理。</p>
-      <p>灵活的线路与计费方案带来更具竞争力的调用成本，实时价格和每笔消费均可查阅。</p>
-    </details>
-  `;
-}
-
 function renderNoticeDocBody(selected) {
   const selectedId = selected?.id || '';
   const bodyMatchesSelection = noticeCenterState.selectedBodyId === selectedId;
@@ -3118,6 +3119,7 @@ function renderNoticeCenterPage() {
     <section class="notice-layout">
       <aside class="notice-list">
         ${renderNoticeListSection('公告', groups.announcements, '暂无公告。')}
+        ${renderNoticeListSection('赞助商', groups.sponsors, '暂无赞助商信息。')}
         ${renderNoticeListSection('教程', groups.tutorials, '暂无教程。')}
       </aside>
       <article class="notice-document">
@@ -3139,7 +3141,6 @@ function renderNoticeCenterPage() {
         </div>
       </article>
     </section>
-    ${renderFluxionSponsor()}
   `;
   bindNoticeCenterActions(contentArea);
   hydrateNoticeImages(contentArea);

--- a/wandao_electron/renderer/styles.css
+++ b/wandao_electron/renderer/styles.css
@@ -2257,50 +2257,6 @@ button,
   background: transparent;
 }
 
-.notice-sponsor {
-  margin-top: 16px;
-  padding: 18px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface-raise);
-  color: var(--text-2);
-}
-
-.notice-sponsor summary {
-  cursor: pointer;
-  color: var(--text);
-  font-size: 16px;
-  user-select: none;
-}
-
-.notice-sponsor-banner-link {
-  display: block;
-  margin-top: 14px;
-  border-radius: var(--r-md);
-  overflow: hidden;
-}
-
-.notice-sponsor-banner {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.notice-sponsor blockquote {
-  margin: 12px 0;
-  padding: 8px 12px;
-  border-left: 4px solid var(--border-strong);
-  color: var(--text-2);
-}
-
-.notice-sponsor p + p {
-  margin-top: 10px;
-}
-
-.notice-sponsor a {
-  color: var(--brand-pressed);
-}
-
 .notice-doc-loading,
 .notice-doc-empty {
   min-height: 280px;
@@ -2745,8 +2701,12 @@ button,
     padding-left: 8px;
   }
 
-  .notice-sponsor {
-    padding: 14px;
+  .notice-list-section:nth-child(3) {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+    padding-top: 12px;
+    padding-left: 0;
   }
 
   .browser-option {


### PR DESCRIPTION
## 改动
- 移除教程公告页底部对每篇文档重复展示的赞助横幅。
- 新增“赞助商”独立分类，并将 Fluxion AI 横幅、原有文案、跳转链接与兑换码迁移为单篇 Markdown。
- 补齐公告类型校验、离线回退内容、响应式列表布局和维护文档。

## 验证
- `node --check wandao_electron/renderer/app.js`
- `node --test tests_js/fluxion_sponsor.test.js tests_js/guide_markdown.test.js`
- `python scripts/validate_providers.py`
- `python -m unittest tests.test_notice_center`