### PR TITLE
fix(feishu): retry failed resources and flag incomplete docs

### DIFF
--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1976,6 +1976,7 @@ async (fallbackTitle) => {
       tocRecoveryAttempts: recoveryAttempts,
       tocRecoveryMissing: recoveryMissing,
       tocRecoveryLimited: recoveryLimited,
+      incomplete: recoveryMissing > 0 || recoveryLimited,
     };
   }
 
@@ -2030,7 +2031,11 @@ async (fallbackTitle) => {
   // reaching the bottom of the content scroller. A clean bottom stop means the
   // document was fully collected; hitting the ceiling by itself used to cause
   // false "内容可能不完整" reports on fully-exported docs.
-  if (collected.hitIterationCeiling && !collected.reachedBottom) result.incomplete = true;
+  if (
+    (collected.hitIterationCeiling && !collected.reachedBottom)
+    || collected.tocRecoveryMissing > 0
+    || collected.tocRecoveryLimited
+  ) result.incomplete = true;
   return result;
 }
 """
@@ -2898,7 +2903,12 @@ def export_wiki(args: argparse.Namespace) -> dict[str, Any]:
             if checkpoint and getattr(args, "resume", False) and not args.update_existing and checkpoint.item_status(item_key) == "completed":
                 skipped += 1
                 continue
-            if args.incremental and token in existing and not args.update_existing:
+            if (
+                args.incremental
+                and token in existing
+                and not args.update_existing
+                and not getattr(args, "retry_failed", False)
+            ):
                 if checkpoint:
                     checkpoint.complete_item(item_key, local_path=str(md_path), metadata={"doc": doc, "skippedExisting": True})
                 skipped += 1

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_feishu_session_and_markdown.py
+++ b/tests/test_feishu_session_and_markdown.py
@@ -667,6 +667,11 @@ class FakeCheckpoint:
         self.closed = True
 
 
+class FailedCheckpoint(FakeCheckpoint):
+    def item_status(self, _key: str) -> str:
+        return "failed"
+
+
 class FeishuImageLocalizationTests(unittest.TestCase):
     def test_download_openapi_media_uses_local_extension_and_bearer_token(self) -> None:
         class FakeResponse:
@@ -1016,6 +1021,77 @@ class FeishuRelativeResourceReportingTests(unittest.TestCase):
         self.assertEqual(checkpoint.failed_tasks[0][1], "failed")
         self.assertEqual(checkpoint.completed_tasks, [])
         self.assertTrue(checkpoint.closed)
+
+    def test_retry_failed_reprocesses_existing_markdown_in_incremental_mode(self) -> None:
+        node = {
+            "wiki_token": "wiki-token",
+            "parent_wiki_token": "",
+            "title": "README.md",
+            "obj_token": "file-token",
+            "obj_type": 12,
+            "file_type": "md",
+            "has_child": False,
+            "sort_id": 1,
+            "url": ENTRY_URL,
+        }
+        tree = {
+            "spaceId": "space-id",
+            "space": {"space_name": "Knowledge base"},
+            "rootList": ["wiki-token"],
+            "childMap": {},
+            "nodes": {"wiki-token": node},
+        }
+        extracted = {
+            "title": "README.md",
+            "markdown": "# README\n\n正文\n",
+            "images": [],
+            "renderer": "markdown_file",
+        }
+        checkpoint = FailedCheckpoint()
+        cdp = FakeSessionCdp()
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            existing_path = output / "README.md"
+            existing_path.write_text("旧内容\n", encoding="utf-8")
+            args = argparse.Namespace(
+                wiki_url=ENTRY_URL,
+                output=str(output),
+                wait_login=False,
+                selected_doc_ids=None,
+                incremental=True,
+                update_existing=False,
+                resume=True,
+                retry_failed=True,
+                download_timeout=5,
+                keep_remote_images=True,
+                progress_every=1,
+                request_delay=0,
+                request_jitter=0,
+                close_started_chrome=False,
+                stop_event=None,
+                log_callback=None,
+            )
+            with (
+                mock.patch.object(feishu, "connect_wiki_browser", return_value=(cdp, None)),
+                mock.patch.object(feishu, "prepare_entry_session", return_value={}),
+                mock.patch.object(feishu, "load_wiki_tree", return_value=tree),
+                mock.patch.object(feishu, "fetch_doc_markdown", return_value=extracted),
+                mock.patch.object(
+                    feishu,
+                    "localize_images",
+                    return_value=(extracted["markdown"], 0, []),
+                ),
+                mock.patch.object(feishu, "scan_exported_docs", return_value={"wiki-token": existing_path}),
+                mock.patch.object(feishu, "open_checkpoint_from_args", return_value=checkpoint),
+                mock.patch.object(feishu, "emit"),
+            ):
+                report = feishu.export_wiki(args)
+
+        self.assertEqual(report["exportedDocs"], 1)
+        self.assertEqual(report["skippedDocs"], 0)
+        self.assertEqual(report["outcome"], "completed")
+        self.assertEqual(len(checkpoint.completed_items), 1)
 
 
 if __name__ == "__main__":

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -326,6 +326,46 @@ test('collectFeishuDocBlocks recovers a missing heading through a TOC anchor', a
   assert.equal(result.tocRecoveryMissing, 0);
 });
 
+test('collectFeishuDocBlocks marks unresolved TOC content as incomplete', async () => {
+  const api = loadScrollApi();
+  const { document } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="root-render-unit-container"><div class="render-unit-wrapper"></div></div>
+    </div>
+    <a id="missing-anchor" href="#missing">Missing heading</a>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  const anchor = document.querySelector('#missing-anchor');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => 400 });
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => { scrollTop = Math.min(Math.max(value, 0), 200); },
+  });
+  const first = document.createElement('div');
+  first.setAttribute('data-block-type', 'paragraph');
+  first.setAttribute('data-block-id', 'first');
+  first.textContent = 'first';
+  wrapper.appendChild(first);
+
+  const result = await api.collectFeishuDocBlocks({
+    root: document.querySelector('.root-render-unit-container'),
+    scroller,
+    document,
+    sleep: async () => {},
+    currentBlocks: () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type')),
+    renderBlock: (el) => el.textContent || '',
+    recoveryAnchors: [{ element: anchor, text: 'Missing heading', href: '#missing' }],
+    maxIterations: 20,
+  });
+
+  assert.equal(result.tocRecoveryMissing, 1);
+  assert.equal(result.incomplete, true);
+});
+
 test('resolveFeishuDocScroller skips scrollbar chrome that cannot scroll', () => {
   const api = loadScrollApi();
   const { document, window } = parseHTML(`<!doctype html><html><body>


### PR DESCRIPTION
## Summary

- Retry failed Feishu resources even when the Markdown file already exists in incremental mode.
- Mark documents incomplete when TOC recovery still has unresolved content.
- Bump the Feishu plugin version to 1.0.12.

## Validation

- py -m unittest tests.test_feishu_session_and_markdown -v
- node --test tests_js/feishu_converter_scroll.test.js
- py scripts/quality_check.py
- Full local quality checks passed.

Fixes the Feishu export behavior where a partial document or failed image retry could be reported as completed.