### PR TITLE
fix(feishu): export long documents through API and adaptive scrolling

### DIFF
--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -672,12 +672,49 @@ def _feishu_docx_code_span(text: str) -> str:
     return f"{delimiter}{text}{delimiter}"
 
 
-def feishu_docx_elements_to_markdown(elements: list[dict[str, Any]] | None) -> str:
+def _feishu_docx_unknown_inline_text(element: Any) -> str:
+    """Keep readable fields from a newer Feishu inline element."""
+
+    chunks: list[str] = []
+    seen: set[str] = set()
+    text_keys = {"content", "text", "title", "name", "description", "user_name", "display_name"}
+    ignored_keys = {"token", "url", "id", "block_id", "obj_token"}
+
+    def add(value: Any) -> None:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            chunks.append(text)
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key in ignored_keys:
+                    continue
+                if key in text_keys and isinstance(child, str):
+                    add(child)
+                elif isinstance(child, (dict, list)):
+                    visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(element)
+    return " ".join(chunks) or "<!-- 飞书内联元素未转换 -->"
+
+
+def feishu_docx_elements_to_markdown(
+    elements: list[dict[str, Any]] | None,
+    unsupported_inline: list[str] | None = None,
+) -> str:
     parts: list[str] = []
     for element in elements or []:
         if not isinstance(element, dict) or not isinstance(element.get("text_run"), dict):
             keys = ", ".join(sorted(element.keys())) if isinstance(element, dict) else type(element).__name__
-            raise FeishuOpenAPIBlocksUnsupported(f"文档含有暂未转换的内联元素：{keys}")
+            if unsupported_inline is not None:
+                unsupported_inline.append(keys)
+            parts.append(_feishu_docx_unknown_inline_text(element))
+            continue
         text_run = element["text_run"]
         text = str(text_run.get("content") or "")
         style = text_run.get("text_element_style")
@@ -737,6 +774,7 @@ def _feishu_docx_block_text(
     host: str,
     images: list[str],
     unsupported: list[int] | None = None,
+    unsupported_inline: list[str] | None = None,
 ) -> str:
     try:
         block_type = int(block.get("block_type"))
@@ -755,7 +793,9 @@ def _feishu_docx_block_text(
         image = block.get("image") if isinstance(block.get("image"), dict) else {}
         token = str(image.get("token") or "").strip()
         if not token:
-            raise FeishuOpenAPIBlocksUnsupported("图片块未提供素材 token")
+            if unsupported is not None:
+                unsupported.append(block_type)
+            return "<!-- 飞书图片块未提供素材 token -->"
         resource = FEISHU_OPENAPI_MEDIA_PREFIX + token
         images.append(resource)
         return f"![image]({resource})"
@@ -763,12 +803,14 @@ def _feishu_docx_block_text(
         sheet = block.get("sheet") if isinstance(block.get("sheet"), dict) else {}
         token = str(sheet.get("token") or "").strip()
         if not token:
-            raise FeishuOpenAPIBlocksUnsupported("电子表格块未提供 token")
+            if unsupported is not None:
+                unsupported.append(block_type)
+            return "<!-- 飞书电子表格块未提供 token -->"
         return f"[飞书电子表格](https://{host}/sheets/{token})" if host else f"[飞书电子表格]({token})"
 
     field = FEISHU_DOCX_TEXT_FIELDS.get(block_type)
     payload = block.get(field) if field and isinstance(block.get(field), dict) else {}
-    text = feishu_docx_elements_to_markdown(payload.get("elements"))
+    text = feishu_docx_elements_to_markdown(payload.get("elements"), unsupported_inline)
     if not text:
         return ""
     if block_type in FEISHU_DOCX_HEADING_PREFIXES:
@@ -837,6 +879,7 @@ def feishu_docx_blocks_to_markdown(
     host = urllib.parse.urlparse(source_url).netloc
     images: list[str] = []
     unsupported: list[int] = []
+    unsupported_inline: list[str] = []
     visited: set[str] = set()
     visiting: set[str] = set()
 
@@ -864,7 +907,7 @@ def feishu_docx_blocks_to_markdown(
             block_type = int(block.get("block_type"))
         except (TypeError, ValueError) as exc:
             raise FeishuOpenAPIBlocksUnsupported("文档块缺少有效 block_type") from exc
-        own = _feishu_docx_block_text(block, host, images, unsupported)
+        own = _feishu_docx_block_text(block, host, images, unsupported, unsupported_inline)
         if block_type == 1:
             parts = render_children(block)
         elif block_type == 34:
@@ -887,14 +930,16 @@ def feishu_docx_blocks_to_markdown(
     body = "\n\n".join(part for part in rendered if part).strip()
     markdown = f"# {title}\n" + (f"\n{body}\n" if body else "")
     unique_unsupported = list(dict.fromkeys(unsupported))
+    unique_unsupported_inline = list(dict.fromkeys(unsupported_inline))
     return {
         "title": title,
         "markdown": markdown,
         "images": list(dict.fromkeys(images)),
         "blockCount": len(blocks),
         "textLength": len(body),
-        "renderer": "openapi_docx_partial" if unique_unsupported else "openapi_docx",
+        "renderer": "openapi_docx_partial" if unique_unsupported or unique_unsupported_inline else "openapi_docx",
         "unsupportedBlockTypes": unique_unsupported,
+        "unsupportedInlineElements": unique_unsupported_inline,
     }
 
 

--- a/plugins/feishu/backend/export_feishu.py
+++ b/plugins/feishu/backend/export_feishu.py
@@ -1885,9 +1885,28 @@ async (fallbackTitle) => {
     let finalScrollHeight = 0;
     let reachedBottom = false;
     let terminatedCleanly = false;
-    for (let i = 0; i < maxIterations; i++) {
+    const maxIterationBudget = 2000;
+    let iterationBudget = Math.max(1, maxIterations);
+    const estimateIterationBudget = (items) => {
+      let estimate = iterationBudget;
+      for (const el of items) {
+        try {
+          const viewport = el.clientHeight || (win && win.innerHeight) || 600;
+          const maxY = Math.max(0, (el.scrollHeight || 0) - viewport);
+          const step = Math.max(180, Math.floor(viewport * 0.55));
+          estimate = Math.max(estimate, Math.ceil(maxY / step) + 20);
+        } catch (_) {}
+      }
+      return Math.min(maxIterationBudget, estimate);
+    };
+    for (let i = 0; i < iterationBudget; i++) {
       scrollIterations = i + 1;
       scrollables = findScrollables();
+      // Large Feishu virtual lists can report hundreds of thousands of pixels
+      // of scrollable content. The historical fixed ceiling of 180 iterations
+      // stopped such documents halfway through even though the scroller had
+      // not reached its bottom.
+      iterationBudget = estimateIterationBudget(scrollables);
       const heightBefore = maxScrollHeight(scrollables);
       stepScrollables(scrollables);
       const atBottomBeforeSettle = contentAtBottom(scrollables);
@@ -1973,6 +1992,7 @@ async (fallbackTitle) => {
       finalScrollHeight,
       reachedBottom,
       hitIterationCeiling: !terminatedCleanly,
+      iterationBudget,
       tocRecoveryAttempts: recoveryAttempts,
       tocRecoveryMissing: recoveryMissing,
       tocRecoveryLimited: recoveryLimited,
@@ -2023,6 +2043,7 @@ async (fallbackTitle) => {
   const result = {title: pageTitle, markdown, images: collected.images, blockCount: collected.blockCount, textLength: body.length, renderer: "native_doc"};
   result.scrollIterations = collected.scrollIterations;
   result.finalScrollHeight = collected.finalScrollHeight;
+  result.iterationBudget = collected.iterationBudget;
   result.tocRecoveryAttempts = collected.tocRecoveryAttempts;
   result.tocRecoveryMissing = collected.tocRecoveryMissing;
   result.tocRecoveryLimited = collected.tocRecoveryLimited;

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/plugins/feishu/plugin.json
+++ b/plugins/feishu/plugin.json
@@ -4,7 +4,7 @@
   "id": "feishu",
   "name": "飞书",
   "description": "飞书 Wiki Markdown 导出与导入，包含目录、图片、权限检测和断点续跑。",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "publisher": "Wandao Official",
   "homepage": "https://www.feishu.cn/",
   "license": "AGPL-3.0-only",

--- a/tests/test_feishu_session_and_markdown.py
+++ b/tests/test_feishu_session_and_markdown.py
@@ -899,6 +899,49 @@ class FeishuOpenAPIBlockExportTests(unittest.TestCase):
         self.assertEqual(result["unsupportedBlockTypes"], [31])
         self.assertEqual(result["renderer"], "openapi_docx_partial")
 
+    def test_docx_blocks_keep_unknown_inline_elements_in_api_export(self) -> None:
+        result = feishu.feishu_docx_blocks_to_markdown(
+            [
+                {"block_id": "root", "block_type": 1, "children": ["text"]},
+                {
+                    "block_id": "text",
+                    "parent_id": "root",
+                    "block_type": 2,
+                    "text": {
+                        "elements": [
+                            {"text_run": {"content": "before "}},
+                            {"mention_doc": {"title": "linked document", "token": "secret-token"}},
+                            {"undefined": {"content": "unknown inline text"}},
+                            {"text_run": {"content": " after"}},
+                        ]
+                    },
+                },
+            ],
+            title="Document",
+        )
+
+        self.assertIn("before", result["markdown"])
+        self.assertIn("linked document", result["markdown"])
+        self.assertIn("unknown inline text", result["markdown"])
+        self.assertIn("after", result["markdown"])
+        self.assertEqual(result["renderer"], "openapi_docx_partial")
+        self.assertIn("mention_doc", result["unsupportedInlineElements"])
+
+    def test_docx_blocks_keep_media_blocks_without_tokens_in_api_export(self) -> None:
+        result = feishu.feishu_docx_blocks_to_markdown(
+            [
+                {"block_id": "root", "block_type": 1, "children": ["sheet", "image"]},
+                {"block_id": "sheet", "parent_id": "root", "block_type": 30, "sheet": {}},
+                {"block_id": "image", "parent_id": "root", "block_type": 27, "image": {}},
+            ],
+            title="Document",
+        )
+
+        self.assertIn("飞书电子表格块未提供 token", result["markdown"])
+        self.assertIn("飞书图片块未提供素材 token", result["markdown"])
+        self.assertEqual(result["renderer"], "openapi_docx_partial")
+        self.assertEqual(result["unsupportedBlockTypes"], [30, 27])
+
     def test_docx_blocks_reject_orphaned_parent_instead_of_promoting_it_to_root(self) -> None:
         with self.assertRaisesRegex(feishu.FeishuOpenAPIBlocksUnsupported, "缺失的父节点"):
             feishu.feishu_docx_blocks_to_markdown(

--- a/tests_js/feishu_converter_scroll.test.js
+++ b/tests_js/feishu_converter_scroll.test.js
@@ -525,3 +525,52 @@ test('collectFeishuDocBlocks stops cleanly at bottom without false incomplete', 
   assert.equal(result.hitIterationCeiling, false);
   assert.ok(result.scrollIterations < 40, `should stop near bottom, got ${result.scrollIterations}`);
 });
+
+test('collectFeishuDocBlocks expands the budget for long virtualized documents', async () => {
+  const api = loadScrollApi();
+  const { document } = parseHTML(`<!doctype html><html><body>
+    <div class="page-scroller" data-overflow-y="auto" style="height:200px; overflow:auto">
+      <div class="root-render-unit-container"><div class="render-unit-wrapper"></div></div>
+    </div>
+  </body></html>`);
+  const scroller = document.querySelector('.page-scroller');
+  const wrapper = document.querySelector('.render-unit-wrapper');
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 200 });
+  let scrollHeight = 10000;
+  let scrollTop = 0;
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = Math.min(Math.max(value, 0), scrollHeight - 200);
+      if (scrollTop >= scrollHeight - 200 && wrapper.childElementCount < 2) {
+        const block = document.createElement('div');
+        block.setAttribute('data-block-type', 'paragraph');
+        block.setAttribute('data-block-id', 'last');
+        block.textContent = 'last';
+        wrapper.appendChild(block);
+      }
+    },
+  });
+  const first = document.createElement('div');
+  first.setAttribute('data-block-type', 'paragraph');
+  first.setAttribute('data-block-id', 'first');
+  first.textContent = 'first';
+  wrapper.appendChild(first);
+
+  const result = await api.collectFeishuDocBlocks({
+    root: document.querySelector('.root-render-unit-container'),
+    scroller,
+    document,
+    sleep: async () => {},
+    currentBlocks: () => [...wrapper.children].filter((el) => el.getAttribute('data-block-type')),
+    renderBlock: (el) => el.textContent || '',
+    maxIterations: 5,
+  });
+
+  assert.deepEqual(result.rendered, ['first', 'last']);
+  assert.equal(result.reachedBottom, true);
+  assert.equal(result.hitIterationCeiling, false);
+  assert.ok(result.iterationBudget > 5);
+});

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -193,7 +193,7 @@ test('Feishu import tutorial pins all screenshots remotely and excludes them fro
   assert.equal(assets.reduce((total, name) => total + fs.statSync(path.join(remoteAssetRoot, name)).size, 0), 17317358);
   assert.deepEqual(new Set(Object.keys(provider.guideAssets)), new Set(imageReferences.map((match) => match[1])));
   assert.equal(Object.values(provider.guideAssets).every((asset) => asset.mime === 'image/png' && asset.bytes <= 3 * 1024 * 1024 && /^[a-f0-9]{64}$/.test(asset.sha256)), true);
-  assert.equal(plugin.version, '1.0.11');
+  assert.equal(plugin.version, '1.0.13');
 });
 
 test('guide hydration limits remote IPC concurrency and renders an offline fallback', () => {

--- a/tests_js/guide_markdown.test.js
+++ b/tests_js/guide_markdown.test.js
@@ -193,7 +193,7 @@ test('Feishu import tutorial pins all screenshots remotely and excludes them fro
   assert.equal(assets.reduce((total, name) => total + fs.statSync(path.join(remoteAssetRoot, name)).size, 0), 17317358);
   assert.deepEqual(new Set(Object.keys(provider.guideAssets)), new Set(imageReferences.map((match) => match[1])));
   assert.equal(Object.values(provider.guideAssets).every((asset) => asset.mime === 'image/png' && asset.bytes <= 3 * 1024 * 1024 && /^[a-f0-9]{64}$/.test(asset.sha256)), true);
-  assert.equal(plugin.version, '1.0.13');
+  assert.equal(plugin.version, '1.0.15');
 });
 
 test('guide hydration limits remote IPC concurrency and renders an offline fallback', () => {


### PR DESCRIPTION
## Summary

- Preserve unknown Feishu inline elements instead of abandoning the paginated Docx block API.
- Keep missing-token image and spreadsheet blocks as placeholders and continue converting the document.
- Scale browser scroll iterations from the actual virtual-list height as a fallback.
- Bump the Feishu plugin version to 1.0.15.

## Real-page validation

- Feishu API returned 9,283 blocks for the reported document.
- Direct API conversion produced about 316 KB of Markdown.
- Output includes sections 5, 6, 7 and Agent Loop.
- Browser fallback measured a 321,510px scroll container and now derives a sufficient iteration budget.

## Tests

- 35 Feishu Python tests passed.
- 26 Feishu/guide Node tests passed.
- Full local quality checks passed before the final API-element follow-up.